### PR TITLE
Fix HF model loading under transformers >= 5.13 (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 dataset
 *.out
 *.err
+.venv/
+*.egg-info/

--- a/requirements-win-cuda.txt
+++ b/requirements-win-cuda.txt
@@ -1,0 +1,47 @@
+# Windows + NVIDIA CUDA dependencies for running RampNet's Python-side code
+# (rampnet package, HF export, stage-2 evaluate/demo) and the test suite on a
+# Windows dev box. This is NOT the paper's training environment — that is the
+# linux-64 conda env in environment.yml / environment.lock.yml (Slurm, 16x L40s).
+#
+# Why a separate file: on Linux pip installs CUDA torch wheels by default, but on
+# Windows the default PyPI torch is CPU-only. The +cu126 pins below pull the
+# CUDA 12.6 build from PyTorch's wheel index. A CUDA 13.x-capable driver runs the
+# 12.6 runtime fine (drivers are forward-compatible with older CUDA runtimes).
+#
+# Setup (from the repo root, Python 3.12):
+#   python -m venv .venv
+#   .venv\Scripts\Activate.ps1        # PowerShell   (or .venv\Scripts\activate.bat in cmd)
+#   python -m pip install -U pip
+#   pip install -r requirements-win-cuda.txt
+#   pip install -e .                  # the local `rampnet` package
+#   pytest tests/ -v
+#
+# CPU-only fallback (no GPU): drop the two +cu126 pins and the --extra-index-url
+# line, then `pip install torch==2.6.0 torchvision==0.21.0` for the CPU wheels.
+
+--extra-index-url https://download.pytorch.org/whl/cu126
+
+# torch 2.6 / torchvision 0.21 match environment.yml's pinned versions so
+# checkpoints and timm behavior line up with the paper environment.
+torch==2.6.0+cu126
+torchvision==0.21.0+cu126
+
+# transformers >= 5.13 is the range issue #19's HF-loading fix targets; the
+# default resolution (5.14.x) is exactly the version that reproduced the crash.
+# Pin transformers==5.12.1 in a throwaway venv to exercise the other supported arm.
+transformers>=5.13
+huggingface_hub
+timm
+datasets
+
+numpy
+pillow
+scikit-image
+scikit-learn
+scipy
+pandas
+matplotlib
+tqdm
+requests
+pydantic
+pytest

--- a/scripts/export_hf_model.py
+++ b/scripts/export_hf_model.py
@@ -73,6 +73,46 @@ def render_eval_section(metrics_json_path):
     return "\n".join(lines)
 
 
+def assemble_package(output_dir, reference_model, recommended_threshold=0.55):
+    """Write a loadable trust_remote_code package (config + modeling files +
+    weights) to ``output_dir``, copying ``reference_model``'s weights into the
+    HF wrapper layout.
+
+    Shared by ``main()`` and ``tests/test_hf_load.py`` so the exporter and the
+    load smoke test exercise the identical package layout — the one that
+    ``AutoModel.from_pretrained(..., trust_remote_code=True)`` must accept on the
+    transformers versions we support (see issue #19).
+    """
+    sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
+    # Imported as a package so the relative imports match how the Hub's
+    # dynamic-module loader will resolve them.
+    from hf_package.configuration_rampnet import RampNetConfig  # noqa: E402
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # The modeling code shipped to the Hub imports the architecture from
+    # rampnet_model.py, copied verbatim from the canonical rampnet/model.py so
+    # the Hub package can never fork the architecture.
+    shutil.copy(os.path.join(REPO_ROOT, "rampnet", "model.py"),
+                os.path.join(output_dir, "rampnet_model.py"))
+    for fname in ("configuration_rampnet.py", "modeling_rampnet.py"):
+        shutil.copy(os.path.join(PACKAGE_DIR, fname), os.path.join(output_dir, fname))
+
+    config = RampNetConfig(recommended_threshold=recommended_threshold)
+    config.auto_map = {
+        "AutoConfig": "configuration_rampnet.RampNetConfig",
+        "AutoModel": "modeling_rampnet.RampNetModel",
+    }
+    config.save_pretrained(output_dir)
+
+    # Wrap the weights in the HF module layout (prefix 'model.') and save.
+    from transformers import AutoConfig, AutoModel
+    hf_config = AutoConfig.from_pretrained(output_dir, trust_remote_code=True)
+    hf_model = AutoModel.from_config(hf_config, trust_remote_code=True)
+    hf_model.model.load_state_dict(reference_model.state_dict())
+    hf_model.save_pretrained(output_dir)
+
+
 def verify_roundtrip(output_dir, reference_model):
     from transformers import AutoModel
     exported = AutoModel.from_pretrained(output_dir, trust_remote_code=True).eval()
@@ -94,34 +134,8 @@ def main():
     reference_model.eval()
     fingerprint = checkpoint_fingerprint(args.checkpoint)
 
-    sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
-    # Imported as a package so the relative imports match how the Hub's
-    # dynamic-module loader will resolve them.
-    from hf_package.configuration_rampnet import RampNetConfig  # noqa: E402
-
-    os.makedirs(args.output_dir, exist_ok=True)
-
-    # The modeling code shipped to the Hub imports the architecture from
-    # rampnet_model.py, copied verbatim from the canonical rampnet/model.py so
-    # the Hub package can never fork the architecture.
-    shutil.copy(os.path.join(REPO_ROOT, "rampnet", "model.py"),
-                os.path.join(args.output_dir, "rampnet_model.py"))
-    for fname in ("configuration_rampnet.py", "modeling_rampnet.py"):
-        shutil.copy(os.path.join(PACKAGE_DIR, fname), os.path.join(args.output_dir, fname))
-
-    config = RampNetConfig(recommended_threshold=args.recommended_threshold)
-    config.auto_map = {
-        "AutoConfig": "configuration_rampnet.RampNetConfig",
-        "AutoModel": "modeling_rampnet.RampNetModel",
-    }
-    config.save_pretrained(args.output_dir)
-
-    # Wrap the weights in the HF module layout (prefix 'model.') and save.
-    from transformers import AutoConfig, AutoModel
-    hf_config = AutoConfig.from_pretrained(args.output_dir, trust_remote_code=True)
-    hf_model = AutoModel.from_config(hf_config, trust_remote_code=True)
-    hf_model.model.load_state_dict(reference_model.state_dict())
-    hf_model.save_pretrained(args.output_dir)
+    assemble_package(args.output_dir, reference_model,
+                     recommended_threshold=args.recommended_threshold)
     print(f"Saved weights and config to {args.output_dir}")
 
     with open(os.path.join(PACKAGE_DIR, "README.model_card.template.md"), encoding='utf-8') as f:

--- a/scripts/hf_package/README.model_card.template.md
+++ b/scripts/hf_package/README.model_card.template.md
@@ -44,6 +44,19 @@ choosing an operating point.
 - Per-city deployments should calibrate on ~100 locally labeled panoramas; see the repo README's
   "Choosing a Detection Threshold" section.
 
+## Requirements
+
+Loads via `trust_remote_code`, so a compatible `transformers` is required:
+
+- `transformers >= 5.13` — supported (the custom-model auto-class contract this
+  version introduced is satisfied; see issue #19).
+- `transformers 5.12.x` — supported.
+
+Both are covered by a round-trip load smoke test (`tests/test_hf_load.py` in the
+training repo). Earlier revisions of this model fail to load on
+`transformers >= 5.13` with `AttributeError: ... 'KeypointModel' has no attribute
+'register_for_auto_class'` — pull the current revision.
+
 ## Usage
 
 ```python

--- a/scripts/hf_package/modeling_rampnet.py
+++ b/scripts/hf_package/modeling_rampnet.py
@@ -16,6 +16,10 @@ class RampNetModel(PreTrainedModel):
             heatmap_size=tuple(config.heatmap_size),
             pretrained_backbone=False,
         )
+        # Required under transformers >= 5.x: initializes loading-related state
+        # (e.g. all_tied_weights_keys) that from_pretrained expects on every
+        # PreTrainedModel. Harmless no-op extras under 4.x.
+        self.post_init()
 
     def forward(self, pixel_values):
         """Returns the predicted curb ramp keypoint heatmap (B, 1, H, W)."""

--- a/tests/test_hf_load.py
+++ b/tests/test_hf_load.py
@@ -1,0 +1,52 @@
+"""Load smoke test for the exported HuggingFace package (issue #19).
+
+The published package must load via the custom-code path
+
+    AutoModel.from_pretrained(<dir>, trust_remote_code=True)
+
+on the transformers versions we support. transformers 5.13 changed the
+custom-model auto-class contract (it now calls ``register_for_auto_class`` on
+the remote-code class and expects loading-related state such as
+``all_tied_weights_keys``); the pre-#19 published package registered a bare
+``KeypointModel`` and crashed. This test asserts the *current* exporter's
+package — ``RampNetModel(PreTrainedModel)`` wrapping ``KeypointModel``, with
+``post_init()`` — round-trips a load and forward pass on whatever transformers
+is installed.
+
+Run inside the project conda env, and specifically re-run it on each supported
+transformers version to actually close #19:
+
+    pip install 'transformers==5.12.1' && pytest tests/test_hf_load.py -v
+    pip install 'transformers>=5.13'   && pytest tests/test_hf_load.py -v
+"""
+import os
+import sys
+
+import torch
+from transformers import AutoModel
+
+from rampnet.model import KeypointModel, PANO_HEATMAP_SIZE
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
+from export_hf_model import assemble_package  # noqa: E402
+
+
+def test_hf_package_loads_with_trust_remote_code(tmp_path):
+    # Random-init weights are enough: the contract under test is the load path,
+    # not a specific checkpoint. Assemble exactly what the exporter ships.
+    reference = KeypointModel(heatmap_size=PANO_HEATMAP_SIZE, pretrained_backbone=False).eval()
+    pkg_dir = str(tmp_path / "pkg")
+    assemble_package(pkg_dir, reference)
+
+    # The exact call from issue #19's repro.
+    model = AutoModel.from_pretrained(pkg_dir, trust_remote_code=True).eval()
+
+    # Small input keeps this CPU-friendly; the Upsample head fixes output size.
+    x = torch.zeros(1, 3, 128, 256)
+    with torch.no_grad():
+        out = model(x)
+        ref_out = reference(x)
+    assert out.shape == (1, 1, PANO_HEATMAP_SIZE[0], PANO_HEATMAP_SIZE[1])
+    # Weights survived the assemble -> save -> from_pretrained round-trip.
+    assert torch.allclose(out, ref_out, atol=1e-6)


### PR DESCRIPTION
## Summary

Closes the code side of #19: the published model fails to load under `transformers >= 5.13` with `AttributeError: type object 'KeypointModel' has no attribute 'register_for_auto_class'`.

**Root cause.** The live HF package registers a bare `KeypointModel` as the AutoModel (`config.json`: `architectures: ["KeypointModel"]`, `auto_map: {"AutoModel": "modeling.KeypointModel"}`), so transformers ≥5.13 calls `register_for_auto_class` on a class that doesn't inherit it. The repo's current exporter already wraps the architecture in `RampNetModel(PreTrainedModel)` (which has that method); the only remaining gap was the 5.x `post_init()` requirement.

## Changes

- **`modeling_rampnet.py`** — call `post_init()` in `RampNetModel.__init__` (initializes loading-related state such as `all_tied_weights_keys` that `from_pretrained` expects on every `PreTrainedModel`; harmless no-op under 4.x).
- **`export_hf_model.py`** — extract `assemble_package()` so the exporter and the smoke test build the **identical** `trust_remote_code` layout (no drift).
- **`tests/test_hf_load.py`** — assemble a package from random weights and assert `AutoModel.from_pretrained(..., trust_remote_code=True)` loads + forwards + round-trips weights. This is the exact call from #19's repro.
- **model card** — document the supported `transformers` range and the old-revision failure mode.
- **`requirements-win-cuda.txt` + `.gitignore`** — Windows/NVIDIA venv so the Python side and tests run locally (the repo's linux-64 conda env doesn't run on Windows; pip's default Windows torch is CPU-only).

## Verification

`pytest tests/` → **26 passed**, with `test_hf_load.py` run on **both `transformers==5.12.1` and `5.14.1`** (RTX 3070, torch 2.6.0+cu126).

## Not in this PR (gated)

Fully closing #19 also requires **re-exporting and re-publishing** the model so the *live* HF artifact carries this layout — that needs the trained checkpoint + Hub write access + maintainer review, per the HF publishing plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)