### PR TITLE
Add rampnet.validation: portable precision/recall from human verdicts (#22)

### DIFF
--- a/rampnet/validation.py
+++ b/rampnet/validation.py
@@ -1,0 +1,195 @@
+"""Precision/recall from human validation verdicts.
+
+The counterpart to :mod:`rampnet.metrics`: where ``metrics`` derives its
+``(confidence, is_true_positive)`` flags by spatially *matching* predicted peaks
+against ground-truth keypoints, this module derives the same flags from a human
+reviewer's per-detection verdicts and their marks for ramps the model *missed*.
+Both feed the identical precision/recall definitions (precision = TP / (TP + FP),
+recall = TP / total_gt), so a "corrected" model-eval number and a human-validation
+number mean the same thing and can be reported side by side.
+
+It is the scoring half of the deployment spot-check loop (a gallery renders
+sampled detections, a reviewer judges each crop and marks missed ramps, exporting
+a ``verdicts.json``); the deployment pipeline owns only the thin I/O adapter that
+loads its ``results.jsonl`` + verdicts and calls :func:`collect` / :func:`format_report`.
+
+Verdict schema (one entry per reviewed pano, keyed by pano id):
+  - ``dets``:   per-detection verdict, aligned with the pano's detections —
+                ``True`` (correct), ``False`` (incorrect), ``"unsure"``
+                (abstains from both metrics), or ``None`` (not yet judged; the
+                pano is then partially judged and unusable for either metric).
+  - ``missed``: reviewer marks for ramps the model missed. Each is a point dict;
+                ``{"unsure": True}`` abstains (kept out of the recall denominator).
+  - ``no_missed``: present on entries exported by a gallery with the missed-ramp
+                confirmation feature — the pano's false-negative check is
+                *confirmed* only if ``no_missed`` is set or a missed mark exists.
+                Entries without the key are legacy and trusted (see :func:`collect`).
+  - ``group``:  sampling group; ``"top"`` are the always-included densest panos,
+                excludable from unbiased estimates via ``exclude_top``.
+
+Pure-Python (no torch); ``pytest tests/test_validation.py``.
+"""
+import math
+from collections import namedtuple
+
+# Confidence thresholds for the human-readable sweep. The lowest matches the
+# detector's own peak threshold (peak_local_max threshold_abs), so the first row
+# is "every emitted detection".
+THRESHOLDS = [0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95]
+
+# The verdict pools produced by collect(). judged/recall_judged are lists of
+# (confidence, is_correct) — the same shape rampnet.metrics.match_predictions
+# returns — so the precision/recall math below is shared between the two sources.
+Pools = namedtuple('Pools', [
+    'judged',         # PRECISION pool: decided (conf, is_correct) on fully-judged panos
+    'recall_judged',  # RECALL pool: the subset from panos whose missed-ramp check is confirmed
+    'missed_total',   # confident missed-ramp marks on the recall-pool panos (the FN count)
+    'n_seen',         # panos whose verdicts line up with results.jsonl
+    'n_judged',       # of those, fully judged (no None verdicts)
+    'n_unconfirmed',  # fully-judged panos held out of recall (missed-ramp check unconfirmed)
+    'n_unsure',       # detections marked 'unsure' (abstained)
+    'missed_unsure',  # missed marks flagged unsure (abstained)
+    'warnings',       # human-readable notes (e.g. verdict/results mismatch) — presentation-free
+])
+
+
+def wilson_interval(successes, n, z=1.96):
+    """95% Wilson score interval for a proportion."""
+    if n == 0:
+        return (0.0, 1.0)
+    p = successes / n
+    denom = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    margin = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / denom
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def collect(panos, confs_by_pid, exclude_top=False, assume_scanned=False):
+    """Turn reviewer verdicts into precision/recall pools.
+
+    panos:        {pano_id: verdict entry} (see the schema in the module docstring).
+    confs_by_pid: {pano_id: [detection confidence, ...]} from the run's results.
+
+    Precision counts every *decided* detection on panos whose detections are all
+    judged. Recall additionally requires the pano's missed-ramp check to be
+    confirmed, so its numerator (correct detections) and denominator (those plus
+    confident missed marks) cover the same panos.
+
+    ``assume_scanned=True`` treats every fully-judged pano as false-negative
+    checked, regardless of the per-pano flag — reviewer attestation that they
+    scanned each pano for misses without clicking "no missed ramps" on the clean
+    ones. It is an explicit override; the gate otherwise exists so panos nobody
+    scanned can't inflate recall.
+
+    'unsure' abstention: an 'unsure' crop verdict and a missed mark with
+    ``{'unsure': True}`` are the reviewer saying "can't tell from this imagery" —
+    dropped from both metrics (forcing a guess would bias either) and reported as
+    separate counts. A pano with unsure marks still counts as fully judged.
+
+    The missed-ramp check is per entry: new-schema entries carry ``no_missed`` and
+    must have it set or have a missed mark; legacy entries (no key) are trusted.
+    Mixed old/new files therefore score correctly.
+
+    This gate mirrors reviewed()/fnChecked() in the spot-check viewer JS — keep the
+    two in sync. Returns a :class:`Pools`.
+    """
+    judged, recall_judged, missed_total, missed_unsure = [], [], 0, 0
+    n_seen = n_judged = n_unconfirmed = n_unsure = 0
+    warnings = []
+    for pid, entry in panos.items():
+        if exclude_top and entry.get('group') == 'top':
+            continue
+        confs = confs_by_pid.get(pid)
+        if confs is None or len(confs) != len(entry['dets']):
+            warnings.append(f"skipping {pid}: verdicts don't match results detections")
+            continue
+        n_seen += 1
+        if any(d is None for d in entry['dets']):
+            continue  # partially judged: unusable for either metric
+        n_judged += 1
+        n_unsure += sum(1 for d in entry['dets'] if d == 'unsure')
+        # Decided verdicts only (True/False); 'unsure' abstains from both metrics.
+        pano_judged = [(c, d) for c, d in zip(confs, entry['dets']) if d != 'unsure']
+        judged += pano_judged
+        fn_checked = True if assume_scanned else (
+            (entry['no_missed'] or entry['missed']) if 'no_missed' in entry else True)
+        if fn_checked:
+            recall_judged += pano_judged
+            missed_total += sum(1 for m in entry['missed'] if not m.get('unsure'))
+            missed_unsure += sum(1 for m in entry['missed'] if m.get('unsure'))
+        else:
+            n_unconfirmed += 1
+    return Pools(judged, recall_judged, missed_total, n_seen, n_judged,
+                 n_unconfirmed, n_unsure, missed_unsure, warnings)
+
+
+# --- Shared precision/recall primitives -----------------------------------
+# One definition each, used by both the headline numbers and the threshold
+# sweep so they can't diverge; identical in form to the precision (TP/(TP+FP))
+# and recall (TP/total_gt) that rampnet.metrics computes for the matched path.
+
+def _precision_at(judged, threshold=0.0):
+    """(#correct, #kept) among detections with confidence >= threshold."""
+    kept = [ok for c, ok in judged if c >= threshold]
+    return sum(kept), len(kept)
+
+
+def _recall_tp_at(recall_judged, threshold=0.0):
+    """#correct detections in the recall pool with confidence >= threshold."""
+    return sum(1 for c, ok in recall_judged if c >= threshold and ok)
+
+
+def total_ramps(pools):
+    """Recall denominator: correct detections in the recall pool + confident missed marks."""
+    return _recall_tp_at(pools.recall_judged) + pools.missed_total
+
+
+def format_report(title, pools, thresholds=THRESHOLDS):
+    """Render one titled precision/recall block (headline + threshold sweep) as text.
+
+    Returns the block as a string (no printing), so callers own presentation. Any
+    per-pool notes in ``pools.warnings`` are the caller's to surface.
+    """
+    lines = [f"--- {title} ---",
+             f"Panos fully judged:   {pools.n_judged} (of {pools.n_seen} seen)"]
+    if pools.n_unconfirmed:
+        lines.append(
+            f"! {pools.n_unconfirmed} of those excluded from RECALL only: their "
+            f"missed-ramp check was never confirmed\n  (mark the missed ramps in "
+            f"the gallery, then re-export).")
+
+    tp, n_judged_dets = _precision_at(pools.judged)
+    fp = n_judged_dets - tp
+    lines.append(f"Detections judged:    {n_judged_dets}  (correct {tp}, incorrect {fp})")
+    if pools.n_unsure:
+        lines.append(f"Detections unsure:    {pools.n_unsure}  (abstained — not in precision or recall)")
+    lines.append(f"Missed ramps marked:  {pools.missed_total}"
+                 + (f"  (+{pools.missed_unsure} unsure, abstained)" if pools.missed_unsure else ""))
+
+    if not pools.judged:
+        lines.append("Nothing judged yet.")
+        return "\n".join(lines)
+
+    p = tp / n_judged_dets
+    lo, hi = wilson_interval(tp, n_judged_dets)
+    lines.append(f"Precision: {p:.3f}  (95% CI {lo:.3f}-{hi:.3f})")
+
+    denom = total_ramps(pools)
+    rtp = _recall_tp_at(pools.recall_judged)
+    if denom:
+        r = rtp / denom
+        rlo, rhi = wilson_interval(rtp, denom)
+        lines.append(f"Recall:    {r:.3f}  (95% CI {rlo:.3f}-{rhi:.3f})  "
+                     f"[vs ramps visible in the {pools.n_judged - pools.n_unconfirmed} recall-pool panos]")
+
+    lines.append("")
+    lines.append(f"{'threshold':>9}  {'kept':>5}  {'precision':>9}  {'recall':>7}")
+    for t in thresholds:
+        ktp, kept = _precision_at(pools.judged, t)
+        if not kept:
+            break
+        prec = ktp / kept
+        rtp_t = _recall_tp_at(pools.recall_judged, t)
+        rec = rtp_t / denom if denom else float('nan')
+        lines.append(f"{t:>9.2f}  {kept:>5}  {prec:>9.3f}  {rec:>7.3f}")
+    return "\n".join(lines)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,144 @@
+"""Tests for human-verdict precision/recall scoring (rampnet.validation).
+
+Ported from the deployment pipeline's score_validation suite, which owned this
+logic before it moved here. Pure-Python: no torch.
+    pytest tests/test_validation.py -v
+"""
+from rampnet.validation import (
+    collect, format_report, total_ramps, wilson_interval, THRESHOLDS,
+)
+
+
+def test_wilson_interval_edges():
+    assert wilson_interval(0, 0) == (0.0, 1.0)
+    lo, hi = wilson_interval(10, 10)
+    assert 0.0 < lo < 1.0 and hi == 1.0
+    lo, hi = wilson_interval(0, 10)
+    assert lo == 0.0 and 0.0 < hi < 1.0
+
+
+def test_wilson_interval_contains_p_and_narrows():
+    lo_s, hi_s = wilson_interval(5, 10)
+    lo_l, hi_l = wilson_interval(500, 1000)
+    assert lo_s < 0.5 < hi_s and lo_l < 0.5 < hi_l
+    assert (hi_l - lo_l) < (hi_s - lo_s)  # more data, tighter interval
+
+
+CONFS = {
+    "P_TWO_DETS": [0.91, 0.63],
+    "P_EMPTY": [],
+    "P_ONE_DET": [0.7],
+}
+
+
+def _panos(no_missed_flags=True):
+    """Three panos: fully judged w/ a missed mark, empty+affirmed, judged-unaffirmed."""
+    panos = {
+        "P_TWO_DETS": {"group": "random", "dets": [True, True],
+                       "missed": [{"x": 0.2, "y": 0.3}], "no_missed": False},
+        "P_EMPTY": {"group": "empty", "dets": [], "missed": [], "no_missed": True},
+        "P_ONE_DET": {"group": "random", "dets": [False], "missed": [], "no_missed": False},
+    }
+    if not no_missed_flags:  # old-schema export: flag absent everywhere
+        for entry in panos.values():
+            del entry["no_missed"]
+    return panos
+
+
+def test_collect_unconfirmed_pano_counts_for_precision_not_recall():
+    pools = collect(_panos(), CONFS)
+    assert (pools.n_seen, pools.n_judged, pools.n_unconfirmed) == (3, 3, 1)
+    assert (pools.n_unsure, pools.missed_unsure) == (0, 0)
+    # P_ONE_DET's crop verdict is valid for precision even though its missed-ramp
+    # check was never confirmed...
+    assert sorted(pools.judged) == [(0.63, True), (0.7, False), (0.91, True)]
+    # ...but it is excluded from the recall pool.
+    assert sorted(pools.recall_judged) == [(0.63, True), (0.91, True)]
+    assert pools.missed_total == 1
+    assert total_ramps(pools) == 3  # 2 correct in recall pool + 1 missed
+
+
+def test_collect_assume_scanned_includes_unconfirmed_panos():
+    # Reviewer attests they scanned every pano: P_ONE_DET (no missed mark, not
+    # affirmed) must now enter the recall pool instead of being held out.
+    pools = collect(_panos(), CONFS, assume_scanned=True)
+    assert (pools.n_seen, pools.n_judged, pools.n_unconfirmed) == (3, 3, 0)
+    assert sorted(pools.recall_judged) == [(0.63, True), (0.7, False), (0.91, True)]
+    assert pools.missed_total == 1
+
+
+def test_collect_old_schema_keeps_legacy_behavior():
+    pools = collect(_panos(no_missed_flags=False), CONFS)
+    # Legacy entries (no no_missed key) are trusted for recall, as before.
+    assert (pools.n_seen, pools.n_judged, pools.n_unconfirmed) == (3, 3, 0)
+    assert len(pools.judged) == 3 and len(pools.recall_judged) == 3 and pools.missed_total == 1
+
+
+def test_collect_mixed_schema_gates_per_entry():
+    # A legacy entry hand-merged into a new-schema file must stay trusted; the
+    # new-schema unconfirmed entry must still be excluded from recall.
+    panos = _panos()
+    del panos["P_TWO_DETS"]["no_missed"]  # legacy entry, missed mark
+    pools = collect(panos, CONFS)
+    assert pools.n_unconfirmed == 1  # P_ONE_DET only
+    assert sorted(pools.recall_judged) == [(0.63, True), (0.91, True)]
+    assert pools.missed_total == 1
+
+
+def test_collect_unsure_abstains_from_both_metrics():
+    # A pano with one confident-correct det, one 'unsure' det, and one 'unsure'
+    # missed mark. The unsure crop leaves precision/recall; the unsure missed mark
+    # leaves the recall denominator; both are counted separately. The unsure missed
+    # mark still confirms the pano was scanned (it enters the recall pool).
+    panos = {"P_TWO_DETS": {"group": "random", "dets": [True, "unsure"],
+                            "missed": [{"x": 0.1, "y": 0.1, "unsure": True}],
+                            "no_missed": False}}
+    pools = collect(panos, {"P_TWO_DETS": [0.91, 0.63]})
+    assert (pools.n_seen, pools.n_judged, pools.n_unconfirmed) == (1, 1, 0)
+    assert pools.judged == [(0.91, True)]          # 'unsure' det dropped from precision
+    assert pools.recall_judged == [(0.91, True)]   # ...and from recall
+    assert (pools.n_unsure, pools.missed_total, pools.missed_unsure) == (1, 0, 1)
+
+
+def test_collect_skips_partially_judged():
+    panos = {"P_TWO_DETS": {"group": "random", "dets": [True, None],
+                            "missed": [], "no_missed": True}}
+    pools = collect(panos, CONFS)
+    assert pools.n_seen == 1 and pools.n_judged == 0
+    assert pools.judged == [] and pools.recall_judged == [] and pools.missed_total == 0
+
+
+def test_collect_mismatched_counts_warns_not_prints():
+    panos = {"P_TWO_DETS": {"group": "random", "dets": [True],  # results has 2
+                            "missed": [], "no_missed": True}}
+    pools = collect(panos, CONFS)
+    assert pools.n_seen == 0 and pools.n_judged == 0 and pools.judged == []
+    assert any("don't match" in w for w in pools.warnings)  # surfaced as data, not stdout
+
+
+def test_collect_exclude_top():
+    panos = _panos()
+    panos["P_TWO_DETS"]["group"] = "top"
+    pools = collect(panos, CONFS, exclude_top=True)
+    assert pools.n_seen == 2 and pools.n_judged == 2
+    # P_EMPTY (affirmed, no dets) and P_ONE_DET (unconfirmed) remain.
+    assert pools.judged == [(0.7, False)] and pools.recall_judged == [] and pools.missed_total == 0
+    assert pools.n_unconfirmed == 1
+
+
+def test_format_report_headline_and_sweep():
+    pools = collect(_panos(), CONFS)
+    text = format_report("All reviewed panos", pools)
+    assert "Precision: 0.667" in text          # 2 correct of 3 judged
+    assert "Recall:    0.667" in text           # 2 correct of 3 ramps
+    # Threshold sweep present, and raising the bar drops the low-confidence FP:
+    # at 0.75 only the two 0.91/0.63->0.91 correct dets survive on the precision side.
+    assert "threshold" in text and "precision" in text
+    prec_at_75 = [ln for ln in text.splitlines() if ln.strip().startswith("0.75")]
+    assert prec_at_75 and "1.000" in prec_at_75[0]  # 0.7 FP excluded -> precision 1.0
+
+
+def test_format_report_nothing_judged():
+    pools = collect({"P": {"group": "random", "dets": [None], "missed": [], "no_missed": True}},
+                    {"P": [0.9]})
+    assert "Nothing judged yet." in format_report("Empty", pools)


### PR DESCRIPTION
Implements the portable evaluation module from #22.

## What

Adds `rampnet/validation.py` — precision/recall scoring from **human validation verdicts**, the counterpart to `rampnet/metrics.py`'s spatial matching:

- `metrics.match_predictions` derives `(confidence, is_true_positive)` flags by *matching* predicted peaks against ground-truth keypoints.
- `validation.collect` derives the **same** flags from a reviewer's per-detection verdicts and their marks for ramps the model *missed*.

Both then feed the same precision/recall definitions (precision = TP/(TP+FP), recall = TP/total_gt), so a corrected model-eval number and a human-validation number mean the same thing and can be reported side by side.

## Why here

This logic currently lives in the deployment repo (`sidewalk-auto-labeler/scripts/score_validation.py`). Moving it up means:

- The **HF validation benchmark** (#21) — human-verdict ground truth on real GSV + Mapillary panos — can be scored by RampNet directly, without RampNet importing its own downstream consumer.
- The #20 model/backbone harness and the deployment pipeline share **one** definition of precision/recall, so numbers stay comparable to `v1.0-iccv2025`.

Dependency direction: all model-evaluation and ground-truth tooling lives in RampNet. The deployment pipeline (sidewalk-auto-labeler) is a separate production consumer that runs the published model to label cities and does **no validation** — it does not import this module. Its `score_validation.py` is removed, not rewired (see ProjectSidewalk/sidewalk-auto-labeler#15). The only thing the labeler consumes from RampNet is the model, from HF.

## Design notes

- **Torch-free**, no new dependencies — fits the package's stated purpose ("shared model, checkpoint-loading, and metrics code") and its `dependencies = []`.
- New module, not folded into `metrics.py`, to keep that module's spatial-matching focus cohesive.
- The fixed-threshold report table is preserved but sourced from shared precision/recall primitives, so headline and sweep can't diverge.
- `collect()` returns warnings **as data** (`Pools.warnings`) rather than printing, so the module is presentation-free; the CLI owns display.
- Verdict-schema semantics carried over verbatim: `unsure` abstains from both metrics, the missed-ramp gate confirms a pano was scanned before it counts toward recall, legacy (pre-confirmation) entries stay trusted, `top` panos are excludable for unbiased estimates. The gate still mirrors `reviewed()`/`fnChecked()` in the spot-check viewer JS — noted in the docstring.

## Tests

`tests/test_validation.py` ported from the deployment suite (12 tests: interval math, all verdict-schema branches, report rendering). Pure-Python. Existing `tests/test_metrics.py` unaffected.

## Follow-up

- ProjectSidewalk/sidewalk-auto-labeler#15 — labeler becomes pure production; its scoring + GT-labeler tooling move here (not imported back).
- #21 — HF benchmark uses this as its scorer.
- #25 — resolution experiment uses this as its scorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
