### PR TITLE
HF export/publish script for the stage-2 model (#3)

### DIFF
--- a/scripts/export_hf_model.py
+++ b/scripts/export_hf_model.py
@@ -1,0 +1,159 @@
+"""Export a trained stage-2 checkpoint as a versioned HuggingFace model package.
+
+Produces a local trust_remote_code package (config + modeling files + weights +
+model card) that reproduces projectsidewalk/rampnet-model from this repo, and
+optionally pushes it to the Hub. Run from the repo root:
+
+    python scripts/export_hf_model.py --checkpoint stage_two/checkpoints/epoch_1_step_9378.pth \
+        --metrics-json stage_two/evaluation_results/metrics_manual_r0.022_pt0.55.json \
+        [--push --repo-id projectsidewalk/rampnet-model]
+
+Generate the metrics JSON first with stage_two/evaluate.py (at the recommended
+operating threshold, with TTA) so the model card carries real gold-set numbers.
+"""
+import argparse
+import datetime
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import torch
+
+from rampnet.model import KeypointModel, PANO_HEATMAP_SIZE
+from rampnet.loading import load_checkpoint, checkpoint_fingerprint
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PACKAGE_DIR = os.path.join(REPO_ROOT, "scripts", "hf_package")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Export a stage-2 checkpoint as a HuggingFace model package.")
+    parser.add_argument('--checkpoint', required=True, help="Trained stage-2 checkpoint (.pth)")
+    parser.add_argument('--output-dir', default='hf_export', help="Where to write the package (default: hf_export)")
+    parser.add_argument('--metrics-json', default=None,
+                        help="metrics_*.json produced by stage_two/evaluate.py; embedded in the model card")
+    parser.add_argument('--dataset-revision', default='main',
+                        help="Revision of projectsidewalk/rampnet-dataset the checkpoint was trained on")
+    parser.add_argument('--recommended-threshold', type=float, default=0.55,
+                        help="Operating threshold documented in the model card (default: 0.55)")
+    parser.add_argument('--repo-id', default='projectsidewalk/rampnet-model',
+                        help="Hub repo id used in the card's usage example and for --push")
+    parser.add_argument('--push', action='store_true', help="Upload the package to the Hub after export")
+    parser.add_argument('--skip-verify', action='store_true',
+                        help="Skip the round-trip check that the exported package reproduces the checkpoint's output")
+    return parser.parse_args()
+
+
+def git_commit():
+    try:
+        return subprocess.check_output(
+            ['git', 'rev-parse', '--short', 'HEAD'], cwd=REPO_ROOT, text=True).strip()
+    except Exception:
+        return 'unknown'
+
+
+def render_eval_section(metrics_json_path):
+    if metrics_json_path is None:
+        return ("*No evaluation metrics were supplied at export time. Run `stage_two/evaluate.py "
+                "--threshold <t>` and re-export with `--metrics-json` to fill this in.*")
+    with open(metrics_json_path) as f:
+        m = json.load(f)
+    lines = [
+        "| Metric | Value |",
+        "| :--- | :--- |",
+        f"| Average Precision (interpolated) | {m['ap']:.4f} |",
+        f"| Precision @ threshold {m['peak_threshold_abs']} | {m['precision_at_threshold']:.4f} |",
+        f"| Recall @ threshold {m['peak_threshold_abs']} | {m['recall_at_threshold']:.4f} |",
+        f"| Ground-truth points | {m['total_gt_points']} |",
+        f"| Matching radius (normalized) | {m['radius_threshold_normalized']} |",
+        f"| Flip TTA | {'on' if m.get('tta', True) else 'off'} |",
+    ]
+    return "\n".join(lines)
+
+
+def verify_roundtrip(output_dir, reference_model):
+    from transformers import AutoModel
+    exported = AutoModel.from_pretrained(output_dir, trust_remote_code=True).eval()
+    x = torch.randn(1, 3, 256, 512)
+    with torch.no_grad():
+        expected = reference_model(x)
+        actual = exported(x)
+    if not torch.allclose(expected, actual, atol=1e-6):
+        raise RuntimeError("Exported package output does not match the source checkpoint's output.")
+    print("Round-trip verification passed: exported package reproduces the checkpoint's output.")
+
+
+def main():
+    args = parse_args()
+
+    print(f"Loading checkpoint {args.checkpoint} (strict)...")
+    reference_model = KeypointModel(heatmap_size=PANO_HEATMAP_SIZE)
+    load_checkpoint(reference_model, args.checkpoint, map_location='cpu')
+    reference_model.eval()
+    fingerprint = checkpoint_fingerprint(args.checkpoint)
+
+    sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
+    # Imported as a package so the relative imports match how the Hub's
+    # dynamic-module loader will resolve them.
+    from hf_package.configuration_rampnet import RampNetConfig  # noqa: E402
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # The modeling code shipped to the Hub imports the architecture from
+    # rampnet_model.py, copied verbatim from the canonical rampnet/model.py so
+    # the Hub package can never fork the architecture.
+    shutil.copy(os.path.join(REPO_ROOT, "rampnet", "model.py"),
+                os.path.join(args.output_dir, "rampnet_model.py"))
+    for fname in ("configuration_rampnet.py", "modeling_rampnet.py"):
+        shutil.copy(os.path.join(PACKAGE_DIR, fname), os.path.join(args.output_dir, fname))
+
+    config = RampNetConfig(recommended_threshold=args.recommended_threshold)
+    config.auto_map = {
+        "AutoConfig": "configuration_rampnet.RampNetConfig",
+        "AutoModel": "modeling_rampnet.RampNetModel",
+    }
+    config.save_pretrained(args.output_dir)
+
+    # Wrap the weights in the HF module layout (prefix 'model.') and save.
+    from transformers import AutoConfig, AutoModel
+    hf_config = AutoConfig.from_pretrained(args.output_dir, trust_remote_code=True)
+    hf_model = AutoModel.from_config(hf_config, trust_remote_code=True)
+    hf_model.model.load_state_dict(reference_model.state_dict())
+    hf_model.save_pretrained(args.output_dir)
+    print(f"Saved weights and config to {args.output_dir}")
+
+    with open(os.path.join(PACKAGE_DIR, "README.model_card.template.md"), encoding='utf-8') as f:
+        template = f.read()
+    card = template.format(
+        git_commit=git_commit(),
+        checkpoint_name=os.path.basename(args.checkpoint),
+        checkpoint_fingerprint=fingerprint,
+        dataset_revision=args.dataset_revision,
+        export_date=datetime.date.today().isoformat(),
+        eval_section=render_eval_section(args.metrics_json),
+        recommended_threshold=args.recommended_threshold,
+        repo_id=args.repo_id,
+    )
+    with open(os.path.join(args.output_dir, "README.md"), 'w', encoding='utf-8') as f:
+        f.write(card)
+    print("Wrote model card README.md")
+
+    if not args.skip_verify:
+        verify_roundtrip(args.output_dir, reference_model)
+
+    if args.push:
+        from huggingface_hub import HfApi
+        api = HfApi()
+        api.create_repo(args.repo_id, repo_type='model', exist_ok=True)
+        api.upload_folder(folder_path=args.output_dir, repo_id=args.repo_id, repo_type='model',
+                          commit_message=f"Export {os.path.basename(args.checkpoint)} "
+                                         f"(sha256 {fingerprint}) from commit {git_commit()}")
+        print(f"Pushed to https://huggingface.co/{args.repo_id}")
+    else:
+        print("Dry run complete (no --push). Inspect the package, then re-run with --push to publish.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hf_package/README.model_card.template.md
+++ b/scripts/hf_package/README.model_card.template.md
@@ -1,0 +1,85 @@
+---
+license: mit
+library_name: transformers
+pipeline_tag: keypoint-detection
+tags:
+  - curb-ramp-detection
+  - accessibility
+  - street-view
+  - keypoint-heatmap
+---
+
+# RampNet Curb Ramp Detection Model
+
+Stage-2 model from **RampNet: A Two-Stage Pipeline for Bootstrapping Curb Ramp Detection in
+Streetscape Images from Open Government Metadata** (O'Meara et al., ICCV'25 CV4A11y workshop,
+[arXiv:2508.09415](https://arxiv.org/abs/2508.09415)).
+
+Takes a 2048x4096 equirectangular street-view panorama (ImageNet-normalized) and predicts a
+512x1024 heatmap of curb ramp locations. Extract detections with `skimage.feature.peak_local_max`.
+
+## Provenance
+
+| Field | Value |
+| :--- | :--- |
+| Training code | https://github.com/ProjectSidewalk/RampNet @ `{git_commit}` |
+| Source checkpoint | `{checkpoint_name}` (sha256 prefix `{checkpoint_fingerprint}`) |
+| Training dataset | [projectsidewalk/rampnet-dataset](https://huggingface.co/datasets/projectsidewalk/rampnet-dataset) revision `{dataset_revision}` |
+| Exported | {export_date} by `scripts/export_hf_model.py` |
+
+## Evaluation (1,000-panorama manually labeled gold set)
+
+{eval_section}
+
+**Important:** these numbers were measured **with horizontal-flip test-time augmentation**
+(evaluate the original and mirrored panorama, combine heatmaps with elementwise max). Single-pass
+inference will land somewhat below them; derive your own threshold curve without TTA before
+choosing an operating point.
+
+## Choosing a detection threshold
+
+- `{recommended_threshold}` is the recommended default operating point (see evaluation above).
+- Sweeping thresholds: run `stage_two/evaluate.py` in the training repo, which emits full
+  precision/recall-vs-confidence curves as CSV.
+- Per-city deployments should calibrate on ~100 locally labeled panoramas; see the repo README's
+  "Choosing a Detection Threshold" section.
+
+## Usage
+
+```python
+import torch
+from transformers import AutoModel
+from PIL import Image
+import numpy as np
+from torchvision import transforms
+from skimage.feature import peak_local_max
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+model = AutoModel.from_pretrained("{repo_id}", trust_remote_code=True).to(DEVICE).eval()
+
+preprocess = transforms.Compose([
+    transforms.Resize((2048, 4096), interpolation=transforms.InterpolationMode.BILINEAR),
+    transforms.ToTensor(),
+    transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+])
+
+img = Image.open("panorama.jpg").convert("RGB")
+with torch.no_grad():
+    heatmap = model(preprocess(img).unsqueeze(0).to(DEVICE)).squeeze().cpu().numpy()
+
+peaks = peak_local_max(np.clip(heatmap, 0, 1), min_distance=10, threshold_abs={recommended_threshold})
+scale_w, scale_h = img.width / heatmap.shape[1], img.height / heatmap.shape[0]
+print([(int(c * scale_w), int(r * scale_h)) for r, c in peaks])
+```
+
+## Citation
+
+```bibtex
+@inproceedings{{omeara2025rampnet,
+  author    = {{John S. O'Meara and Jared Hwang and Zeyu Wang and Michael Saugstad and Jon E. Froehlich}},
+  title     = {{{{RampNet: A Two-Stage Pipeline for Bootstrapping Curb Ramp Detection in Streetscape Images from Open Government Metadata}}}},
+  booktitle = {{{{ICCV'25 Workshop on Vision Foundation Models and Generative AI for Accessibility: Challenges and Opportunities (ICCV 2025 Workshop)}}}},
+  year      = {{2025}},
+  doi       = {{https://doi.org/10.48550/arXiv.2508.09415}},
+}}
+```

--- a/scripts/hf_package/configuration_rampnet.py
+++ b/scripts/hf_package/configuration_rampnet.py
@@ -1,0 +1,25 @@
+from transformers import PretrainedConfig
+
+
+class RampNetConfig(PretrainedConfig):
+    model_type = "rampnet"
+
+    def __init__(
+        self,
+        input_size=(2048, 4096),
+        heatmap_size=(512, 1024),
+        image_mean=(0.485, 0.456, 0.406),
+        image_std=(0.229, 0.224, 0.225),
+        recommended_threshold=0.55,
+        recommended_min_distance=10,
+        tta_recommended=True,
+        **kwargs,
+    ):
+        self.input_size = list(input_size)
+        self.heatmap_size = list(heatmap_size)
+        self.image_mean = list(image_mean)
+        self.image_std = list(image_std)
+        self.recommended_threshold = recommended_threshold
+        self.recommended_min_distance = recommended_min_distance
+        self.tta_recommended = tta_recommended
+        super().__init__(**kwargs)

--- a/scripts/hf_package/modeling_rampnet.py
+++ b/scripts/hf_package/modeling_rampnet.py
@@ -1,0 +1,22 @@
+from transformers import PreTrainedModel
+
+from .configuration_rampnet import RampNetConfig
+# rampnet_model.py is copied verbatim from rampnet/model.py by
+# scripts/export_hf_model.py at export time — it is generated, not a fork.
+from .rampnet_model import KeypointModel
+
+
+class RampNetModel(PreTrainedModel):
+    config_class = RampNetConfig
+    main_input_name = "pixel_values"
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = KeypointModel(
+            heatmap_size=tuple(config.heatmap_size),
+            pretrained_backbone=False,
+        )
+
+    def forward(self, pixel_values):
+        """Returns the predicted curb ramp keypoint heatmap (B, 1, H, W)."""
+        return self.model(pixel_values)


### PR DESCRIPTION
## Summary

`projectsidewalk/rampnet-model` could not be regenerated from this repo — the trust_remote_code package existed only on the Hub. This adds `scripts/export_hf_model.py`:

- **Canonical architecture, never forked**: the modeling wrapper imports from `rampnet_model.py`, copied **verbatim from `rampnet/model.py` at export time** — the Hub package can never diverge from the training architecture (why this PR sits atop #13).
- **Model card with real provenance**: auto-filled with the training-code git commit, checkpoint sha256 fingerprint, dataset revision, gold-set eval numbers (from the `metrics_*.json` that `stage_two/evaluate.py` now emits — why this sits atop #15), the recommended 0.55 threshold, and the flip-TTA caveat.
- **Round-trip verification before publish**: loads the exported package via `AutoModel.from_pretrained(..., trust_remote_code=True)` and asserts identical output to the source checkpoint; `--push` uploads via `huggingface_hub` with a provenance-carrying commit message.

### Usage (on the cluster)
```bash
cd stage_two && python evaluate.py --checkpoint checkpoints/epoch_1_step_9378.pth --threshold 0.55 && cd ..
python scripts/export_hf_model.py \
  --checkpoint stage_two/checkpoints/epoch_1_step_9378.pth \
  --metrics-json stage_two/evaluation_results/metrics_manual_r0.022_pt0.55.json
# inspect hf_export/, then re-run with --push
```

One-time follow-up when first publishing: diff the exported weights against the current Hub weights to document that Hub v1 == paper checkpoint.

**Stacked on #15** (→ #13 → main). Merge order: #13 → #15 → this.

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)