### PR TITLE
Provenance docs, seeded splits, temporal-filter fixes (#8, #10, #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ conda activate sidewalkcv2
 
 ¹This number is the sum of curb ramp locations from the three cities with "Good" location precision listed in Table 1: New York City (217,680), Portland (45,324), and Bend (13,611).
 
+**Provenance note:** see [`docs/data_provenance.md`](docs/data_provenance.md) for the registry of which cities' data entered training (evaluations in those cities are optimistically biased), the undocumented Google endpoints the regeneration pipeline depends on, and why the HuggingFace dataset — not a re-run of `split_dataset.py` — is the split of record for the paper.
+
 ## Dataset Setup
 
 Before reproducing our results, certain datasets will need to be downloaded.

--- a/docs/data_provenance.md
+++ b/docs/data_provenance.md
@@ -1,0 +1,86 @@
+# Data Provenance and Training-Data Contamination Registry
+
+This document records where every piece of RampNet training data came from, which external
+services the regeneration pipeline depends on, and — critically — **which cities' data entered
+training**, so that future model evaluations do not accidentally use contaminated ground truth.
+
+## 1. Training-data contamination registry
+
+If you evaluate a RampNet-derived model in any of these cities, the evaluation is **optimistically
+biased** — the model may have seen imagery or labels from there during training. Use held-out
+cities (or freshly collected post-deployment validation data, e.g. Project Sidewalk agree-rates)
+for unbiased measurements.
+
+| City | Entered training via | Pipeline stage |
+| :--- | :--- | :--- |
+| New York City, NY | Open-government curb ramp locations (`nyc.csv`) | Stage 1 dataset → Stage 2 model |
+| Portland, OR | Open-government curb ramp locations (`portland.geojson`) | Stage 1 dataset → Stage 2 model |
+| Bend, OR | Open-government curb ramp locations (`bend.geojson`) | Stage 1 dataset → Stage 2 model |
+| Blackhawk Hills, IL | Project Sidewalk labels | Crop-model pre-training |
+| Chicago, IL | Project Sidewalk labels | Crop-model pre-training |
+| Cliffside Park, NJ | Project Sidewalk labels | Crop-model pre-training |
+| Columbus, OH | Project Sidewalk labels | Crop-model pre-training |
+| Knoxville, TN (knox) | Project Sidewalk labels | Crop-model pre-training |
+| Mendota, IL | Project Sidewalk labels | Crop-model pre-training |
+| Newberg, OR | Project Sidewalk labels | Crop-model pre-training |
+| Oradell, NJ | Project Sidewalk labels | Crop-model pre-training |
+| Pittsburgh, PA | Project Sidewalk labels | Crop-model pre-training |
+| Seattle, WA (sea) | Project Sidewalk labels | Crop-model pre-training |
+| St. Louis, MO | Project Sidewalk labels | Crop-model pre-training |
+| Teaneck, NJ | Project Sidewalk labels | Crop-model pre-training |
+
+The Project Sidewalk city list is the set of `https://sidewalk-<city>.cs.washington.edu` servers
+queried in `stage_one/crop_model/ps_model/data/download_data.py`. Note the crop model's influence
+flows into the Stage 1 dataset (it places every keypoint), so crop-model cities are transitively
+contaminated for the full pipeline too. The 1,000-panorama manual gold set (`manual_labels/`) is
+sampled from the NYC/Portland/Bend Stage 1 dataset — it is a *label-quality* gold standard, not a
+geographically held-out one.
+
+Additionally, the Project Sidewalk label CSVs are fetched **live** at pipeline run time with no
+snapshot pinning: re-running `download_data.py` today produces a different crop-model training set
+than the paper's, because those databases keep growing.
+
+## 2. Undocumented Google endpoints (regeneration brittleness)
+
+Stage 1 regeneration depends entirely on internal, unversioned Google Street View endpoints.
+None of these are covered by any API contract; Google can change or remove them at any time.
+As of this writing the parses are guarded by validating helpers in
+`stage_one/dataset_generation/search_panos.py` that raise `GoogleEndpointSchemaError` on schema
+drift instead of silently producing garbage.
+
+### 2.1 Panorama search
+- **Endpoint:** `https://maps.googleapis.com/maps/api/js/GeoPhotoService.SingleImageSearch?pb=...`
+  (hand-crafted protobuf-in-URL, built in `make_search_url`)
+- **Parse:** JSONP payload; panorama list lives at `data[1][5][0][3][0]` (reversed), with per-pano
+  fields `pano[0][1]`=id, `pano[2][0][2..3]`=lat/lon, `pano[2][2][0..2]`=heading/pitch/roll,
+  `pano[3][0]`=elevation (`extract_panoramas`).
+- **Failure mode:** schema drift here raises from pydantic validation or index errors.
+
+### 2.2 Panorama metadata (capture date + heading)
+- **Endpoint:** `https://maps.googleapis.com/$rpc/google.internal.maps.mapsjs.v1.MapsJsInternalService/GetMetadata`
+  (JSON+protobuf POST body)
+- **Parses:** capture date at `[1][0][6][7]` = `[year, month]`; heading at `[1][0][5][0][1][2][0]`
+  (degrees). Both feed directly into label placement — the heading determines where on the
+  panorama each curb ramp keypoint lands — which is why implausible values now raise.
+
+### 2.3 Panorama tiles
+- **Endpoint:** `https://streetviewpixels-pa.googleapis.com/v1/tile?cb_client=maps_sv.tactile&panoid=...&x=..&y=..&zoom=..`
+- Used by both `stage_one/dataset_generation/download_dataset.py` (zoom 3, 4096x2048 target) and
+  `stage_one/crop_model/ps_model/data/download_data.py` (zoom 4, 8192x4096 target). Panorama
+  dimensions are discovered heuristically by probing for all-black tiles; non-standard panoramas
+  can be misdetected.
+
+## 3. Open-government source data
+
+The exact NYC/Portland/Bend curb ramp files used for the paper are archived in the paper's
+supplemental material; the live portal links in the README serve current (drifting) versions.
+Install-date semantics differ per city, and many records have **no install date**; see
+`TREAT_UNDATED_AS_PREDATING` in `stage_one/dataset_generation/generate_dataset_meta.py` for how
+those are handled during regeneration.
+
+## 4. Split of record
+
+The train/val/test split of the released dataset is frozen in
+[projectsidewalk/rampnet-dataset](https://huggingface.co/datasets/projectsidewalk/rampnet-dataset).
+The split scripts are seeded now, but the paper split predates the seeding — treat the HuggingFace
+dataset, not a re-run of `split_dataset.py`, as authoritative for reproducing paper experiments.

--- a/stage_one/crop_model/ps_model/data/download_data.py
+++ b/stage_one/crop_model/ps_model/data/download_data.py
@@ -242,7 +242,7 @@ all_cities = all_cities[
 
 total_images = len(all_cities)
 
-all_cities = [x for _, x in all_cities.sample(frac=1).reset_index(drop=True).groupby('Panorama ID')]
+all_cities = [x for _, x in all_cities.sample(frac=1, random_state=42).reset_index(drop=True).groupby('Panorama ID')]
 
 
 start_time = time.time()

--- a/stage_one/crop_model/ps_model/data/splititup.sh
+++ b/stage_one/crop_model/ps_model/data/splititup.sh
@@ -24,8 +24,8 @@ VAL_SIZE=$((TOTAL_FILES * 15 / 100))
 # Remaining goes to test
 TEST_SIZE=$((TOTAL_FILES - TRAIN_SIZE - VAL_SIZE))
 
-# Shuffle files
-shuffled_files=( $(printf "%s\n" "${FILES[@]}" | shuf) )
+# Shuffle files (deterministically, so the split is reproducible)
+shuffled_files=( $(printf "%s\n" "${FILES[@]}" | shuf --random-source=<(yes 42)) )
 
 # Copy files to train, val, and test folders
 for i in "${!shuffled_files[@]}"; do

--- a/stage_one/dataset_generation/combine_location_data.py
+++ b/stage_one/dataset_generation/combine_location_data.py
@@ -5,26 +5,33 @@ import re
 import random
 
 def convert_date(value):
+    """Normalize an install date to YYYY-MM-DD, or "" when unknown.
+
+    Unknown dates used to be silently replaced with 2000-01-01, which made
+    every dateless curb ramp trivially pass the downstream "installed before
+    the panorama was captured" check. An empty string keeps the missing-ness
+    explicit; generate_dataset_meta.py decides how to treat it.
+    """
     if value is None or value == "":
-        return "2000-01-01"
+        return ""
     if isinstance(value, str):
         if value.lower() == "none" or value.strip() == "":
-            return "2000-01-01"
+            return ""
     if isinstance(value, (int, float)):
         try:
-            
+
             dt = datetime.datetime.utcfromtimestamp(value / 1000)
             return dt.strftime("%Y-%m-%d")
         except Exception:
-            return "2000-01-01"
+            return ""
     elif isinstance(value, str):
         try:
             dt = datetime.datetime.strptime(value, "%m/%d/%Y")
             return dt.strftime("%Y-%m-%d")
         except ValueError:
-            return "2000-01-01"
+            return ""
     else:
-        return "2000-01-01"
+        return ""
 
 def parse_geojson(file_path, date_field):
     results = []
@@ -78,8 +85,9 @@ def main():
     
     
     all_data.extend(parse_csv("location_data/nyc.csv", "GeoCyclora"))
-    
-    
+
+
+    random.seed(42)
     random.shuffle(all_data)
     
     

--- a/stage_one/dataset_generation/generate_dataset_meta.py
+++ b/stage_one/dataset_generation/generate_dataset_meta.py
@@ -11,6 +11,12 @@ from concurrent.futures import ThreadPoolExecutor
 DISCOVERY_DISTANCE_THRESHOLD = 10
 INCLUSION_DISTANCE_THRESHOLD = 35
 
+# Curb ramps with no install date in the government data cannot be verified to
+# predate the panorama. True preserves the paper-era behavior of assuming they
+# do (they used to be given a silent 2000-01-01 sentinel); False conservatively
+# discards any panorama near an undated curb ramp.
+TREAT_UNDATED_AS_PREDATING = True
+
 curb_ramp_locations = pd.read_csv("all_locations.csv")
 transformer = Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)
 
@@ -36,11 +42,18 @@ def process_pano(pano):
         distance = geopy.distance.geodesic((row["latitude"], row["longitude"]), (pano.lat, pano.lon)).m
         if distance <= INCLUSION_DISTANCE_THRESHOLD:
             curb_ramps_to_include.append(row)
-            curb_year, curb_month = int(row["date"].split("-")[0]), int(row["date"].split("-")[1])
-            pano_year, pano_month = int(pano.date.split("-")[0]), int(pano.date.split("-")[1])
-            if curb_year > pano_year:
+            curb_date = row["date"]
+            if not isinstance(curb_date, str) or curb_date == "":
+                if TREAT_UNDATED_AS_PREDATING:
+                    continue
                 return
-            if curb_month >= pano_month:
+            curb_year, curb_month = int(curb_date.split("-")[0]), int(curb_date.split("-")[1])
+            pano_year, pano_month = int(pano.date.split("-")[0]), int(pano.date.split("-")[1])
+            # Discard the pano unless the curb ramp was installed strictly
+            # before the month the panorama was captured. The old check
+            # compared months without the year (curb 2019-05 vs pano 2020-03
+            # was wrongly rejected because 5 >= 3).
+            if (curb_year, curb_month) >= (pano_year, pano_month):
                 return
     if curb_ramps_to_include:
         curb_coords = [[row["latitude"], row["longitude"]] for row in curb_ramps_to_include]

--- a/stage_one/dataset_generation/search_panos.py
+++ b/stage_one/dataset_generation/search_panos.py
@@ -36,31 +36,49 @@ def search_request(lat: float, lon: float) -> Response:
     return requests.get(url)
 
 
-@lru_cache(maxsize=None)
-def get_date_of_panorama(pano_id: str) -> str:
-    headers = {
-        "accept": "*/*",
-        "accept-language": "en-US,en;q=0.9",
-        "content-type": "application/json+protobuf",
-    }
+class GoogleEndpointSchemaError(RuntimeError):
+    """The undocumented Google endpoint returned data in an unexpected shape.
 
-    data = [
-        ["apiv3", None, None, None, "US", None, None, None, None, None, [[0]]],
-        ["en", "US"],
-        [[[2, pano_id]]],
-        [[1, 2, 3, 4, 8, 6]]
-    ]
+    These endpoints are internal and unversioned (see docs/data_provenance.md);
+    when Google changes the response schema, the positional parses below must
+    fail loudly instead of silently feeding garbage into the dataset labels.
+    """
 
-    url = "https://maps.googleapis.com/$rpc/google.internal.maps.mapsjs.v1.MapsJsInternalService/GetMetadata"
-    response = requests.post(url, headers=headers, json=data)
 
-    year = response.json()[1][0][6][7][0]
-    month = response.json()[1][0][6][7][1]
+def _parse_pano_date(metadata_json) -> str:
+    """Extract "YYYY-M" capture date from a GetMetadata response.
 
+    Positional path [1][0][6][7] = [year, month, ...], observed 2025-07.
+    """
+    try:
+        year, month = metadata_json[1][0][6][7][0], metadata_json[1][0][6][7][1]
+    except (IndexError, KeyError, TypeError) as e:
+        raise GoogleEndpointSchemaError(
+            f"GetMetadata date path [1][0][6][7] not found — schema drift? ({e})")
+    if not (isinstance(year, int) and isinstance(month, int) and 1990 <= year <= 2100 and 1 <= month <= 12):
+        raise GoogleEndpointSchemaError(
+            f"GetMetadata date path returned implausible values year={year!r} month={month!r}")
     return f"{year}-{month}"
 
-@lru_cache(maxsize=None)
-def get_pano_heading(pano_id: str) -> str:
+
+def _parse_pano_heading(metadata_json) -> float:
+    """Extract the panorama heading in degrees from a GetMetadata response.
+
+    Positional path [1][0][5][0][1][2][0], observed 2025-07. The heading feeds
+    directly into keypoint placement, so an implausible value must raise.
+    """
+    try:
+        heading = float(metadata_json[1][0][5][0][1][2][0])
+    except (IndexError, KeyError, TypeError, ValueError) as e:
+        raise GoogleEndpointSchemaError(
+            f"GetMetadata heading path [1][0][5][0][1][2][0] not found — schema drift? ({e})")
+    if not (-360.0 <= heading <= 360.0):
+        raise GoogleEndpointSchemaError(
+            f"GetMetadata heading path returned implausible value {heading!r}")
+    return heading
+
+
+def _get_metadata(pano_id: str):
     headers = {
         "accept": "*/*",
         "accept-language": "en-US,en;q=0.9",
@@ -76,8 +94,20 @@ def get_pano_heading(pano_id: str) -> str:
 
     url = "https://maps.googleapis.com/$rpc/google.internal.maps.mapsjs.v1.MapsJsInternalService/GetMetadata"
     response = requests.post(url, headers=headers, json=data)
+    if response.status_code != 200:
+        raise GoogleEndpointSchemaError(
+            f"GetMetadata returned HTTP {response.status_code} for pano {pano_id}")
+    return response.json()
 
-    return float(response.json()[1][0][5][0][1][2][0])
+
+@lru_cache(maxsize=None)
+def get_date_of_panorama(pano_id: str) -> str:
+    return _parse_pano_date(_get_metadata(pano_id))
+
+
+@lru_cache(maxsize=None)
+def get_pano_heading(pano_id: str) -> float:
+    return _parse_pano_heading(_get_metadata(pano_id))
 
 def extract_panoramas(text: str) -> List[Panorama]:
     blob = re.findall(r"callbackfunc\( (.*) \)$", text)[0]

--- a/stage_one/dataset_generation/split_dataset.py
+++ b/stage_one/dataset_generation/split_dataset.py
@@ -11,6 +11,13 @@ from collections import deque
 CONSIDER_MANUAL = False
 MANUAL_LABELS_DIR = "../../manual_labels"
 
+# Fixed seed so the group shuffle (and therefore the split) is reproducible.
+# Note: the paper's split was generated before this seed existed and cannot be
+# recreated by re-running this script — the HuggingFace dataset
+# (projectsidewalk/rampnet-dataset) is the split of record for the paper.
+SPLIT_SEED = 42
+random.seed(SPLIT_SEED)
+
 DATASET_DIR = "../../dataset"
 BASE_OUTPUT_DIR = "../../dataset_split"
 


### PR DESCRIPTION
## Summary

The docs-and-small-fixes tranche (deliberately **not** a resilient-scraper framework — the endpoints are unversioned internals; the right move is documentation plus loud failure).

### docs/data_provenance.md (#8)
- **Contamination registry**: NYC/Portland/Bend (gov data → Stage 2) and the 12 Project Sidewalk deployment cities (→ crop model, transitively → every Stage 1 label). Evaluations in these cities are optimistically biased; the doc says to use held-out cities or fresh post-deployment validation instead.
- Documents all three undocumented Google endpoints (SingleImageSearch, GetMetadata, tile server), their positional parse paths, and failure modes.
- Records that the **HF dataset is the split of record** — linked from the README.

### Loud failure on schema drift (#8)
`search_panos.py`'"'"'s `response.json()[1][0][6][7][0]`-style parses are now named validating helpers (`_parse_pano_date`, `_parse_pano_heading`) that raise `GoogleEndpointSchemaError` on drift or implausible values. The heading feeds directly into keypoint placement, so silent garbage here silently corrupts labels.

### Seeded splits (#10)
`split_dataset.py`, `splititup.sh` (`shuf --random-source`), `combine_location_data.py`, `download_data.py` (`random_state=42`). Regenerated splits are now reproducible; comments note the paper split predates the seeds.

### Temporal-filter fixes (#11)
- Missing install dates no longer become a silent `2000-01-01` sentinel that always passed the "installed before pano" check — handling is explicit via `TREAT_UNDATED_AS_PREDATING` (default True preserves paper-era behavior, documented).
- The comparison is now `(year, month)` tuple-based; the old month-only check wrongly rejected panos (curb 2019-05 vs pano 2020-03 failed because 5 ≥ 3).

Only affects dataset **regeneration** — the released dataset/model are untouched. Independent of the #13 stack; merges directly to main.

Closes #8, closes #10, closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)