### PR TITLE
CLI entry points for stage_two + warm-start fine-tuning (#5, #6, #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,17 +186,29 @@ You can either start where you left off in Stage 1, with the dataset fully gener
 
 ### Training
 
-Run `train.py` in `stage_two`. This will take a very long time (> 24 hours). We trained on 16x NVIDIA L40s GPUs on a slurm cluster. We train for only one epoch but you may increase this if you desire. The model is saved at `best_model.pth`.
+Run `train.py` in `stage_two` (see `python train.py --help` for options). This will take a very long time (> 24 hours). We trained on 16x NVIDIA L40s GPUs on a slurm cluster. We train for only one epoch (`--epochs`) but you may increase this if you desire. The model is saved at `best_model.pth`.
+
+To **fine-tune from existing weights** (e.g. the released RampNet model, or a previous run's checkpoint) instead of training from ImageNet initialization:
+
+```bash
+python train.py --preset finetune --init-weights path/to/checkpoint.pth
+```
+
+The `finetune` preset lowers the learning rate to 3e-6 (override with `--lr`). Note that an existing `latest_checkpoint.pth` resume file always takes precedence over `--init-weights` — delete it if you intend to start a fresh fine-tuning run.
 
 ### Evaluating the Results
 
-There are two metrics that you can evaluate against. You can evaluate against (1) the test split of the generated dataset or (2) the manually annotated panoramas. We place more emphasis on the latter due to it being less prone to errors and it being directly from a human source instead of machine-derived. To switch between these benchmarks, modify the `EVALUATE_ON_MANUAL_DATASET` variable in `evaluate.py` in the `stage_two` folder.
+There are two benchmarks you can evaluate against: (1) the test split of the generated dataset or (2) the manually annotated panoramas. We place more emphasis on the latter due to it being less prone to errors and it being directly from a human source instead of machine-derived. Select with `--dataset manual` (default) or `--dataset test`:
 
-After running `evaluate.py` (which will take some time), you should have results printed in the console and in the `evaluation_results` directory. Note that the repo has the `evaluation_results` included from our past runs, so if `evaluation_results` is present, it doesn't necessarily mean evaluation was successful - it might just be the folder that was included in the github repo. This directory will contain the precision vs recall and precision & recall vs model confidence curves.
+```bash
+python evaluate.py --checkpoint checkpoints/your_checkpoint.pth --dataset manual
+```
+
+After running `evaluate.py` (which will take some time), you should have results printed in the console and in the `evaluation_results` directory: the precision vs recall and precision & recall vs model confidence curves (PNG + CSV), plus a machine-readable `metrics_*.json`. Note that the repo has the `evaluation_results` included from our past runs, so if `evaluation_results` is present, it doesn't necessarily mean evaluation was successful - it might just be the folder that was included in the github repo.
 
 ![Precision vs. Recall Curve](/stage_two/evaluation_results/pr_curve_manual_r0.022_pt0.0.png "Precision vs. Recall Curve")
 
-Please make sure to delete `evaluate_cache` between subsequent runs of `evaluate.py` if you are changing something in the script (e.g. the `EVALUATE_ON_MANUAL_DATASET` variable).
+Cached heatmaps are keyed by checkpoint hash and TTA setting, so switching checkpoints is safe without clearing anything; pass `--fresh` to force recomputation (e.g. after code changes to inference).
 
 ## Acknowledgments
 This work is supported by the NSF and is part of the [OSCUR initiative]([url](https://oscur.org/)).

--- a/stage_two/demo.py
+++ b/stage_two/demo.py
@@ -1,3 +1,5 @@
+import argparse
+import os
 import torch
 import gradio as gr
 from PIL import Image, ImageOps, ImageDraw
@@ -9,17 +11,30 @@ from skimage.feature import peak_local_max
 from rampnet.model import KeypointModel
 from rampnet.loading import load_checkpoint
 
-MODEL_CHECKPOINT_PATH = "checkpoints/epoch_1_step_9378.pth"
 MODEL_INPUT_SIZE = (2048, 4096)
 MODEL_HEATMAP_SIZE = (512, 1024)
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-GRADIO_PORT = 25566
 
-def load_trained_model(checkpoint_path, heatmap_size):
-    """Loads the KeypointModel and weights from a checkpoint."""
-    print(f"Loading model checkpoint from: {checkpoint_path}")
-    model = KeypointModel(heatmap_size=heatmap_size)
-    load_checkpoint(model, checkpoint_path, map_location=DEVICE)
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Gradio demo for the RampNet curb ramp detector.")
+    parser.add_argument('--checkpoint', default="projectsidewalk/rampnet-model",
+                        help="Local .pth checkpoint path, or a HuggingFace repo id such as "
+                             "'projectsidewalk/rampnet-model' (the default: the released weights)")
+    parser.add_argument('--port', type=int, default=25566, help="Gradio server port")
+    return parser.parse_args()
+
+
+def load_trained_model(checkpoint):
+    """Loads the model from a local checkpoint file or a HuggingFace repo id."""
+    if os.path.exists(checkpoint):
+        print(f"Loading local model checkpoint from: {checkpoint}")
+        model = KeypointModel(heatmap_size=MODEL_HEATMAP_SIZE)
+        load_checkpoint(model, checkpoint, map_location=DEVICE)
+    else:
+        print(f"'{checkpoint}' is not a local file; loading it as a HuggingFace repo id.")
+        from transformers import AutoModel
+        model = AutoModel.from_pretrained(checkpoint, trust_remote_code=True)
     model.to(DEVICE)
     model.eval()
     print("Model loaded successfully.")
@@ -122,13 +137,8 @@ def predict_and_visualize(input_image_pil):
 
     return output_image_pil 
 
-try:
-    model = load_trained_model(MODEL_CHECKPOINT_PATH, MODEL_HEATMAP_SIZE)
-except Exception as e:
-    print(f"Error loading model: {e}")
-    print("Please ensure the model checkpoint exists and the model definition is correct.")
-    print("If using scikit-image, ensure it's installed (`pip install scikit-image`)")
-    exit()
+args = parse_args()
+model = load_trained_model(args.checkpoint)
 
 print("Setting up Gradio interface...")
 iface = gr.Interface(
@@ -139,5 +149,5 @@ iface = gr.Interface(
     description="Upload an equirectangular image."
 )
 
-print(f"Launching Gradio server on port {GRADIO_PORT}...")
-iface.launch(server_name="0.0.0.0", server_port=GRADIO_PORT)
+print(f"Launching Gradio server on port {args.port}...")
+iface.launch(server_name="0.0.0.0", server_port=args.port)

--- a/stage_two/evaluate.py
+++ b/stage_two/evaluate.py
@@ -1,4 +1,6 @@
+import argparse
 import os
+import shutil
 import torch
 from PIL import Image, ImageOps
 import numpy as np
@@ -17,30 +19,37 @@ from rampnet.metrics import (
     match_predictions,
 )
 
-MODEL_CHECKPOINT_PATH = "checkpoints/epoch_1_step_9378.pth"
-DATASET_ROOT_DIR = '../dataset'
-TEST_SPLIT_NAME = 'test'
-MANUAL_DATASET_ROOT_DIR = '../manual_labels'
-
-
-
-EVALUATE_ON_MANUAL_DATASET = True
-
-
 MODEL_INPUT_SIZE = (2048, 4096)
 MODEL_HEATMAP_SIZE = (512, 1024)
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 RADIUS_THRESHOLD_NORMALIZED = 0.022
 PEAK_MIN_DISTANCE = 10
-PEAK_THRESHOLD_ABS = 0.0
 
 
-CACHE_DIR = "evaluate_cache"
-HEATMAP_CACHE_DIR = os.path.join(CACHE_DIR, "heatmaps")
-RESULTS_DIR = "evaluation_results"
-
-
-DATASET_ID_STR = "manual" if EVALUATE_ON_MANUAL_DATASET else TEST_SPLIT_NAME
+def parse_args():
+    parser = argparse.ArgumentParser(description="Evaluate the stage-2 panorama curb ramp detector.")
+    parser.add_argument('--checkpoint', default="checkpoints/epoch_1_step_9378.pth",
+                        help="Path to the trained checkpoint")
+    parser.add_argument('--dataset', choices=['manual', 'test'], default='manual',
+                        help="'manual' = 1k manually labeled gold set (default); "
+                             "'test' = test split of the generated dataset")
+    parser.add_argument('--data-root', default='../dataset',
+                        help="Dataset root containing the test split (and the images for manual labels)")
+    parser.add_argument('--manual-labels', default='../manual_labels',
+                        help="Directory of manual .txt label files")
+    parser.add_argument('--threshold', type=float, default=0.0,
+                        help="Peak-extraction confidence threshold. The default 0.0 keeps every peak "
+                             "so the full PR curve can be swept; see the README's 'Choosing a "
+                             "Detection Threshold' section for operating points.")
+    parser.add_argument('--tta', action=argparse.BooleanOptionalAction, default=True,
+                        help="Horizontal-flip test-time augmentation (default: on, as in the paper)")
+    parser.add_argument('--cache-dir', default='evaluate_cache',
+                        help="Heatmap cache root (keyed by checkpoint hash + TTA setting)")
+    parser.add_argument('--fresh', action='store_true',
+                        help="Delete this checkpoint's cached heatmaps before evaluating")
+    parser.add_argument('--results-dir', default='evaluation_results',
+                        help="Where plots, CSVs, and metrics.json are written")
+    return parser.parse_args()
 
 
 def load_trained_model(checkpoint_path, heatmap_size):
@@ -52,12 +61,14 @@ def load_trained_model(checkpoint_path, heatmap_size):
     print("Model loaded successfully.")
     return model
 
+
 preprocess_transform = transforms.Compose([
     transforms.Resize(MODEL_INPUT_SIZE, interpolation=transforms.InterpolationMode.BILINEAR),
     transforms.ToTensor(),
     transforms.Normalize(mean=[0.485, 0.456, 0.406],
                          std=[0.229, 0.224, 0.225])
 ])
+
 
 def extract_peaks_from_heatmap(heatmap_np, min_distance, threshold_abs, heatmap_shape):
     heatmap_h, heatmap_w = heatmap_shape
@@ -73,8 +84,9 @@ def extract_peaks_from_heatmap(heatmap_np, min_distance, threshold_abs, heatmap_
         peaks_normalized.append((x_norm, y_norm, confidence))
     return peaks_normalized
 
-def get_test_files(primary_path, 
-                     secondary_path_or_split_name, 
+
+def get_test_files(primary_path,
+                     secondary_path_or_split_name,
                      is_manual_dataset=False):
     image_files = []
     label_files = []
@@ -108,7 +120,7 @@ def get_test_files(primary_path,
                 if not found_image:
                     print(f"Warning: Manual label file '{label_f_name}' found, but no corresponding image (tried {', '.join(IMG_EXTENSIONS)}) in '{image_source_dir}'. Skipping.")
         print(f"Found {len(image_files)} image/{label_extension[1:].upper()} pairs for manual dataset.")
-    else: 
+    else:
         dataset_root = primary_path
         split_name = secondary_path_or_split_name
         data_dir = os.path.join(dataset_root, split_name)
@@ -128,50 +140,71 @@ def get_test_files(primary_path,
     return image_files, label_files
 
 
-def main():
-    os.makedirs(RESULTS_DIR, exist_ok=True)
-    print(f"Using device: {DEVICE}")
-    print(f"Evaluating on {'MANUAL dataset' if EVALUATE_ON_MANUAL_DATASET else 'ORIGINAL ' + TEST_SPLIT_NAME + ' dataset'}")
-    print(f"Results directory: {RESULTS_DIR}")
+def load_gt_points(label_path, is_manual_dataset):
+    gt_points_normalized = []
+    try:
+        if is_manual_dataset:
+            with open(label_path, 'r') as f:
+                lines = f.readlines()
+            for line in lines:
+                parts = line.strip().split()
+                if len(parts) >= 3:
+                    try:
+                        x_norm = float(parts[1])
+                        y_norm = float(parts[2])
+                        if not (0.0 <= x_norm <= 1.0 and 0.0 <= y_norm <= 1.0):
+                            print(f"Warning: Normalized coordinates out of [0,1] range in {label_path}: x={x_norm}, y={y_norm}. Skipping point.")
+                            continue
+                        gt_points_normalized.append((x_norm, y_norm))
+                    except ValueError:
+                        print(f"Warning: Could not parse coordinates in line '{line.strip()}' from {label_path}. Skipping line.")
+                elif line.strip():
+                    print(f"Warning: Malformed line in {label_path}: '{line.strip()}'. Skipping line.")
+        else:
+            with open(label_path, 'r') as f:
+                data = json.load(f)
+            raw_points = data.get("curb_ramp_points_normalized", [])
+            for p in raw_points:
+                if isinstance(p, (list, tuple)) and len(p) == 2 and \
+                   isinstance(p[0], (int, float)) and isinstance(p[1], (int, float)):
+                    gt_points_normalized.append(tuple(p))
+    except FileNotFoundError:
+        print(f"Label file not found: {label_path}. Assuming no GT points.")
+    except Exception as e:
+        print(f"Error loading labels from {label_path}: {e}. Assuming no GT points.")
+    return gt_points_normalized
 
-    model = load_trained_model(MODEL_CHECKPOINT_PATH, MODEL_HEATMAP_SIZE)
 
-    # Cached heatmaps are only valid for the weights that produced them, so
-    # the cache directory is keyed by the checkpoint's content hash.
-    ckpt_fingerprint = checkpoint_fingerprint(MODEL_CHECKPOINT_PATH)
-    heatmap_cache_dir = os.path.join(HEATMAP_CACHE_DIR, ckpt_fingerprint)
-    os.makedirs(heatmap_cache_dir, exist_ok=True)
-    print(f"Cache directory: {heatmap_cache_dir}")
+def predict_heatmap(model, input_image_pil, use_tta):
+    img_tensor_original = preprocess_transform(input_image_pil).unsqueeze(0).to(DEVICE)
+    with torch.no_grad():
+        pred_heatmap_original_raw = model(img_tensor_original)
+    pred_heatmap_original_np = np.clip(pred_heatmap_original_raw.squeeze().cpu().numpy(), 0, 1)
+    if not use_tta:
+        return pred_heatmap_original_np
+    input_image_flipped_pil = ImageOps.mirror(input_image_pil)
+    img_tensor_flipped = preprocess_transform(input_image_flipped_pil).unsqueeze(0).to(DEVICE)
+    with torch.no_grad():
+        pred_heatmap_flipped_raw = model(img_tensor_flipped)
+    pred_heatmap_flipped_oriented_np = np.clip(pred_heatmap_flipped_raw.squeeze().cpu().numpy(), 0, 1)
+    pred_heatmap_flipped_reverted_np = np.fliplr(pred_heatmap_flipped_oriented_np)
+    return np.maximum(pred_heatmap_original_np, pred_heatmap_flipped_reverted_np)
 
+
+def evaluate(model, image_paths, label_paths, is_manual_dataset, heatmap_cache_dir,
+             peak_threshold_abs=0.0, use_tta=True, dataset_id_str="dataset"):
+    """Run detection evaluation and return a metrics dict.
+
+    Importable entry point for automated pipelines (e.g. retraining gates and
+    the HF model-card generator); main() adds plots/CSVs around it.
+    """
     heatmap_h, heatmap_w = MODEL_HEATMAP_SIZE
-    RADIUS_THRESHOLD_PIXELS = RADIUS_THRESHOLD_NORMALIZED * heatmap_w
-    RADIUS_THRESHOLD_PIXELS_SQ = RADIUS_THRESHOLD_PIXELS**2
-    print(f"Heatmap dimensions (H, W): ({heatmap_h}, {heatmap_w})")
-    print(f"RADIUS_THRESHOLD_NORMALIZED: {RADIUS_THRESHOLD_NORMALIZED}")
-    print(f"Effective RADIUS_THRESHOLD_PIXELS for matching: {RADIUS_THRESHOLD_PIXELS:.2f}")
-
-    if EVALUATE_ON_MANUAL_DATASET:
-        
-        image_paths, label_paths = get_test_files(
-            primary_path=MANUAL_DATASET_ROOT_DIR,
-            secondary_path_or_split_name=os.path.join(DATASET_ROOT_DIR, TEST_SPLIT_NAME),
-            is_manual_dataset=True
-        )
-    else:
-        
-        image_paths, label_paths = get_test_files(
-            primary_path=DATASET_ROOT_DIR,
-            secondary_path_or_split_name=TEST_SPLIT_NAME,
-            is_manual_dataset=False
-        )
-
-    if not image_paths:
-        print("No image/label pairs found. Exiting.")
-        return
+    radius_threshold_pixels = RADIUS_THRESHOLD_NORMALIZED * heatmap_w
+    radius_threshold_pixels_sq = radius_threshold_pixels**2
 
     all_pred_details_for_ap = []
     total_gt_count = 0
-    for i in tqdm(range(len(image_paths)), desc=f"Evaluating on {DATASET_ID_STR}"):
+    for i in tqdm(range(len(image_paths)), desc=f"Evaluating on {dataset_id_str}"):
         img_path = image_paths[i]
         label_path = label_paths[i]
         base_name = os.path.splitext(os.path.basename(img_path))[0]
@@ -184,135 +217,182 @@ def main():
             except Exception as e:
                 print(f"Error loading image {img_path}: {e}. Skipping.")
                 continue
-            img_tensor_original = preprocess_transform(input_image_pil).unsqueeze(0).to(DEVICE)
-            with torch.no_grad():
-                pred_heatmap_original_raw = model(img_tensor_original)
-            pred_heatmap_original_np = np.clip(pred_heatmap_original_raw.squeeze().cpu().numpy(), 0, 1)
-            input_image_flipped_pil = ImageOps.mirror(input_image_pil)
-            img_tensor_flipped = preprocess_transform(input_image_flipped_pil).unsqueeze(0).to(DEVICE)
-            with torch.no_grad():
-                pred_heatmap_flipped_raw = model(img_tensor_flipped)
-            pred_heatmap_flipped_oriented_np = np.clip(pred_heatmap_flipped_raw.squeeze().cpu().numpy(), 0, 1)
-            pred_heatmap_flipped_reverted_np = np.fliplr(pred_heatmap_flipped_oriented_np)
-            combined_heatmap_np = np.maximum(pred_heatmap_original_np, pred_heatmap_flipped_reverted_np)
+            combined_heatmap_np = predict_heatmap(model, input_image_pil, use_tta)
             np.save(cached_heatmap_path, combined_heatmap_np)
 
-        gt_points_normalized = []
-        try:
-            if EVALUATE_ON_MANUAL_DATASET:
-                with open(label_path, 'r') as f:
-                    lines = f.readlines()
-                for line in lines:
-                    parts = line.strip().split()
-                    if len(parts) >= 3:
-                        try:
-                            x_norm = float(parts[1])
-                            y_norm = float(parts[2])
-                            if not (0.0 <= x_norm <= 1.0 and 0.0 <= y_norm <= 1.0):
-                                print(f"Warning: Normalized coordinates out of [0,1] range in {label_path}: x={x_norm}, y={y_norm}. Skipping point.")
-                                continue
-                            gt_points_normalized.append((x_norm, y_norm))
-                        except ValueError:
-                            print(f"Warning: Could not parse coordinates in line '{line.strip()}' from {label_path}. Skipping line.")
-                    elif line.strip():
-                        print(f"Warning: Malformed line in {label_path}: '{line.strip()}'. Skipping line.")
-            else:
-                with open(label_path, 'r') as f:
-                    data = json.load(f)
-                raw_points = data.get("curb_ramp_points_normalized", [])
-                for p in raw_points:
-                    if isinstance(p, (list, tuple)) and len(p) == 2 and \
-                       isinstance(p[0], (int, float)) and isinstance(p[1], (int, float)):
-                        gt_points_normalized.append(tuple(p)) 
-        except FileNotFoundError:
-            print(f"Label file not found: {label_path}. Assuming no GT points.")
-        except Exception as e:
-            print(f"Error loading labels from {label_path}: {e}. Assuming no GT points.")
+        gt_points_normalized = load_gt_points(label_path, is_manual_dataset)
         total_gt_count += len(gt_points_normalized)
         pred_peaks_normalized = extract_peaks_from_heatmap(
             combined_heatmap_np,
             min_distance=PEAK_MIN_DISTANCE,
-            threshold_abs=PEAK_THRESHOLD_ABS,
+            threshold_abs=peak_threshold_abs,
             heatmap_shape=MODEL_HEATMAP_SIZE
         )
         all_pred_details_for_ap.extend(match_predictions(
             pred_peaks_normalized,
             gt_points_normalized,
-            RADIUS_THRESHOLD_PIXELS_SQ,
+            radius_threshold_pixels_sq,
             scale_x=heatmap_w,
             scale_y=heatmap_h,
         ))
+
     ap, recalls_curve_plot, precisions_curve_plot, sorted_confidences, sorted_tp_flags = \
         calculate_ap_and_pr_curve(all_pred_details_for_ap, total_gt_count)
+
+    tp_at_threshold = sum(1 for conf, is_tp in all_pred_details_for_ap if is_tp)
+    num_preds = len(all_pred_details_for_ap)
+    precision_at_threshold = tp_at_threshold / num_preds if num_preds > 0 else 0.0
+    recall_at_threshold = tp_at_threshold / total_gt_count if total_gt_count > 0 else 0.0
+
+    return {
+        'dataset': dataset_id_str,
+        'ap': ap,
+        'total_gt_points': total_gt_count,
+        'total_predictions': num_preds,
+        'peak_threshold_abs': peak_threshold_abs,
+        'precision_at_threshold': precision_at_threshold,
+        'recall_at_threshold': recall_at_threshold,
+        'radius_threshold_normalized': RADIUS_THRESHOLD_NORMALIZED,
+        'tta': use_tta,
+        'recalls_curve': recalls_curve_plot,
+        'precisions_curve': precisions_curve_plot,
+        'sorted_confidences': sorted_confidences,
+        'sorted_tp_flags': sorted_tp_flags,
+    }
+
+
+def main():
+    args = parse_args()
+    evaluate_on_manual = args.dataset == 'manual'
+    dataset_id_str = 'manual' if evaluate_on_manual else 'test'
+
+    os.makedirs(args.results_dir, exist_ok=True)
+    print(f"Using device: {DEVICE}")
+    print(f"Evaluating on {'MANUAL dataset' if evaluate_on_manual else 'ORIGINAL test dataset'}")
+    print(f"Results directory: {args.results_dir}")
+
+    model = load_trained_model(args.checkpoint, MODEL_HEATMAP_SIZE)
+
+    # Cached heatmaps are only valid for the exact weights and TTA setting that
+    # produced them, so the cache directory is keyed by both.
+    ckpt_fingerprint = checkpoint_fingerprint(args.checkpoint)
+    cache_key = f"{ckpt_fingerprint}_{'tta' if args.tta else 'notta'}"
+    heatmap_cache_dir = os.path.join(args.cache_dir, "heatmaps", cache_key)
+    if args.fresh and os.path.isdir(heatmap_cache_dir):
+        print(f"--fresh: clearing cached heatmaps in {heatmap_cache_dir}")
+        shutil.rmtree(heatmap_cache_dir)
+    os.makedirs(heatmap_cache_dir, exist_ok=True)
+    print(f"Cache directory: {heatmap_cache_dir}")
+
+    if evaluate_on_manual:
+        image_paths, label_paths = get_test_files(
+            primary_path=args.manual_labels,
+            secondary_path_or_split_name=os.path.join(args.data_root, 'test'),
+            is_manual_dataset=True
+        )
+    else:
+        image_paths, label_paths = get_test_files(
+            primary_path=args.data_root,
+            secondary_path_or_split_name='test',
+            is_manual_dataset=False
+        )
+
+    if not image_paths:
+        raise FileNotFoundError("No image/label pairs found.")
+
+    metrics = evaluate(
+        model, image_paths, label_paths,
+        is_manual_dataset=evaluate_on_manual,
+        heatmap_cache_dir=heatmap_cache_dir,
+        peak_threshold_abs=args.threshold,
+        use_tta=args.tta,
+        dataset_id_str=dataset_id_str,
+    )
+    ap = metrics['ap']
+    total_gt_count = metrics['total_gt_points']
+    recalls_curve_plot = metrics['recalls_curve']
+    precisions_curve_plot = metrics['precisions_curve']
+    sorted_confidences = metrics['sorted_confidences']
+    sorted_tp_flags = metrics['sorted_tp_flags']
+
     num_pred_total_above_peak_thresh = len(sorted_confidences)
-    print(f"\n--- Evaluation Results ({DATASET_ID_STR} dataset) ---")
+    print(f"\n--- Evaluation Results ({dataset_id_str} dataset) ---")
     print(f"Average Precision (AP): {ap:.4f}")
     print(f"Total Ground Truth Points: {total_gt_count}")
-    print(f"Total Predictions (above PEAK_THRESHOLD_ABS={PEAK_THRESHOLD_ABS}): {num_pred_total_above_peak_thresh}")
+    print(f"Total Predictions (above threshold={args.threshold}): {num_pred_total_above_peak_thresh}")
+    if args.threshold > 0.0:
+        print(f"Precision at threshold {args.threshold}: {metrics['precision_at_threshold']:.4f}")
+        print(f"Recall at threshold {args.threshold}: {metrics['recall_at_threshold']:.4f}")
 
-    params_str = f"r{RADIUS_THRESHOLD_NORMALIZED}_pt{PEAK_THRESHOLD_ABS}"
+    params_str = f"r{RADIUS_THRESHOLD_NORMALIZED}_pt{args.threshold}"
+
+    metrics_json = {k: v for k, v in metrics.items()
+                    if k not in ('recalls_curve', 'precisions_curve', 'sorted_confidences', 'sorted_tp_flags')}
+    metrics_json['checkpoint'] = args.checkpoint
+    metrics_json['checkpoint_fingerprint'] = ckpt_fingerprint
+    metrics_json_path = os.path.join(args.results_dir, f"metrics_{dataset_id_str}_{params_str}.json")
+    with open(metrics_json_path, 'w') as f:
+        json.dump(metrics_json, f, indent=2)
+    print(f"Metrics saved to {metrics_json_path}")
+
     if num_pred_total_above_peak_thresh > 0 and total_gt_count > 0:
         plt.figure(figsize=(8, 6))
         plt.plot(recalls_curve_plot, precisions_curve_plot, marker='.', linestyle='-')
         plt.xlabel("Recall")
         plt.ylabel("Precision")
-        plt.title(f"Precision-Recall Curve (AP: {ap:.4f}) for {DATASET_ID_STR}\nParams: {params_str}")
+        plt.title(f"Precision-Recall Curve (AP: {ap:.4f}) for {dataset_id_str}\nParams: {params_str}")
         plt.xlim([0.0, 1.0])
         plt.ylim([0.0, 1.05])
         plt.grid(True)
-        pr_curve_filename = f"pr_curve_{DATASET_ID_STR}_{params_str}.png"
-        pr_curve_path = os.path.join(RESULTS_DIR, pr_curve_filename)
+        pr_curve_filename = f"pr_curve_{dataset_id_str}_{params_str}.png"
+        pr_curve_path = os.path.join(args.results_dir, pr_curve_filename)
         plt.savefig(pr_curve_path)
         plt.close()
         print(f"Precision-Recall curve saved to {pr_curve_path}")
 
-        
-        pr_csv_filename = f"pr_data_{DATASET_ID_STR}_{params_str}.csv"
-        pr_csv_path = os.path.join(RESULTS_DIR, pr_csv_filename)
+        pr_csv_filename = f"pr_data_{dataset_id_str}_{params_str}.csv"
+        pr_csv_path = os.path.join(args.results_dir, pr_csv_filename)
         with open(pr_csv_path, 'w', newline='') as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow(['recall', 'precision'])
             writer.writerows(zip(recalls_curve_plot, precisions_curve_plot))
         print(f"Precision-Recall data saved to {pr_csv_path}")
-        
 
     elif num_pred_total_above_peak_thresh == 0 and total_gt_count > 0:
-        print(f"No predictions made (above PEAK_THRESHOLD_ABS={PEAK_THRESHOLD_ABS}), PR curve is effectively at (0,0). Skipping PR curve plot.")
+        print(f"No predictions made (above threshold={args.threshold}), PR curve is effectively at (0,0). Skipping PR curve plot.")
     elif total_gt_count == 0:
         print("No ground truth points, AP is 0. Skipping PR curve plot.")
-    
+
     conf_thresholds_for_plot, precisions_at_thresholds_for_plot, recalls_at_thresholds_for_plot = \
         calculate_pr_rc_confidence_curves(sorted_confidences, sorted_tp_flags, total_gt_count)
     if not sorted_confidences and total_gt_count > 0:
-        print(f"No predictions made above PEAK_THRESHOLD_ABS={PEAK_THRESHOLD_ABS} (or all predictions were filtered out). Plotting default P/R vs Confidence curves.")
+        print(f"No predictions made above threshold={args.threshold} (or all predictions were filtered out). Plotting default P/R vs Confidence curves.")
     elif not sorted_confidences and total_gt_count == 0:
-        print(f"No predictions and no ground truth. Plotting default P/R vs Confidence curves.")
+        print("No predictions and no ground truth. Plotting default P/R vs Confidence curves.")
 
     plt.figure(figsize=(10, 7))
     plt.plot(conf_thresholds_for_plot, precisions_at_thresholds_for_plot, marker='.', linestyle='-', label='Precision', color='blue')
     plt.plot(conf_thresholds_for_plot, recalls_at_thresholds_for_plot, marker='.', linestyle='-', label='Recall', color='red')
     plt.xlabel("Confidence Threshold")
     plt.ylabel("Metric Value")
-    plt.title(f"Precision and Recall vs. Confidence for {DATASET_ID_STR}\nParams: {params_str}")
+    plt.title(f"Precision and Recall vs. Confidence for {dataset_id_str}\nParams: {params_str}")
     plt.xlim([-0.05, 1.05])
     plt.ylim([-0.05, 1.05])
     plt.grid(True)
     plt.legend()
-    pr_rc_vs_c_filename = f"pr_rc_vs_c_curve_{DATASET_ID_STR}_{params_str}.png"
-    pr_rc_vs_c_curve_path = os.path.join(RESULTS_DIR, pr_rc_vs_c_filename)
+    pr_rc_vs_c_filename = f"pr_rc_vs_c_curve_{dataset_id_str}_{params_str}.png"
+    pr_rc_vs_c_curve_path = os.path.join(args.results_dir, pr_rc_vs_c_filename)
     plt.savefig(pr_rc_vs_c_curve_path)
     plt.close()
     print(f"Precision-Recall vs. Confidence curve saved to {pr_rc_vs_c_curve_path}")
 
-    
-    pr_rc_vs_c_csv_filename = f"pr_rc_vs_c_data_{DATASET_ID_STR}_{params_str}.csv"
-    pr_rc_vs_c_csv_path = os.path.join(RESULTS_DIR, pr_rc_vs_c_csv_filename)
+    pr_rc_vs_c_csv_filename = f"pr_rc_vs_c_data_{dataset_id_str}_{params_str}.csv"
+    pr_rc_vs_c_csv_path = os.path.join(args.results_dir, pr_rc_vs_c_csv_filename)
     with open(pr_rc_vs_c_csv_path, 'w', newline='') as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(['confidence_threshold', 'precision', 'recall'])
         writer.writerows(zip(conf_thresholds_for_plot, precisions_at_thresholds_for_plot, recalls_at_thresholds_for_plot))
     print(f"Precision-Recall vs. Confidence data saved to {pr_rc_vs_c_csv_path}")
-    
 
 
 if __name__ == "__main__":

--- a/stage_two/train.py
+++ b/stage_two/train.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import random
 import numpy as np
@@ -19,6 +20,41 @@ import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 from rampnet.model import KeypointModel
+from rampnet.loading import load_checkpoint
+
+# Learning-rate defaults per preset: training from ImageNet initialization
+# uses the paper's 1e-5; fine-tuning released/earlier RampNet weights wants a
+# much smaller step so it refines rather than forgets.
+PRESET_LR = {'scratch': 1e-5, 'finetune': 3e-6}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train the stage-2 panorama curb ramp detector.")
+    parser.add_argument('--data-root', default='../dataset',
+                        help="Dataset root containing train/ and val/ splits (default: ../dataset)")
+    parser.add_argument('--epochs', type=int, default=1,
+                        help="Number of training epochs (default: 1, as in the paper)")
+    parser.add_argument('--lr', type=float, default=None,
+                        help="Learning rate; overrides the --preset default")
+    parser.add_argument('--preset', choices=sorted(PRESET_LR), default='scratch',
+                        help="'scratch' trains from ImageNet weights (lr 1e-5); "
+                             "'finetune' warm-starts from --init-weights (lr 3e-6)")
+    parser.add_argument('--init-weights', default=None,
+                        help="Checkpoint to warm-start from (e.g. the released RampNet weights). "
+                             "Ignored when latest_checkpoint.pth exists: resuming an interrupted "
+                             "run always takes precedence, and warm-starting applies at step 0 only.")
+    parser.add_argument('--checkpoint-dir', default='checkpoints',
+                        help="Directory for per-epoch checkpoints (default: checkpoints)")
+    args = parser.parse_args()
+    if args.preset == 'finetune' and args.init_weights is None:
+        parser.error("--preset finetune requires --init-weights")
+    if args.lr is None:
+        args.lr = PRESET_LR[args.preset]
+    return args
+
+
+args = parse_args()
+
 
 def setup_distributed():
     rank = int(os.environ.get("RANK", 0))
@@ -39,7 +75,7 @@ torch.manual_seed(42)
 random.seed(42)
 np.random.seed(42)
 
-new_root_dir = '../dataset'
+new_root_dir = args.data_root
 
 def generate_heatmap_from_points(points_normalized, heatmap_shape=(512, 1024), sigma=10.0):
     heatmap_h, heatmap_w = heatmap_shape
@@ -230,23 +266,39 @@ if world_size > 1:
     model = DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False)
 
 criterion = nn.MSELoss()
-optimizer = optim.Adam(model.parameters(), lr=1e-5)
+optimizer = optim.Adam(model.parameters(), lr=args.lr)
 scaler = torch.cuda.amp.GradScaler()
 
 if rank == 0:
     os.makedirs("peek_training", exist_ok=True)
-    os.makedirs("checkpoints", exist_ok=True)
+    os.makedirs(args.checkpoint_dir, exist_ok=True)
     writer = SummaryWriter(log_dir='runs/experiment_1')
+    print(f"Preset: {args.preset}, lr: {args.lr}, epochs: {args.epochs}, data root: {new_root_dir}")
+
 else:
     writer = None
 
-num_epochs = 1
+num_epochs = args.epochs
 checkpoint_interval_steps = 1000
 start_epoch = 0
 global_step = 0
 batch_idx_in_epoch = 0
 best_val_loss = float('inf')
 checkpoint_file = "latest_checkpoint.pth"
+
+if args.init_weights:
+    if os.path.exists(checkpoint_file):
+        # A resume file means this run was interrupted mid-training; restoring
+        # it (weights + optimizer + step) must win, otherwise a stale
+        # latest_checkpoint.pth would silently defeat the warm start.
+        if rank == 0:
+            print(f"Ignoring --init-weights {args.init_weights}: resume checkpoint "
+                  f"{checkpoint_file} exists and takes precedence.")
+    else:
+        model_to_init = model.module if isinstance(model, DDP) else model
+        load_checkpoint(model_to_init, args.init_weights, map_location='cpu')
+        if rank == 0:
+            print(f"Warm-started model weights from {args.init_weights}")
 
 if os.path.exists(checkpoint_file):
     checkpoint = torch.load(checkpoint_file, map_location='cpu')
@@ -380,7 +432,7 @@ for epoch in range(start_epoch, num_epochs):
             print(f"Epoch {epoch+1} Validation Loss: {avg_val_loss:.4f}")
             writer.add_scalar('Loss/val_epoch', avg_val_loss, global_step)
 
-            epoch_checkpoint_path = os.path.join("checkpoints", f"epoch_{epoch+1}_step_{global_step}.pth")
+            epoch_checkpoint_path = os.path.join(args.checkpoint_dir, f"epoch_{epoch+1}_step_{global_step}.pth")
             model_state_to_save = model.module.state_dict() if isinstance(model, DDP) else model.state_dict()
             torch.save({
                 'epoch': epoch + 1,


### PR DESCRIPTION
## Summary

Makes stage_two scriptable (no more config-by-editing-constants) and adds warm-start fine-tuning.

### train.py
- `--data-root`, `--epochs`, `--lr`, `--checkpoint-dir`
- **`--init-weights <ckpt>` + `--preset finetune`** (lr 3e-6; scratch preset keeps the paper 1e-5) — the prerequisite for fine-tuning RampNet on Project Sidewalk validation data. Reuses the proven warm-start pattern from `stage_one/crop_model/ps_and_manual_model/train.py`.
- Explicit precedence: an existing `latest_checkpoint.pth` resume file **always wins** over `--init-weights` (which applies at step 0 only), so a stale resume file cannot silently defeat a warm start — it tells you it ignored the flag.

### evaluate.py
- `--checkpoint`, `--dataset manual|test` (replaces the `EVALUATE_ON_MANUAL_DATASET` constant), `--threshold`, `--tta/--no-tta`, `--cache-dir`, `--fresh`, `--results-dir`
- Core refactored into an importable `evaluate(model, image_paths, ...) -> metrics dict` — the entry point for automated eval gates and the upcoming HF model-card generator (#3)
- Writes machine-readable `metrics_*.json` (AP, P/R at threshold, GT/pred counts, checkpoint fingerprint) next to the plots
- Cache keyed by checkpoint hash **and TTA setting** (a `--no-tta` run can never poison a TTA run'"'"'s cache)

### demo.py
- `--checkpoint` accepts a local `.pth` **or a HuggingFace repo id**, defaulting to `projectsidewalk/rampnet-model` — the demo now works out of the box, which permanently resolves #1 (the never-distributed `epoch_1_step_9378.pth`)
- `--port` for the Gradio server

README Stage 2 sections updated to the CLI (including the fine-tune recipe and the note that the evaluate-cache-deletion ritual is obsolete).

**Stacked on #13** (needs `rampnet` imports); GitHub retargets to `main` when #13 merges. Merge order: #13 → this.

Closes #5, closes #6, closes #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)