### PR TITLE
Fix eval heatmap cache collision between datasets

### DIFF
--- a/stage_two/evaluate.py
+++ b/stage_two/evaluate.py
@@ -44,7 +44,7 @@ def parse_args():
     parser.add_argument('--tta', action=argparse.BooleanOptionalAction, default=True,
                         help="Horizontal-flip test-time augmentation (default: on, as in the paper)")
     parser.add_argument('--cache-dir', default='evaluate_cache',
-                        help="Heatmap cache root (keyed by checkpoint hash + TTA setting)")
+                        help="Heatmap cache root (keyed by checkpoint hash + dataset + TTA setting)")
     parser.add_argument('--fresh', action='store_true',
                         help="Delete this checkpoint's cached heatmaps before evaluating")
     parser.add_argument('--results-dir', default='evaluation_results',

--- a/stage_two/evaluate.py
+++ b/stage_two/evaluate.py
@@ -273,10 +273,13 @@ def main():
 
     model = load_trained_model(args.checkpoint, MODEL_HEATMAP_SIZE)
 
-    # Cached heatmaps are only valid for the exact weights and TTA setting that
-    # produced them, so the cache directory is keyed by both.
+    # Cached heatmaps are only valid for the exact weights, dataset, and TTA setting
+    # that produced them, so the cache directory is keyed by all three. The dataset id
+    # matters because 'manual' and 'test' draw images from the same test split and so
+    # share pano ids; without it in the key they collide and silently serve each other's
+    # cached heatmaps.
     ckpt_fingerprint = checkpoint_fingerprint(args.checkpoint)
-    cache_key = f"{ckpt_fingerprint}_{'tta' if args.tta else 'notta'}"
+    cache_key = f"{ckpt_fingerprint}_{dataset_id_str}_{'tta' if args.tta else 'notta'}"
     heatmap_cache_dir = os.path.join(args.cache_dir, "heatmaps", cache_key)
     if args.fresh and os.path.isdir(heatmap_cache_dir):
         print(f"--fresh: clearing cached heatmaps in {heatmap_cache_dir}")


### PR DESCRIPTION
## Problem

`stage_two/evaluate.py` keys its heatmap cache directory by **checkpoint fingerprint + TTA setting only**:

```python
cache_key = f"{ckpt_fingerprint}_{'tta' if args.tta else 'notta'}"
```

The `manual` gold set and the `test` split both source their images from the **same** test split (`get_test_files` reads manual images from `<data-root>/test`), so they share pano ids. Evaluating one checkpoint on both datasets with the same TTA setting therefore reuses the *other* dataset's cached `.npy` heatmaps for any overlapping pano id — silently corrupting the metrics.

## Fix

Add the dataset id to the cache key so all three axes that determine a heatmap (weights, dataset, TTA) are distinguished:

```python
cache_key = f"{ckpt_fingerprint}_{dataset_id_str}_{'tta' if args.tta else 'notta'}"
```

`dataset_id_str` is already computed a few lines above. One-line behavioral change plus a clarifying comment; no change to the metrics/matching logic.

## Impact & notes

- Existing caches under the old key format are simply ignored (new key → cache miss → recompute), so first runs after this land recompute heatmaps once. No manual cache cleanup required.
- Consistent with the guidance in `CLAUDE.md` to treat stale eval caches as a correctness hazard.

## Verification

- `python -m py_compile stage_two/evaluate.py` passes.
- `--dataset manual` and `--dataset test` now write to distinct cache subdirs; re-running `--dataset manual` still reproduces the committed gold-set metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)