### PR TITLE
Canonical KeypointModel, strict-only loading, corrected eval matching (#4, #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ Please install CUDA 11.8. Then run the following commands to create the conda en
 ```bash
 conda env create -f environment.yml
 conda activate sidewalkcv2
+pip install -e .
 ```
+
+The `pip install -e .` step installs the small shared `rampnet` package (model definition, checkpoint loading, evaluation metrics) that the stage 1 and stage 2 scripts import.
 
 
 ## Dataset Summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rampnet"
+version = "1.1.0"
+description = "Shared model, checkpoint-loading, and metrics code for the RampNet pipeline"
+requires-python = ">=3.10"
+# torch/timm are intentionally not declared: they come from the conda
+# environment (see environment.yml) and pip must not try to reinstall them.
+dependencies = []
+
+[tool.setuptools]
+packages = ["rampnet"]

--- a/rampnet/__init__.py
+++ b/rampnet/__init__.py
@@ -1,0 +1,9 @@
+"""Shared RampNet code: canonical model, checkpoint loading, and metrics.
+
+Import submodules directly so that pure-Python parts stay usable without the
+deep-learning stack installed:
+
+    from rampnet.model import KeypointModel        # needs torch + timm
+    from rampnet.loading import load_checkpoint    # needs torch
+    from rampnet.metrics import match_predictions  # pure Python
+"""

--- a/rampnet/loading.py
+++ b/rampnet/loading.py
@@ -1,0 +1,44 @@
+import hashlib
+import os
+
+import torch
+
+_STATE_DICT_KEYS = ('model_state_dict', 'state_dict', 'model')
+
+
+def load_checkpoint(model, checkpoint_path, map_location='cpu'):
+    """Load a RampNet checkpoint into `model`, strictly.
+
+    Accepts the checkpoint formats produced across this repo: a raw state_dict,
+    a dict wrapping it under 'model_state_dict'/'state_dict'/'model', and
+    DDP-saved dicts with a 'module.' prefix. Any missing file or key mismatch
+    raises — never fall back to strict=False, which silently leaves layers
+    randomly initialized and corrupts evaluation results.
+    """
+    if not os.path.exists(checkpoint_path):
+        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint_path}")
+    checkpoint = torch.load(checkpoint_path, map_location=map_location)
+    state_dict = checkpoint
+    if isinstance(checkpoint, dict):
+        for key in _STATE_DICT_KEYS:
+            if key in checkpoint:
+                state_dict = checkpoint[key]
+                break
+    if state_dict and all(k.startswith('module.') for k in state_dict):
+        state_dict = {k[len('module.'):]: v for k, v in state_dict.items()}
+    model.load_state_dict(state_dict)
+    return model
+
+
+def checkpoint_fingerprint(checkpoint_path, digest_chars=12):
+    """Short content hash of a checkpoint file, for keying prediction caches.
+
+    Cached heatmaps are only valid for the exact weights that produced them;
+    keying the cache directory by this fingerprint makes switching checkpoints
+    safe without manually deleting the cache.
+    """
+    h = hashlib.sha256()
+    with open(checkpoint_path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1 << 20), b''):
+            h.update(chunk)
+    return h.hexdigest()[:digest_chars]

--- a/rampnet/metrics.py
+++ b/rampnet/metrics.py
@@ -1,0 +1,138 @@
+"""Shared detection metrics for RampNet evaluators.
+
+The matching here replaces the pre-release per-evaluator logic, which had two
+defects that biased reported numbers upward (issue #9): a single prediction
+within radius of two ground-truth points could be counted as two true
+positives, and duplicate detections of an already-matched ground-truth point
+were dropped entirely instead of counted as false positives.
+"""
+
+
+def match_predictions(pred_peaks, gt_points, radius_sq, scale_x, scale_y):
+    """Greedy one-to-one matching of predicted peaks to ground-truth points.
+
+    pred_peaks: iterable of (x_norm, y_norm, confidence).
+    gt_points: iterable of (x_norm, y_norm).
+    radius_sq: squared matching radius, in the scaled coordinate space.
+    scale_x/scale_y: factors mapping normalized coords into that space.
+
+    Predictions are processed in descending confidence order; each claims the
+    nearest unclaimed ground-truth point strictly within the radius (a true
+    positive). A prediction with no unclaimed ground truth in range — including
+    a duplicate detection of an already-claimed point — is a false positive.
+
+    Returns a list of (confidence, is_true_positive), one entry per prediction.
+    """
+    preds_sorted = sorted(pred_peaks, key=lambda p: p[2], reverse=True)
+    claimed = [False] * len(gt_points)
+    details = []
+    for x_norm, y_norm, conf in preds_sorted:
+        pred_x = x_norm * scale_x
+        pred_y = y_norm * scale_y
+        best_k = -1
+        best_dist_sq = radius_sq
+        for k, (gt_x_norm, gt_y_norm) in enumerate(gt_points):
+            if claimed[k]:
+                continue
+            dist_sq = (pred_x - gt_x_norm * scale_x) ** 2 + (pred_y - gt_y_norm * scale_y) ** 2
+            if dist_sq < best_dist_sq:
+                best_dist_sq = dist_sq
+                best_k = k
+        if best_k >= 0:
+            claimed[best_k] = True
+            details.append((conf, True))
+        else:
+            details.append((conf, False))
+    return details
+
+
+def calculate_ap_and_pr_curve(all_predictions_details, total_gt_points):
+    """All-point interpolated AP (VOC-style precision envelope) and PR curve.
+
+    Returns (ap, plot_recalls, plot_precisions, sorted_confidences,
+    sorted_tp_flags). The plotted curve uses the same monotone precision
+    envelope the AP integrates, so the two are consistent.
+    """
+    if total_gt_points == 0 or not all_predictions_details:
+        return 0.0, [0.0], [0.0], [], []
+
+    sorted_preds = sorted(all_predictions_details, key=lambda x: x[0], reverse=True)
+    sorted_confidences = [p[0] for p in sorted_preds]
+    sorted_tp_flags = [p[1] for p in sorted_preds]
+
+    tp_count = 0
+    fp_count = 0
+    raw_recalls_list = []
+    raw_precisions_list = []
+    for is_tp in sorted_tp_flags:
+        if is_tp:
+            tp_count += 1
+        else:
+            fp_count += 1
+        raw_precisions_list.append(tp_count / (tp_count + fp_count))
+        raw_recalls_list.append(tp_count / total_gt_points)
+
+    # Monotone (max-envelope) interpolation, computed right-to-left.
+    interp_precisions = list(raw_precisions_list)
+    for k in range(len(interp_precisions) - 2, -1, -1):
+        interp_precisions[k] = max(interp_precisions[k], interp_precisions[k + 1])
+
+    ap = 0.0
+    last_recall_val = 0.0
+    for i, is_tp in enumerate(sorted_tp_flags):
+        if is_tp:
+            ap += interp_precisions[i] * (raw_recalls_list[i] - last_recall_val)
+            last_recall_val = raw_recalls_list[i]
+
+    plot_recalls = [0.0] + raw_recalls_list
+    plot_precisions = [1.0] + interp_precisions
+    if plot_recalls[-1] < 1.0:
+        plot_recalls.append(plot_recalls[-1])
+        plot_precisions.append(0.0)
+    return ap, plot_recalls, plot_precisions, sorted_confidences, sorted_tp_flags
+
+
+def calculate_pr_rc_confidence_curves(sorted_confidences, sorted_tp_flags, total_gt_points):
+    """Precision and recall as functions of the confidence threshold."""
+    if not sorted_confidences:
+        conf_thresholds_for_plot = [0.0, 1.0]
+        if total_gt_points > 0:
+            precisions_at_thresholds_for_plot = [1.0, 1.0]
+        else:
+            precisions_at_thresholds_for_plot = [0.0, 0.0]
+        recalls_at_thresholds_for_plot = [0.0, 0.0]
+        return conf_thresholds_for_plot, precisions_at_thresholds_for_plot, recalls_at_thresholds_for_plot
+
+    conf_thresholds_unique_desc = []
+    precisions_at_thresholds_desc = []
+    recalls_at_thresholds_desc = []
+    tp_count_cumulative = 0
+    for i in range(len(sorted_confidences)):
+        if sorted_tp_flags[i]:
+            tp_count_cumulative += 1
+        num_preds_cumulative = i + 1
+        current_precision = tp_count_cumulative / num_preds_cumulative
+        current_recall = tp_count_cumulative / total_gt_points if total_gt_points > 0 else 0.0
+        current_confidence_threshold = sorted_confidences[i]
+        if i == len(sorted_confidences) - 1 or sorted_confidences[i + 1] < current_confidence_threshold:
+            conf_thresholds_unique_desc.append(current_confidence_threshold)
+            precisions_at_thresholds_desc.append(current_precision)
+            recalls_at_thresholds_desc.append(current_recall)
+
+    conf_thresholds_for_plot = list(reversed(conf_thresholds_unique_desc))
+    precisions_at_thresholds_for_plot = list(reversed(precisions_at_thresholds_desc))
+    recalls_at_thresholds_for_plot = list(reversed(recalls_at_thresholds_desc))
+
+    if not conf_thresholds_for_plot or conf_thresholds_for_plot[0] > 0.0:
+        conf_thresholds_for_plot.insert(0, 0.0)
+        precisions_at_thresholds_for_plot.insert(0, precisions_at_thresholds_for_plot[0] if precisions_at_thresholds_for_plot else 0.0)
+        recalls_at_thresholds_for_plot.insert(0, recalls_at_thresholds_for_plot[0] if recalls_at_thresholds_for_plot else 0.0)
+
+    if conf_thresholds_for_plot[-1] < 1.0:
+        conf_thresholds_for_plot.append(1.0)
+        precisions_at_thresholds_for_plot.append(1.0 if total_gt_points > 0 else 0.0)
+        recalls_at_thresholds_for_plot.append(0.0)
+    elif recalls_at_thresholds_for_plot[-1] == 0.0:
+        precisions_at_thresholds_for_plot[-1] = 1.0 if total_gt_points > 0 else 0.0
+
+    return conf_thresholds_for_plot, precisions_at_thresholds_for_plot, recalls_at_thresholds_for_plot

--- a/rampnet/model.py
+++ b/rampnet/model.py
@@ -1,0 +1,44 @@
+import timm
+import torch.nn as nn
+
+BACKBONE_NAME = 'convnextv2_base.fcmae_ft_in22k_in1k_384'
+
+# Panorama model (stage_two): equirectangular 2048x4096 input -> 512x1024 heatmap.
+PANO_INPUT_SIZE = (2048, 4096)
+PANO_HEATMAP_SIZE = (512, 1024)
+
+# Crop model (stage_one): perspective 1024x352 input -> 256x88 heatmap.
+CROP_INPUT_SIZE = (1024, 352)
+CROP_HEATMAP_SIZE = (256, 88)
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+
+class KeypointModel(nn.Module):
+    """The one canonical RampNet keypoint-heatmap model.
+
+    The state_dict key layout (feature_extractor as Sequential over
+    backbone.children()[:-2], i.e. dropping norm_pre and head) is the layout
+    every released checkpoint was trained and saved with — including the
+    HuggingFace weights. Do not restructure the modules (e.g. features_only=True
+    or named submodules): that changes the keys and breaks strict loading of
+    all existing checkpoints.
+    """
+
+    def __init__(self, heatmap_size=PANO_HEATMAP_SIZE, pretrained_backbone=False):
+        super().__init__()
+        backbone = timm.create_model(BACKBONE_NAME, pretrained=pretrained_backbone)
+        self.feature_extractor = nn.Sequential(*list(backbone.children())[:-2])
+        in_channels = backbone.num_features
+        self.head = nn.Sequential(
+            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
+            nn.Conv2d(256, 1, kernel_size=1)
+        )
+
+    def forward(self, image):
+        features = self.feature_extractor(image)
+        heatmap = self.head(features)
+        return heatmap

--- a/stage_one/crop_model/ps_and_manual_model/evaluate.py
+++ b/stage_one/crop_model/ps_and_manual_model/evaluate.py
@@ -2,13 +2,18 @@ import os
 import torch
 from PIL import Image, ImageOps, ImageDraw
 import numpy as np
-import cv2
 from torchvision import transforms
 import matplotlib.pyplot as plt
-import timm
-import torch.nn as nn
 from tqdm import tqdm
 from skimage.feature import peak_local_max
+
+from rampnet.model import KeypointModel
+from rampnet.loading import load_checkpoint, checkpoint_fingerprint
+from rampnet.metrics import (
+    calculate_ap_and_pr_curve,
+    calculate_pr_rc_confidence_curves,
+    match_predictions,
+)
 
 MODEL_CHECKPOINT_PATH = "best_model.pth"
 DATASET_ROOT_DIR = './dataset_1'
@@ -33,68 +38,13 @@ VISUALIZATION_CONF_THRESHOLD = 0.5
 POINT_RADIUS_VIS = 5
 
 
-class KeypointModel(nn.Module):
-    def __init__(self, heatmap_size=(256, 88)):
-        super(KeypointModel, self).__init__()
-        backbone = timm.create_model('convnextv2_base.fcmae_ft_in22k_in1k_384', pretrained=False, num_classes=0, global_pool='')
-        self.feature_extractor = nn.Sequential(*list(backbone.children()))
-        in_channels = backbone.num_features
-        self.head = nn.Sequential(
-            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
-            nn.Conv2d(256, 1, kernel_size=1)
-        )
-    def forward(self, image):
-        features = self.feature_extractor(image)
-        heatmap = self.head(features)
-        return heatmap
-
 def load_trained_model(checkpoint_path, heatmap_size):
     print(f"Loading model checkpoint from: {checkpoint_path}")
-    if not os.path.exists(checkpoint_path):
-        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint_path}. Please ensure it exists.")
     model = KeypointModel(heatmap_size=heatmap_size)
-    try:
-        checkpoint = torch.load(checkpoint_path, map_location=DEVICE)
-    except AttributeError as e:
-        print(f"Warning: AttributeError during torch.load: {e}. Attempting workaround.")
-        import pickle
-        class CustomUnpickler(pickle.Unpickler):
-            def find_class(self, module, name):
-                try:
-                    return super().find_class(module, name)
-                except AttributeError:
-                    print(f"Could not find class {name} in module {module}, returning generic object.")
-                    return object 
-        with open(checkpoint_path, 'rb') as f:
-            unpickler = CustomUnpickler(f)
-            checkpoint = unpickler.load()
-    state_dict = checkpoint
-    if isinstance(checkpoint, dict):
-        if 'model_state_dict' in checkpoint:
-            state_dict = checkpoint['model_state_dict']
-        elif 'state_dict' in checkpoint:
-            state_dict = checkpoint['state_dict']
-        elif 'model' in checkpoint:
-            state_dict = checkpoint['model']
-    if all(key.startswith('module.') for key in state_dict.keys()): 
-        print("Removing 'module.' prefix from state_dict keys.")
-        state_dict = {k.replace('module.', '', 1): v for k, v in state_dict.items()} 
-    try:
-        model.load_state_dict(state_dict) 
-    except RuntimeError as e:
-        print(f"Error loading state_dict: {e}")
-        print("This might be due to a mismatch between the model architecture defined here (possibly a fallback) and the one in the checkpoint.")
-        print("Attempting to load with strict=False, unmatched keys will be ignored.")
-        try:
-            model.load_state_dict(state_dict, strict=False) 
-        except RuntimeError as e_strict_false:
-            print(f"Loading with strict=False also failed: {e_strict_false}")
-            raise e_strict_false
+    load_checkpoint(model, checkpoint_path, map_location=DEVICE)
     model.to(DEVICE)
     model.eval()
-    print("Model loaded successfully (possibly with ignored keys if strict=False was used).")
+    print("Model loaded successfully.")
     return model
 
 preprocess_transform = transforms.Compose([
@@ -134,110 +84,7 @@ def get_image_files(data_dir):
     return image_files
 
 
-def calculate_ap_and_pr_curve(all_predictions_details, total_gt_points):
-    if total_gt_points == 0:
-        return 0.0, [0.0], [0.0], [], []
-    if not all_predictions_details:
-        return 0.0, [0.0], [0.0], [], []
-
-    sorted_preds = sorted(all_predictions_details, key=lambda x: x[0], reverse=True)
-    sorted_confidences = [p[0] for p in sorted_preds]
-    sorted_tp_flags = [p[1] for p in sorted_preds]
-
-    tp_count = 0
-    fp_count = 0
-    ap = 0.0
-    last_recall_val = 0.0
-    raw_recalls_list = []
-    raw_precisions_list = []
-
-    for i in range(len(sorted_preds)):
-        is_tp = sorted_tp_flags[i]
-        if is_tp:
-            tp_count += 1
-        else:
-            fp_count += 1
-
-        current_precision = tp_count / (tp_count + fp_count)
-        current_recall = tp_count / total_gt_points if total_gt_points > 0 else 0.0
-        raw_recalls_list.append(current_recall)
-        raw_precisions_list.append(current_precision)
-
-        if is_tp:
-            ap += current_precision * (current_recall - last_recall_val)
-            last_recall_val = current_recall
-
-    plot_recalls = [0.]
-    plot_precisions = [1.0]
-
-    if raw_recalls_list:
-        interp_precisions = list(raw_precisions_list)
-        for k_interp in range(len(interp_precisions) - 2, -1, -1):
-            interp_precisions[k_interp] = max(interp_precisions[k_interp], interp_precisions[k_interp+1])
-        plot_recalls.extend(raw_recalls_list)
-        plot_precisions.extend(interp_precisions)
-
-    if not plot_recalls or plot_recalls[-1] < 1.0 :
-        if plot_recalls:
-             plot_recalls.append(plot_recalls[-1])
-             plot_precisions.append(0.)
-    return ap, plot_recalls, plot_precisions, sorted_confidences, sorted_tp_flags
-
-def calculate_pr_rc_confidence_curves(sorted_confidences, sorted_tp_flags, total_gt_points):
-    if not sorted_confidences:
-        conf_thresholds_for_plot = [0.0, 1.0]
-        if total_gt_points > 0:
-            precisions_at_thresholds_for_plot = [1.0, 1.0]
-            recalls_at_thresholds_for_plot = [0.0, 0.0]
-        else: 
-            precisions_at_thresholds_for_plot = [0.0, 0.0]
-            recalls_at_thresholds_for_plot = [0.0, 0.0]
-        return conf_thresholds_for_plot, precisions_at_thresholds_for_plot, recalls_at_thresholds_for_plot
-
-    conf_thresholds_unique_desc = []
-    precisions_at_thresholds_desc = []
-    recalls_at_thresholds_desc = []
-    tp_count_cumulative = 0
-    for i in range(len(sorted_confidences)):
-        if sorted_tp_flags[i]:
-            tp_count_cumulative += 1
-        num_preds_cumulative = i + 1
-        current_precision = tp_count_cumulative / num_preds_cumulative
-        if total_gt_points > 0:
-            current_recall = tp_count_cumulative / total_gt_points
-        else:
-            current_recall = 0.0
-        current_confidence_threshold = sorted_confidences[i]
-        print(current_recall)
-        print(current_precision)
-        print(current_confidence_threshold)
-        print("-----")
-        if i == len(sorted_confidences) - 1 or sorted_confidences[i+1] < current_confidence_threshold:
-            conf_thresholds_unique_desc.append(current_confidence_threshold)
-            precisions_at_thresholds_desc.append(current_precision)
-            recalls_at_thresholds_desc.append(current_recall)
-
-    conf_thresholds_for_plot = list(reversed(conf_thresholds_unique_desc))
-    precisions_at_thresholds_for_plot = list(reversed(precisions_at_thresholds_desc))
-    recalls_at_thresholds_for_plot = list(reversed(recalls_at_thresholds_desc))
-
-    if not conf_thresholds_for_plot or conf_thresholds_for_plot[0] > 0.0:
-        conf_thresholds_for_plot.insert(0, 0.0)
-        precisions_at_thresholds_for_plot.insert(0, precisions_at_thresholds_for_plot[0] if precisions_at_thresholds_for_plot else (0.0 if total_gt_points > 0 else 0.0))
-        recalls_at_thresholds_for_plot.insert(0, recalls_at_thresholds_for_plot[0] if recalls_at_thresholds_for_plot else 0.0)
-
-    if not conf_thresholds_for_plot or conf_thresholds_for_plot[-1] < 1.0:
-        conf_thresholds_for_plot.append(1.0)
-        precisions_at_thresholds_for_plot.append(1.0 if total_gt_points > 0 and (not precisions_at_thresholds_desc or precisions_at_thresholds_desc[-1] > 0) else 0.0) 
-        recalls_at_thresholds_for_plot.append(0.0)
-    elif recalls_at_thresholds_for_plot[-1] == 0.0 and conf_thresholds_for_plot[-1] == 1.0: 
-         precisions_at_thresholds_for_plot[-1] = 1.0 if total_gt_points > 0 and (not precisions_at_thresholds_desc or precisions_at_thresholds_desc[-1] > 0) else 0.0
-
-
-    return conf_thresholds_for_plot, precisions_at_thresholds_for_plot, recalls_at_thresholds_for_plot
-
 def main():
-    os.makedirs(HEATMAP_CACHE_DIR, exist_ok=True)
     os.makedirs(RESULTS_DIR, exist_ok=True)
     
     current_visualizations_dir = os.path.join(VISUALIZATIONS_BASE_DIR, DATASET_ID_STR)
@@ -250,21 +97,14 @@ def main():
     print(f"Cache directory: {CACHE_DIR}")
     print(f"Results directory: {RESULTS_DIR}")
 
-    try:
-        model = load_trained_model(MODEL_CHECKPOINT_PATH, MODEL_HEATMAP_SIZE)
-    except FileNotFoundError as e:
-        print(f"{e}")
-        print("Attempting to create a dummy checkpoint for a test run as it's missing.")
-        try:
-            dummy_model_for_checkpoint = KeypointModel(heatmap_size=MODEL_HEATMAP_SIZE)
-            torch.save({'model_state_dict': dummy_model_for_checkpoint.state_dict()}, MODEL_CHECKPOINT_PATH)
-            print(f"Dummy checkpoint created at {MODEL_CHECKPOINT_PATH}. Please re-run the script.")
-        except Exception as ex_create:
-            print(f"Could not create dummy checkpoint: {ex_create}. Exiting.")
-        return
-    except Exception as load_err:
-        print(f"Failed to load model: {load_err}. Exiting.")
-        return
+    model = load_trained_model(MODEL_CHECKPOINT_PATH, MODEL_HEATMAP_SIZE)
+
+    # Cached heatmaps are only valid for the weights that produced them, so
+    # the cache directory is keyed by the checkpoint's content hash.
+    ckpt_fingerprint = checkpoint_fingerprint(MODEL_CHECKPOINT_PATH)
+    heatmap_cache_dir = os.path.join(HEATMAP_CACHE_DIR, ckpt_fingerprint)
+    os.makedirs(heatmap_cache_dir, exist_ok=True)
+    print(f"Heatmap cache directory: {heatmap_cache_dir}")
 
     heatmap_h, heatmap_w = MODEL_HEATMAP_SIZE
     RADIUS_THRESHOLD_PIXELS = RADIUS_THRESHOLD_NORMALIZED * (341 / 4)
@@ -290,7 +130,7 @@ def main():
     for i in tqdm(range(len(image_paths)), desc=f"Evaluating on {DATASET_ID_STR}"):
         img_path = image_paths[i]
         base_name_no_ext = os.path.splitext(os.path.basename(img_path))[0]
-        cached_heatmap_path = os.path.join(HEATMAP_CACHE_DIR, f"{base_name_no_ext}_heatmap.npy")
+        cached_heatmap_path = os.path.join(heatmap_cache_dir, f"{base_name_no_ext}_heatmap.npy")
 
         gt_points_normalized = []
         input_image_pil_for_vis = None 
@@ -359,30 +199,13 @@ def main():
             heatmap_shape=MODEL_HEATMAP_SIZE
         )
         
-        current_image_preds_sorted_by_conf = sorted(pred_peaks_normalized, key=lambda p_item: p_item[2], reverse=True)
-        
-        k_gt_mappings = [False] * len(gt_points_normalized)
-        for pred_x_norm, pred_y_norm, pred_conf in current_image_preds_sorted_by_conf:
-            pred_x_px = pred_x_norm * (341 / 4)
-            pred_y_px = pred_y_norm * (1024 / 4)
-            
-            passes = False
-            
-            for k_gt, (gt_x_norm, gt_y_norm) in enumerate(gt_points_normalized):
-                gt_x_px = gt_x_norm * (341 / 4)
-                gt_y_px = gt_y_norm * (1024 / 4)
-                
-                dist_sq = (pred_x_px - gt_x_px)**2 + (pred_y_px - gt_y_px)**2
-                
-                if dist_sq < RADIUS_THRESHOLD_PIXELS_SQ:
-                    passes = True
-                    if not k_gt_mappings[k_gt]:
-                        all_pred_details_for_ap.append((pred_conf, True))
-                    
-                    k_gt_mappings[k_gt] = True
-            
-            if not passes:
-                all_pred_details_for_ap.append((pred_conf, False))
+        all_pred_details_for_ap.extend(match_predictions(
+            pred_peaks_normalized,
+            gt_points_normalized,
+            RADIUS_THRESHOLD_PIXELS_SQ,
+            scale_x=341 / 4,
+            scale_y=1024 / 4,
+        ))
         if input_image_pil_for_vis:
             draw = ImageDraw.Draw(input_image_pil_for_vis)
             original_w_vis, original_h_vis = input_image_pil_for_vis.size

--- a/stage_one/crop_model/ps_and_manual_model/train.py
+++ b/stage_one/crop_model/ps_and_manual_model/train.py
@@ -12,7 +12,9 @@ from torch.utils.data import Dataset, DataLoader
 from torchvision import transforms
 from torchvision.transforms import functional as F
 from tqdm import tqdm
-import timm
+
+from rampnet.model import KeypointModel
+from rampnet.loading import load_checkpoint
 
 torch.manual_seed(42)
 random.seed(42)
@@ -130,32 +132,9 @@ val_dataset = KeypointDataset(
 train_loader = DataLoader(train_dataset, batch_size=16, shuffle=True, num_workers=4)
 val_loader = DataLoader(val_dataset, batch_size=16, shuffle=False, num_workers=4)
 
-class KeypointModel(nn.Module):
-    def __init__(self, heatmap_size=(256, 88)):
-        super(KeypointModel, self).__init__()
-        backbone = timm.create_model('convnextv2_base.fcmae_ft_in22k_in1k_384', pretrained=True)
-        for param in backbone.parameters():
-            param.requires_grad = True
-            
-        self.feature_extractor = nn.Sequential(*list(backbone.children())[:-2])
-        in_channels = backbone.num_features
-        
-        self.head = nn.Sequential(
-            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
-            nn.Conv2d(256, 1, kernel_size=1)
-        )
-    
-    def forward(self, image):
-        features = self.feature_extractor(image)
-        heatmap = self.head(features)
-        return heatmap
+model = KeypointModel(heatmap_size=HEATMAP_SIZE, pretrained_backbone=True)
 
-model = KeypointModel(heatmap_size=HEATMAP_SIZE)
-
-checkpoint = torch.load('ps_model.pth', map_location='cpu')
-model.load_state_dict(checkpoint)
+load_checkpoint(model, 'ps_model.pth', map_location='cpu')
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 model.to(device)

--- a/stage_one/crop_model/ps_model/model/train.py
+++ b/stage_one/crop_model/ps_model/model/train.py
@@ -12,7 +12,8 @@ from torch.utils.data import Dataset, DataLoader
 from torchvision import transforms
 from torchvision.transforms import functional as F
 from tqdm import tqdm
-import timm
+
+from rampnet.model import KeypointModel
 
 torch.manual_seed(42)
 random.seed(42)
@@ -128,30 +129,7 @@ val_dataset = KeypointDataset(
 train_loader = DataLoader(train_dataset, batch_size=16, shuffle=True, num_workers=4)
 val_loader = DataLoader(val_dataset, batch_size=16, shuffle=False, num_workers=4)
 
-class KeypointModel(nn.Module):
-    def __init__(self, heatmap_size=(256, 88)):
-        super(KeypointModel, self).__init__()
-        backbone = timm.create_model('convnextv2_base.fcmae_ft_in22k_in1k_384', pretrained=True)
-        
-        for param in backbone.parameters():
-            param.requires_grad = True
-            
-        self.feature_extractor = nn.Sequential(*list(backbone.children())[:-2])
-        in_channels = backbone.num_features
-        
-        self.head = nn.Sequential(
-            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
-            nn.Conv2d(256, 1, kernel_size=1)
-        )
-    
-    def forward(self, image):
-        features = self.feature_extractor(image)
-        heatmap = self.head(features)
-        return heatmap
-
-model = KeypointModel(heatmap_size=HEATMAP_SIZE)
+model = KeypointModel(heatmap_size=HEATMAP_SIZE, pretrained_backbone=True)
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 model.to(device)
 

--- a/stage_one/dataset_generation/inference_isolator.py
+++ b/stage_one/dataset_generation/inference_isolator.py
@@ -1,10 +1,11 @@
 import cv2
 import torch
-import torch.nn as nn
-import timm
 from torchvision import transforms
 from PIL import Image
 import numpy as np
+
+from rampnet.model import KeypointModel
+from rampnet.loading import load_checkpoint
 
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -18,32 +19,8 @@ transform = transforms.Compose([
 ])
 
 
-class KeypointModel(nn.Module):
-    def __init__(self, heatmap_size=(256, 88)):
-        super(KeypointModel, self).__init__()
-        
-        backbone = timm.create_model('convnextv2_base.fcmae_ft_in22k_in1k_384', pretrained=True)
-        for param in backbone.parameters():
-            param.requires_grad = True
-        self.feature_extractor = nn.Sequential(*list(backbone.children())[:-2])
-        in_channels = backbone.num_features
-        
-        
-        self.head = nn.Sequential(
-            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
-            nn.Conv2d(256, 1, kernel_size=1)
-        )
-    
-    def forward(self, x):
-        features = self.feature_extractor(x)
-        heatmap = self.head(features)
-        return heatmap
-
-
 model = KeypointModel(heatmap_size=(256, 88))
-model.load_state_dict(torch.load("../crop_model/ps_and_manual_model/best_model.pth", map_location=device))
+load_checkpoint(model, "../crop_model/ps_and_manual_model/best_model.pth", map_location=device)
 model.to(device)
 model.eval()
 

--- a/stage_two/demo.py
+++ b/stage_two/demo.py
@@ -1,60 +1,25 @@
-import os
 import torch
 import gradio as gr
-from PIL import Image, ImageOps, ImageDraw 
+from PIL import Image, ImageOps, ImageDraw
 import numpy as np
 from torchvision import transforms
 
-import timm
-import torch.nn as nn
+from skimage.feature import peak_local_max
 
-from skimage.feature import peak_local_max 
-
-class KeypointModel(nn.Module):
-    def __init__(self, heatmap_size=(512, 1024)):
-        super(KeypointModel, self).__init__()
-        backbone = timm.create_model('convnextv2_base.fcmae_ft_in22k_in1k_384', pretrained=False)
-
-        self.feature_extractor = nn.Sequential(*list(backbone.children())[:-2])
-        in_channels = backbone.num_features
-        self.head = nn.Sequential(
-            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
-            nn.Conv2d(256, 1, kernel_size=1)
-        )
-
-    def forward(self, image):
-        features = self.feature_extractor(image)
-        heatmap = self.head(features)
-        return heatmap
+from rampnet.model import KeypointModel
+from rampnet.loading import load_checkpoint
 
 MODEL_CHECKPOINT_PATH = "checkpoints/epoch_1_step_9378.pth"
-MODEL_INPUT_SIZE = (2048, 4096) 
-MODEL_HEATMAP_SIZE = (512, 1024) 
+MODEL_INPUT_SIZE = (2048, 4096)
+MODEL_HEATMAP_SIZE = (512, 1024)
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 GRADIO_PORT = 25566
 
 def load_trained_model(checkpoint_path, heatmap_size):
     """Loads the KeypointModel and weights from a checkpoint."""
     print(f"Loading model checkpoint from: {checkpoint_path}")
-    if not os.path.exists(checkpoint_path):
-        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint_path}")
-
     model = KeypointModel(heatmap_size=heatmap_size)
-
-    checkpoint = torch.load(checkpoint_path, map_location=DEVICE)
-    state_dict = checkpoint
-
-    if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint:
-        state_dict = checkpoint['model_state_dict']
-    elif isinstance(checkpoint, dict) and 'state_dict' in checkpoint:
-        state_dict = checkpoint['state_dict']
-    if all(key.startswith('module.') for key in state_dict.keys()):
-        print("Removing 'module.' prefix from state_dict keys.")
-        state_dict = {k.replace('module.', '', 1): v for k, v in state_dict.items()}
-
-    model.load_state_dict(state_dict)
+    load_checkpoint(model, checkpoint_path, map_location=DEVICE)
     model.to(DEVICE)
     model.eval()
     print("Model loaded successfully.")

--- a/stage_two/evaluate.py
+++ b/stage_two/evaluate.py
@@ -4,12 +4,18 @@ from PIL import Image, ImageOps
 import numpy as np
 from torchvision import transforms
 import matplotlib.pyplot as plt
-import timm
-import torch.nn as nn
 import json
 from tqdm import tqdm
 from skimage.feature import peak_local_max
-import csv 
+import csv
+
+from rampnet.model import KeypointModel
+from rampnet.loading import load_checkpoint, checkpoint_fingerprint
+from rampnet.metrics import (
+    calculate_ap_and_pr_curve,
+    calculate_pr_rc_confidence_curves,
+    match_predictions,
+)
 
 MODEL_CHECKPOINT_PATH = "checkpoints/epoch_1_step_9378.pth"
 DATASET_ROOT_DIR = '../dataset'
@@ -37,68 +43,13 @@ RESULTS_DIR = "evaluation_results"
 DATASET_ID_STR = "manual" if EVALUATE_ON_MANUAL_DATASET else TEST_SPLIT_NAME
 
 
-class KeypointModel(nn.Module):
-    def __init__(self, heatmap_size=(512, 1024)):
-        super(KeypointModel, self).__init__()
-        backbone = timm.create_model('convnextv2_base.fcmae_ft_in22k_in1k_384', pretrained=False, num_classes=0, global_pool='')
-        self.feature_extractor = nn.Sequential(*list(backbone.children()))
-        in_channels = backbone.num_features
-        self.head = nn.Sequential(
-            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
-            nn.Conv2d(256, 1, kernel_size=1)
-        )
-    def forward(self, image):
-        features = self.feature_extractor(image)
-        heatmap = self.head(features)
-        return heatmap
-
 def load_trained_model(checkpoint_path, heatmap_size):
     print(f"Loading model checkpoint from: {checkpoint_path}")
-    if not os.path.exists(checkpoint_path):
-        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint_path}. Please ensure it exists.")
     model = KeypointModel(heatmap_size=heatmap_size)
-    try:
-        checkpoint = torch.load(checkpoint_path, map_location=DEVICE)
-    except AttributeError as e:
-        print(f"Warning: AttributeError during torch.load: {e}. Attempting workaround.")
-        import pickle
-        class CustomUnpickler(pickle.Unpickler):
-            def find_class(self, module, name):
-                try:
-                    return super().find_class(module, name)
-                except AttributeError:
-                    print(f"Could not find class {name} in module {module}, returning generic object.")
-                    return object 
-        with open(checkpoint_path, 'rb') as f:
-            unpickler = CustomUnpickler(f)
-            checkpoint = unpickler.load()
-    state_dict = checkpoint
-    if isinstance(checkpoint, dict):
-        if 'model_state_dict' in checkpoint:
-            state_dict = checkpoint['model_state_dict']
-        elif 'state_dict' in checkpoint:
-            state_dict = checkpoint['state_dict']
-        elif 'model' in checkpoint:
-            state_dict = checkpoint['model']
-    if all(key.startswith('module.') for key in state_dict.keys()): 
-        print("Removing 'module.' prefix from state_dict keys.")
-        state_dict = {k.replace('module.', '', 1): v for k, v in state_dict.items()} 
-    try:
-        model.load_state_dict(state_dict) 
-    except RuntimeError as e:
-        print(f"Error loading state_dict: {e}")
-        print("This might be due to a mismatch between the model architecture defined here (possibly a fallback) and the one in the checkpoint.")
-        print("Attempting to load with strict=False, unmatched keys will be ignored.")
-        try:
-            model.load_state_dict(state_dict, strict=False) 
-        except RuntimeError as e_strict_false:
-            print(f"Loading with strict=False also failed: {e_strict_false}")
-            raise e_strict_false
+    load_checkpoint(model, checkpoint_path, map_location=DEVICE)
     model.to(DEVICE)
     model.eval()
-    print("Model loaded successfully (possibly with ignored keys if strict=False was used).")
+    print("Model loaded successfully.")
     return model
 
 preprocess_transform = transforms.Compose([
@@ -164,27 +115,7 @@ def get_test_files(primary_path,
         label_extension = '.json'
 
         if not os.path.isdir(data_dir):
-            print(f"Test split directory not found: {data_dir}. Creating dummy data for testing.")
-            os.makedirs(data_dir, exist_ok=True)
-            try:
-                dummy_img = Image.new('RGB', (100, 100), color = 'red')
-                dummy_img_path = os.path.join(data_dir, "dummy_image_01.png")
-                dummy_img.save(dummy_img_path)
-                dummy_json_data = {"curb_ramp_points_normalized": [[0.5, 0.5], [0.2, 0.3]]}
-                dummy_json_path = os.path.join(data_dir, "dummy_image_01.json")
-                with open(dummy_json_path, 'w') as f:
-                    json.dump(dummy_json_data, f)
-
-                dummy_img2 = Image.new('RGB', (120,120), color='blue')
-                dummy_img_path2 = os.path.join(data_dir, "dummy_image_02.png")
-                dummy_img2.save(dummy_img_path2)
-                dummy_json_data2 = {"curb_ramp_points_normalized": []}
-                dummy_json_path2 = os.path.join(data_dir, "dummy_image_02.json")
-                with open(dummy_json_path2, 'w') as f:
-                    json.dump(dummy_json_data2, f)
-            except Exception as e:
-                print(f"Could not create dummy image/json: {e}")
-                raise FileNotFoundError(f"Test split directory not found: {data_dir}, and dummy creation failed.") from e
+            raise FileNotFoundError(f"Test split directory not found: {data_dir}.")
 
         for f_name in sorted(os.listdir(data_dir)):
             if f_name.lower().endswith(IMG_EXTENSIONS):
@@ -197,130 +128,20 @@ def get_test_files(primary_path,
     return image_files, label_files
 
 
-def calculate_ap_and_pr_curve(all_predictions_details, total_gt_points):
-    if total_gt_points == 0:
-        return 0.0, [0.0], [0.0], [], []
-    if not all_predictions_details:
-        return 0.0, [0.0], [0.0], [], []
-
-    sorted_preds = sorted(all_predictions_details, key=lambda x: x[0], reverse=True)
-    sorted_confidences = [p[0] for p in sorted_preds]
-    sorted_tp_flags = [p[1] for p in sorted_preds]
-
-    tp_count = 0
-    fp_count = 0
-    ap = 0.0
-    last_recall_val = 0.0
-    raw_recalls_list = []
-    raw_precisions_list = []
-
-    for i in range(len(sorted_preds)):
-        is_tp = sorted_tp_flags[i]
-        if is_tp:
-            tp_count += 1
-        else:
-            fp_count += 1
-
-        current_precision = tp_count / (tp_count + fp_count)
-        current_recall = tp_count / total_gt_points if total_gt_points > 0 else 0.0
-        raw_recalls_list.append(current_recall)
-        raw_precisions_list.append(current_precision)
-
-        if is_tp:
-            ap += current_precision * (current_recall - last_recall_val)
-            last_recall_val = current_recall
-
-    plot_recalls = [0.]
-    plot_precisions = [1.0]
-
-    
-    
-    
-    
-    
-    
-
-    plot_recalls.extend(raw_recalls_list)
-    plot_precisions.extend(raw_precisions_list)
-
-    if not plot_recalls or plot_recalls[-1] < 1.0 :
-        if plot_recalls:
-             plot_recalls.append(plot_recalls[-1])
-             plot_precisions.append(0.)
-    return ap, plot_recalls, plot_precisions, sorted_confidences, sorted_tp_flags
-
-def calculate_pr_rc_confidence_curves(sorted_confidences, sorted_tp_flags, total_gt_points):
-    if not sorted_confidences:
-        conf_thresholds_for_plot = [0.0, 1.0]
-        if total_gt_points > 0:
-            precisions_at_thresholds_for_plot = [1.0, 1.0]
-            recalls_at_thresholds_for_plot = [0.0, 0.0]
-        else:
-            precisions_at_thresholds_for_plot = [0.0, 0.0]
-            recalls_at_thresholds_for_plot = [0.0, 0.0]
-        return conf_thresholds_for_plot, precisions_at_thresholds_for_plot, recalls_at_thresholds_for_plot
-
-    conf_thresholds_unique_desc = []
-    precisions_at_thresholds_desc = []
-    recalls_at_thresholds_desc = []
-    tp_count_cumulative = 0
-    for i in range(len(sorted_confidences)):
-        if sorted_tp_flags[i]:
-            tp_count_cumulative += 1
-        num_preds_cumulative = i + 1
-        current_precision = tp_count_cumulative / num_preds_cumulative
-        if total_gt_points > 0:
-            current_recall = tp_count_cumulative / total_gt_points
-        else:
-            current_recall = 0.0
-        current_confidence_threshold = sorted_confidences[i]
-        if i == len(sorted_confidences) - 1 or sorted_confidences[i+1] < current_confidence_threshold:
-            conf_thresholds_unique_desc.append(current_confidence_threshold)
-            precisions_at_thresholds_desc.append(current_precision)
-            recalls_at_thresholds_desc.append(current_recall)
-
-    conf_thresholds_for_plot = list(reversed(conf_thresholds_unique_desc))
-    precisions_at_thresholds_for_plot = list(reversed(precisions_at_thresholds_desc))
-    recalls_at_thresholds_for_plot = list(reversed(recalls_at_thresholds_desc))
-
-    if not conf_thresholds_for_plot or conf_thresholds_for_plot[0] > 0.0:
-        conf_thresholds_for_plot.insert(0, 0.0)
-        precisions_at_thresholds_for_plot.insert(0, precisions_at_thresholds_for_plot[0] if precisions_at_thresholds_for_plot else (0.0 if total_gt_points > 0 else 0.0))
-        recalls_at_thresholds_for_plot.insert(0, recalls_at_thresholds_for_plot[0] if recalls_at_thresholds_for_plot else 0.0)
-
-    if not conf_thresholds_for_plot or conf_thresholds_for_plot[-1] < 1.0:
-        conf_thresholds_for_plot.append(1.0)
-        precisions_at_thresholds_for_plot.append(1.0 if total_gt_points > 0 else 0.0)
-        recalls_at_thresholds_for_plot.append(0.0)
-    elif recalls_at_thresholds_for_plot[-1] == 0.0: 
-        precisions_at_thresholds_for_plot[-1] = 1.0 if total_gt_points > 0 else 0.0
-
-
-    return conf_thresholds_for_plot, precisions_at_thresholds_for_plot, recalls_at_thresholds_for_plot
-
 def main():
-    os.makedirs(HEATMAP_CACHE_DIR, exist_ok=True)
-    os.makedirs(RESULTS_DIR, exist_ok=True) 
+    os.makedirs(RESULTS_DIR, exist_ok=True)
     print(f"Using device: {DEVICE}")
     print(f"Evaluating on {'MANUAL dataset' if EVALUATE_ON_MANUAL_DATASET else 'ORIGINAL ' + TEST_SPLIT_NAME + ' dataset'}")
-    print(f"Cache directory: {CACHE_DIR}")
     print(f"Results directory: {RESULTS_DIR}")
 
-    try:
-        model = load_trained_model(MODEL_CHECKPOINT_PATH, MODEL_HEATMAP_SIZE)
-    except FileNotFoundError as e:
-        print(f"{e}")
-        print("Attempting to create a dummy checkpoint for a test run as it's missing.")
-        try:
-            dummy_model_for_checkpoint = KeypointModel(heatmap_size=MODEL_HEATMAP_SIZE)
-            torch.save({'model_state_dict': dummy_model_for_checkpoint.state_dict()}, MODEL_CHECKPOINT_PATH)
-            print(f"Dummy checkpoint created at {MODEL_CHECKPOINT_PATH}. Please re-run the script.")
-        except Exception as ex_create:
-            print(f"Could not create dummy checkpoint: {ex_create}. Exiting.")
-        return
-    except Exception as load_err:
-        print(f"Failed to load model: {load_err}. Exiting.")
-        return
+    model = load_trained_model(MODEL_CHECKPOINT_PATH, MODEL_HEATMAP_SIZE)
+
+    # Cached heatmaps are only valid for the weights that produced them, so
+    # the cache directory is keyed by the checkpoint's content hash.
+    ckpt_fingerprint = checkpoint_fingerprint(MODEL_CHECKPOINT_PATH)
+    heatmap_cache_dir = os.path.join(HEATMAP_CACHE_DIR, ckpt_fingerprint)
+    os.makedirs(heatmap_cache_dir, exist_ok=True)
+    print(f"Cache directory: {heatmap_cache_dir}")
 
     heatmap_h, heatmap_w = MODEL_HEATMAP_SIZE
     RADIUS_THRESHOLD_PIXELS = RADIUS_THRESHOLD_NORMALIZED * heatmap_w
@@ -354,7 +175,7 @@ def main():
         img_path = image_paths[i]
         label_path = label_paths[i]
         base_name = os.path.splitext(os.path.basename(img_path))[0]
-        cached_heatmap_path = os.path.join(HEATMAP_CACHE_DIR, f"{base_name}_heatmap.npy")
+        cached_heatmap_path = os.path.join(heatmap_cache_dir, f"{base_name}_heatmap.npy")
         if os.path.exists(cached_heatmap_path):
             combined_heatmap_np = np.load(cached_heatmap_path)
         else:
@@ -414,23 +235,13 @@ def main():
             threshold_abs=PEAK_THRESHOLD_ABS,
             heatmap_shape=MODEL_HEATMAP_SIZE
         )
-        current_image_preds_sorted_by_conf = sorted(pred_peaks_normalized, key=lambda p_item: p_item[2], reverse=True)
-        k_gt_mappings = [False] * len(gt_points_normalized)
-        for pred_x_norm, pred_y_norm, pred_conf in current_image_preds_sorted_by_conf:
-            pred_x_px = pred_x_norm * heatmap_w
-            pred_y_px = pred_y_norm * heatmap_h
-            passes = False
-            for k_gt, (gt_x_norm, gt_y_norm) in enumerate(gt_points_normalized):
-                gt_x_px = gt_x_norm * heatmap_w
-                gt_y_px = gt_y_norm * heatmap_h
-                dist_sq = (pred_x_px - gt_x_px)**2 + (pred_y_px - gt_y_px)**2
-                if dist_sq < RADIUS_THRESHOLD_PIXELS_SQ:
-                    passes = True
-                    if not k_gt_mappings[k_gt]:
-                        all_pred_details_for_ap.append((pred_conf, True))
-                    k_gt_mappings[k_gt] = True
-            if not passes:
-                all_pred_details_for_ap.append((pred_conf, False))
+        all_pred_details_for_ap.extend(match_predictions(
+            pred_peaks_normalized,
+            gt_points_normalized,
+            RADIUS_THRESHOLD_PIXELS_SQ,
+            scale_x=heatmap_w,
+            scale_y=heatmap_h,
+        ))
     ap, recalls_curve_plot, precisions_curve_plot, sorted_confidences, sorted_tp_flags = \
         calculate_ap_and_pr_curve(all_pred_details_for_ap, total_gt_count)
     num_pred_total_above_peak_thresh = len(sorted_confidences)

--- a/stage_two/train.py
+++ b/stage_two/train.py
@@ -15,9 +15,10 @@ from torch.utils.tensorboard import SummaryWriter
 from torchvision import transforms
 import torchvision.transforms.functional as F
 from tqdm import tqdm
-import timm
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
+
+from rampnet.model import KeypointModel
 
 def setup_distributed():
     rank = int(os.environ.get("RANK", 0))
@@ -224,29 +225,7 @@ val_sampler = DistributedSampler(val_dataset, num_replicas=world_size, rank=rank
 train_loader = DataLoader(train_dataset, batch_size=1, sampler=train_sampler, num_workers=4, pin_memory=True)
 val_loader = DataLoader(val_dataset, batch_size=1, sampler=val_sampler, num_workers=4, pin_memory=True) if val_sampler else None
 
-class KeypointModel(nn.Module):
-    def __init__(self, heatmap_size=(512, 1024)):
-        super(KeypointModel, self).__init__()
-        backbone = timm.create_model('convnextv2_base.fcmae_ft_in22k_in1k_384', pretrained=True)
-        for param in backbone.parameters():
-            param.requires_grad = True
-        
-        self.feature_extractor = nn.Sequential(*list(backbone.children())[:-2])
-        in_channels = backbone.num_features
-        
-        self.head = nn.Sequential(
-            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
-            nn.Conv2d(256, 1, kernel_size=1)
-        )
-
-    def forward(self, image):
-        features = self.feature_extractor(image)
-        heatmap = self.head(features)
-        return heatmap
-
-model = KeypointModel(heatmap_size=heatmap_output_shape).cuda(local_rank)
+model = KeypointModel(heatmap_size=heatmap_output_shape, pretrained_backbone=True).cuda(local_rank)
 if world_size > 1:
     model = DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,71 @@
+"""Tests for the corrected matching and AP computation (issue #9).
+
+Pure-Python: these run anywhere, no torch needed.
+    pytest tests/test_metrics.py -v
+"""
+from rampnet.metrics import calculate_ap_and_pr_curve, match_predictions
+
+RADIUS_SQ = 10.0 ** 2
+SCALE = 100.0  # normalized coords x100 -> pixel-ish space
+
+
+def test_one_prediction_cannot_claim_two_gts():
+    # One high-confidence prediction sits within radius of two GT points.
+    preds = [(0.5, 0.5, 0.9)]
+    gts = [(0.52, 0.5), (0.48, 0.5)]
+    details = match_predictions(preds, gts, RADIUS_SQ, SCALE, SCALE)
+    assert details == [(0.9, True)]  # exactly one TP, never two
+
+
+def test_duplicate_detection_is_false_positive():
+    # Two predictions on the same single GT: best one matches, the duplicate
+    # must be a false positive (pre-release code dropped it entirely).
+    preds = [(0.5, 0.5, 0.9), (0.51, 0.5, 0.8)]
+    gts = [(0.5, 0.5)]
+    details = match_predictions(preds, gts, RADIUS_SQ, SCALE, SCALE)
+    assert sorted(details, reverse=True) == [(0.9, True), (0.8, False)]
+
+
+def test_higher_confidence_matches_first():
+    # The high-confidence prediction claims the GT even if listed second.
+    preds = [(0.51, 0.5, 0.3), (0.5, 0.5, 0.9)]
+    gts = [(0.5, 0.5)]
+    details = match_predictions(preds, gts, RADIUS_SQ, SCALE, SCALE)
+    assert (0.9, True) in details
+    assert (0.3, False) in details
+
+
+def test_prediction_outside_radius_is_false_positive():
+    preds = [(0.5, 0.5, 0.9)]
+    gts = [(0.9, 0.9)]
+    details = match_predictions(preds, gts, RADIUS_SQ, SCALE, SCALE)
+    assert details == [(0.9, False)]
+
+
+def test_nearest_unclaimed_gt_wins():
+    # A prediction between two GTs claims the nearer one, leaving the farther
+    # for the next prediction.
+    preds = [(0.50, 0.5, 0.9), (0.60, 0.5, 0.8)]
+    gts = [(0.49, 0.5), (0.58, 0.5)]
+    details = match_predictions(preds, gts, RADIUS_SQ, SCALE, SCALE)
+    assert details == [(0.9, True), (0.8, True)]
+
+
+def test_ap_perfect_detector():
+    details = [(0.9, True), (0.8, True), (0.7, True)]
+    ap, _, _, _, _ = calculate_ap_and_pr_curve(details, total_gt_points=3)
+    assert abs(ap - 1.0) < 1e-9
+
+
+def test_ap_interpolation_uses_max_envelope():
+    # TP, FP, TP over 2 GTs. Raw precisions: 1.0, 0.5, 2/3.
+    # Interpolated envelope at the first TP is max(1.0, 2/3)=1.0, at the
+    # second TP 2/3. AP = 0.5*1.0 + 0.5*(2/3).
+    details = [(0.9, True), (0.8, False), (0.7, True)]
+    ap, _, _, _, _ = calculate_ap_and_pr_curve(details, total_gt_points=2)
+    assert abs(ap - (0.5 + 0.5 * (2.0 / 3.0))) < 1e-9
+
+
+def test_ap_no_predictions_or_no_gt():
+    assert calculate_ap_and_pr_curve([], 5)[0] == 0.0
+    assert calculate_ap_and_pr_curve([(0.9, False)], 0)[0] == 0.0

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,66 @@
+"""Smoke tests for the canonical KeypointModel.
+
+Run inside the project conda environment (torch/timm required):
+    pytest tests/ -v
+
+These guard the one invariant that matters for every released checkpoint:
+the state_dict key layout of rampnet.model.KeypointModel must stay identical
+to the layout the paper-era training scripts saved (feature_extractor as
+Sequential over backbone.children()[:-2], plus the 4-layer head).
+"""
+import timm
+import torch
+import torch.nn as nn
+import pytest
+
+from rampnet.model import (
+    BACKBONE_NAME,
+    CROP_HEATMAP_SIZE,
+    PANO_HEATMAP_SIZE,
+    KeypointModel,
+)
+
+
+class LegacyTrainKeypointModel(nn.Module):
+    """Verbatim copy of the paper-era train-time construction (v1.0-iccv2025
+    stage_two/train.py). All released checkpoints carry this key layout."""
+
+    def __init__(self, heatmap_size):
+        super().__init__()
+        backbone = timm.create_model(BACKBONE_NAME, pretrained=False)
+        self.feature_extractor = nn.Sequential(*list(backbone.children())[:-2])
+        in_channels = backbone.num_features
+        self.head = nn.Sequential(
+            nn.Conv2d(in_channels, 256, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Upsample(size=heatmap_size, mode='bilinear', align_corners=False),
+            nn.Conv2d(256, 1, kernel_size=1)
+        )
+
+
+@pytest.mark.parametrize("heatmap_size", [PANO_HEATMAP_SIZE, CROP_HEATMAP_SIZE])
+def test_state_dict_keys_match_paper_checkpoints(heatmap_size):
+    canonical = KeypointModel(heatmap_size=heatmap_size, pretrained_backbone=False)
+    legacy = LegacyTrainKeypointModel(heatmap_size=heatmap_size)
+    canonical_sd = canonical.state_dict()
+    legacy_sd = legacy.state_dict()
+    assert list(canonical_sd.keys()) == list(legacy_sd.keys())
+    for key in canonical_sd:
+        assert canonical_sd[key].shape == legacy_sd[key].shape, key
+
+
+def test_legacy_checkpoint_loads_strictly():
+    legacy = LegacyTrainKeypointModel(heatmap_size=PANO_HEATMAP_SIZE)
+    canonical = KeypointModel(heatmap_size=PANO_HEATMAP_SIZE, pretrained_backbone=False)
+    canonical.load_state_dict(legacy.state_dict())  # must not raise
+
+
+@pytest.mark.parametrize("heatmap_size", [PANO_HEATMAP_SIZE, CROP_HEATMAP_SIZE])
+def test_forward_shape(heatmap_size):
+    model = KeypointModel(heatmap_size=heatmap_size, pretrained_backbone=False).eval()
+    # Small input keeps this CPU-friendly; the Upsample head fixes the output
+    # size regardless of input resolution.
+    x = torch.zeros(1, 3, 128, 256)
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (1, 1, heatmap_size[0], heatmap_size[1])


### PR DESCRIPTION
## Summary

Creates the `rampnet` package as the single source of truth for the model architecture, checkpoint loading, and detection metrics, replacing **seven divergent copy-pasted definitions**, and fixes the evaluation matching bug that biased reported precision/recall upward.

### The model divergence this fixes (#4)
Training built the backbone as `nn.Sequential(*children()[:-2])`; both evaluate scripts built it as ALL children with `num_classes=0, global_pool=''` — a different module structure whose key mismatch was masked by a `load_state_dict(strict=False)` fallback that can silently leave layers **randomly initialized** during evaluation. The canonical `rampnet.model.KeypointModel` reproduces the train-time key layout exactly (checkpoint compatibility is the invariant — see the docstring), and `rampnet.loading.load_checkpoint` is strict-only.

### The matching bug this fixes (#9)
`rampnet.metrics.match_predictions` implements greedy one-to-one matching. Previously: one prediction within radius of two GTs → **two TP entries**; a duplicate detection of an already-claimed GT → **dropped entirely** instead of counted as FP. AP is now computed with the standard monotone-envelope interpolation. Both evaluators now share this code.

### Silent-failure removal (#4)
- No more dummy-checkpoint fabrication when the checkpoint is missing
- No more dummy red/blue image fabrication when the test split is missing
- No more `CustomUnpickler` degrading unresolvable classes to `object`
- Heatmap caches are now keyed by a **content hash of the checkpoint**, so switching checkpoints can never silently reuse stale predictions (the "please delete `evaluate_cache`" README ritual is obsolete for checkpoint changes)

### Tests
- `tests/test_metrics.py` — pure Python, **8/8 pass locally**, including regression tests for the double-count and duplicate-drop bugs
- `tests/test_model.py` — asserts the canonical model'"'"'s state_dict keys/shapes match a verbatim copy of the paper-era train construction, and that a legacy checkpoint loads strictly (needs the conda env)

## ⚠️ Follow-up required on the cluster (issue #9 stays open)

The corrected matching changes the metric semantics, so the gold-set numbers must be re-measured to quantify the delta vs the published curves:

```bash
conda activate sidewalkcv2
pip install -e .            # once, from the repo root
pytest tests/ -v            # model-key tests
cd stage_two
python evaluate.py          # EVALUATE_ON_MANUAL_DATASET=True, checkpoint at checkpoints/epoch_1_step_9378.pth
```

Then compare P/R at confidence 0.55 against the committed `evaluation_results/pr_rc_vs_c_data_manual_r0.022_pt0.0.csv` (P=0.938/R=0.935). If the delta is material, add an erratum note to the README.

Closes #4. Addresses the code half of #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)