### PR TITLE
GT labeling tool + model-resolution benchmark re-review (#26, #30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dataset
 *.err
 .venv/
 *.egg-info/
+benchmark/*/panos/
+benchmark/*/gallery/

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -28,11 +28,22 @@ are archived separately and published to HF (#21); they are intentionally not in
 
 | City | Source | Panos | Precision | Recall |
 |------|--------|-------|-----------|--------|
-| richmond | Mapillary 360 | 124 | 0.965 | 0.895 |
-| bend | GSV (Google Street View) | 110 | 0.958 | 0.831 |
+| richmond | Mapillary 360 | 124 | 0.960 | 0.765 |
+| bend | GSV (Google Street View) | 110 | 0.954 | 0.758 |
 
 Both splits are **self-contained**: the reviewer's complete-scan attestation is baked into
 `no_missed` (set on fully-judged panos with no missed marks), so the numbers reproduce with a
 plain `python scripts/score_validation.py benchmark/<city>` — no `--assume-scanned` needed.
 This matters because the recall gate otherwise excludes unconfirmed panos and biases recall
 low (it over-weights panos where a miss *was* found).
+
+**Both splits were reviewed at model resolution** with the pan/zoom labeler (`scripts/gt_gallery.py`),
+which shows the full pano at the model's input resolution (4096×2048) with pan/zoom, rather than a
+downscaled overview. Reviewing at model resolution surfaced genuinely-missed ramps that the earlier
+1600 px overview hid — small/distant curb ramps a reviewer literally could not resolve — correcting
+recall down from earlier, optimistic numbers (richmond 0.895 → 0.765, bend 0.831 → 0.758). Precision
+was essentially unchanged (the zoom mostly resolved `unsure` detections, not misclassifications). The
+correction is consistent across both imagery sources (GSV and Mapillary), and these are the honest
+per-pano-comprehensive figures. Each split includes one `duplicate` verdict — a redundant second
+detection on one physical ramp — scored as a false positive by default (`--lenient-duplicates` scores
+the other way; see `scripts/score_validation.py`).

--- a/benchmark/bend/verdicts.json
+++ b/benchmark/bend/verdicts.json
@@ -1,1509 +1,1766 @@
 {
- "run_key": "81636c89cf5f9c2c5c127ec722349dac909d1de9374d4060579b40306647779f",
- "run_name": "bend",
- "source": "runs\\bend\\results.jsonl",
- "exported_at": "2026-07-21T20:15:17.573Z",
- "panos": {
-  "0CvMs02xHlg3mCMHJdc6Xg": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    false,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.451313125147964,
-     "y": 0.5559595928770124
+  "run_key": "81636c89cf5f9c2c5c127ec722349dac909d1de9374d4060579b40306647779f",
+  "run_name": "bend",
+  "source": "benchmark\\bend\\records.jsonl",
+  "exported_at": "2026-07-22T21:30:46.474Z",
+  "panos": {
+    "0CvMs02xHlg3mCMHJdc6Xg": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.451313125147964,
+          "y": 0.5559595928770124
+        },
+        {
+          "x": 0.474343428178267,
+          "y": 0.5620201989376183
+        }
+      ],
+      "no_missed": false
     },
-    {
-     "x": 0.474343428178267,
-     "y": 0.5620201989376183
+    "0FMaNGiSOoTGqLgh8jHfYQ": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "E15SCY6RTiDuNUu_trZk4Q": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false
+      ],
+      "missed": [
+        {
+          "x": 0.3604040342388731,
+          "y": 0.5535353504527699
+        },
+        {
+          "x": 0.43373736757220643,
+          "y": 0.5777777746951941
+        }
+      ],
+      "no_missed": false
+    },
+    "Kv2haiYlkJCiaO61RVWwQA": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "LN819vhVLLeYwzRsBh2zAg": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false
+      ],
+      "missed": [
+        {
+          "x": 0.3222222160570549,
+          "y": 0.5737373675722064
+        }
+      ],
+      "no_missed": false
+    },
+    "5NVgLhChZXnD_D-z3SLZyQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "Noi7DhIT3xbCjA2Ip4QOyg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false
+      ],
+      "missed": [
+        {
+          "x": 0.6234343372691762,
+          "y": 0.5680808049982244
+        }
+      ],
+      "no_missed": false
+    },
+    "9DA1aapwjQcdUP2HEfrhfg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        "duplicate"
+      ],
+      "missed": [
+        {
+          "x": 0.07070706454190341,
+          "y": 0.5692929262103457
+        }
+      ],
+      "no_missed": false
+    },
+    "VMjtxZNqxl9E6oUXnsdI8Q": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "ZlXmdBYkhIpp-wNfPlSIFw": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "rxF0qBiSbOEnMR9wwxpjEw": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "xU7xT5kREy_Jnq_vYaXc8w": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "yJmMJeV6PD3UZlAmm4cmWg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "DaCRMtjRrkxBB468GFSAvQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.10549247994775528,
+          "y": 0.5300316993017893
+        },
+        {
+          "x": 0.14816698600516462,
+          "y": 0.5298290474910033
+        }
+      ],
+      "no_missed": false
+    },
+    "Jv7Zl2erbO_g10pRN-IS_Q": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "DJ8Zp111zu6KnMZz-0PHgQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "bTkyJpLDQ7HCw4yOdqdNCg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.08646464029947917,
+          "y": 0.5353535322709517,
+          "unsure": true
+        },
+        {
+          "x": 0.9438384269945549,
+          "y": 0.5427272912227746
+        },
+        {
+          "x": 0.13616160999644886,
+          "y": 0.5370707009055398
+        }
+      ],
+      "no_missed": false
+    },
+    "cqb7v_2KGHMeSy8VpvkcDQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        "unsure"
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "hu3-VWXlGi42PkY38XPJzQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "62TiKmlmxt_xn_68w1lgAw": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.6216161554509944,
+          "y": 0.56
+        }
+      ],
+      "no_missed": false
+    },
+    "NS7lT-itv0JiN6UHVvBxsg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.0997979736328125,
+          "y": 0.5406060606060606
+        },
+        {
+          "x": 0.04828282211766099,
+          "y": 0.5418181818181819
+        },
+        {
+          "x": 0.023434337269176136,
+          "y": 0.5490909090909091
+        }
+      ],
+      "no_missed": false
+    },
+    "PX5zU_2KkKO0Gr4FiSe9aw": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "ScnPNQ2cah0xzWlH28uoOw": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "VgWpqFkTwCIROvM0z-DkOw": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.0721717140891335,
+          "y": 0.5346464584812972,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "Wnu3AyufxG1XD9JvU5K-hg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "ZO7V6RR9LtZT8l9-SjIQUg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.9314239246438372,
+          "y": 0.5535832863420271
+        }
+      ],
+      "no_missed": false
+    },
+    "dUy9p1NputrGH7SFDmbCpg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "kJr7eKpZcJO_W6V5XlLtBw": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "pIcQQrFa8_XDG7-VSRhAfQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.2894949433297822,
+          "y": 0.5309090909090909
+        },
+        {
+          "x": 0.33252524636008524,
+          "y": 0.5490909090909091
+        }
+      ],
+      "no_missed": false
+    },
+    "tAnrbC_F_FXbg7kTiYywVA": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "woYJ5n0CfTGMuDWTBqcZAg": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5575757575757576,
+          "y": 0.5268686837861032,
+          "unsure": true
+        },
+        {
+          "x": 0.5327272727272727,
+          "y": 0.525656562573982,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "2S_Fj0bq7qkdKUBw9-g1XA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.11616160999644887,
+          "y": 0.6981818181818182
+        },
+        {
+          "x": 0.15131312514796402,
+          "y": 0.6509090909090909
+        }
+      ],
+      "no_missed": false
+    },
+    "3EUb8DGIsQCcw8z9LOBnAA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "5U3KS0M2Y8w3qsDGGV610g": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "8H6LgNn56hay95HiBYrhHw": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.46606060606060606,
+          "y": 0.525656562573982,
+          "unsure": true
+        },
+        {
+          "x": 0.4812121212121212,
+          "y": 0.525656562573982,
+          "unsure": true
+        },
+        {
+          "x": 0.5860606060606061,
+          "y": 0.5317171686345881,
+          "unsure": true
+        },
+        {
+          "x": 0.827220253767394,
+          "y": 0.5648198743414965,
+          "unsure": true
+        },
+        {
+          "x": 0.7167676706025095,
+          "y": 0.5742424427379261,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "8VPbrd8XBzDOIVoo5Xwz8g": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "8cphEWdm85w5CwOw4rm0_A": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.3773737312085701,
+          "y": 0.5684848484848485
+        },
+        {
+          "x": 0.3585858524206913,
+          "y": 0.5442424242424242
+        }
+      ],
+      "no_missed": false
+    },
+    "E1wxX3pnvZdWrWnUkfkNkA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "I8Y9zDjNKL1k5HUv6BSyFA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4125014694047755,
+          "y": 0.526747294870106,
+          "unsure": true
+        },
+        {
+          "x": 0.4451113176473339,
+          "y": 0.5308686938908673,
+          "unsure": true
+        },
+        {
+          "x": 0.4805241360875154,
+          "y": 0.5284267909756982
+        },
+        {
+          "x": 0.06549370841548144,
+          "y": 0.5253159080351347
+        },
+        {
+          "x": 0.027878787878787878,
+          "y": 0.5201010039358428
+        }
+      ],
+      "no_missed": false
+    },
+    "I_t9Bp1OzV2m-ZKFHssOdg": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.9463751510337548,
+          "y": 0.5319607656865465,
+          "unsure": true
+        },
+        {
+          "x": 0.9648389873965164,
+          "y": 0.518322624754339,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "LMwVmdxU9opG4yzbotuw6g": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4218580808781049,
+          "y": 0.5180644077558382,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "OedGesfk606bGhg4OQESiQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4429538333968534,
+          "y": 0.5168937089194161
+        },
+        {
+          "x": 0.5339577798669883,
+          "y": 0.5185880969654076
+        },
+        {
+          "x": 0.5042989415408832,
+          "y": 0.5155065908694217
+        },
+        {
+          "x": 0.4139141383315576,
+          "y": 0.518282822117661,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "PeJlsIXjn8VkEoryRRBBMg": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4472727457682292,
+          "y": 0.5249494887843277
+        },
+        {
+          "x": 0.5296969881924716,
+          "y": 0.5233333518288352
+        },
+        {
+          "x": 0.03632639030624574,
+          "y": 0.5312447655314984,
+          "unsure": true
+        },
+        {
+          "x": 0.9663045468725726,
+          "y": 0.5307366219673707,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "PgOXmiCTtEV4ip7AJDqf2Q": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.1393939393939394,
+          "y": 0.5511111080285275,
+          "unsure": true
+        },
+        {
+          "x": 0.09090909090909091,
+          "y": 0.5402020171194366
+        },
+        {
+          "x": 0.024660787430501457,
+          "y": 0.542482794429865
+        },
+        {
+          "x": 0.04444445060961174,
+          "y": 0.5394949433297822
+        }
+      ],
+      "no_missed": false
+    },
+    "Ro8ZmvW9hyxIS4GVq1cpMQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "SM4RUwTVtTzgSm3LWvzwqA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "ShaAxuhgD3rK5__gON66zA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "Tn5W3kvbdH7_Fpk29a_hrQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5673504791405647,
+          "y": 0.538278379142594
+        },
+        {
+          "x": 0.5412589379628305,
+          "y": 0.5233515472259002,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "TzKDX5ADk6lqRtZ-F8r6XQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.10545454545454545,
+          "y": 0.5208080777254972,
+          "unsure": true
+        },
+        {
+          "x": 0.9410100948449337,
+          "y": 0.5249494887843277
+        }
+      ],
+      "no_missed": false
+    },
+    "VIMFndX_oqm7vJJD8gDyEA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.3018181818181818,
+          "y": 0.7014141383315577
+        },
+        {
+          "x": 0.2727272727272727,
+          "y": 0.6214141383315578
+        }
+      ],
+      "no_missed": false
+    },
+    "X3HUl4G0JyP3fwNYcFAXVw": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.28545454545454546,
+          "y": 0.5426262595436789
+        },
+        {
+          "x": 0.8121212121212121,
+          "y": 0.6905050474224669
+        }
+      ],
+      "no_missed": false
+    },
+    "f8KWeNBZLlwJXVSj5_0RAg": {
+      "group": "random",
+      "dets": [
+        true,
+        "unsure"
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "hKMeDFlSe7fPsZpi4kS-aA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "kjNgQrRlUM8VkFMli6aIPQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "kmEwK3ZUn80IJAPqjc4nnA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "mVwc04XB9DxuIb05ExnrdA": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "nd-z43_liOX80bmhO15urg": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.06985690179816337,
+          "y": 0.5201683871697917,
+          "unsure": true
+        },
+        {
+          "x": 0.922908550088342,
+          "y": 0.5364525289718272
+        },
+        {
+          "x": 0.9656909160696792,
+          "y": 0.5166620223562147,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "rB_gP9faDRSuiKVDu8h23A": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.44727272727272727,
+          "y": 0.5244444413618607,
+          "unsure": true
+        },
+        {
+          "x": 0.4672727272727273,
+          "y": 0.5220201989376184,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "rvwbAGgi-7mNlZHKSPC8WQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "s4e-NVzTyqcyZ6_5npv6Ow": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "tvNqBlxdm0rdkZgBOGVfog": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "ukV9s59lkyu-xEjUdK7CmQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.1606060606060606,
+          "y": 0.5583838353012547
+        },
+        {
+          "x": 0.09272727272727273,
+          "y": 0.5474747443921638
+        },
+        {
+          "x": 0.2141546837379793,
+          "y": 0.5270917438742238
+        },
+        {
+          "x": 0.21238404492006133,
+          "y": 0.5493609639855036
+        }
+      ],
+      "no_missed": false
+    },
+    "vwNiakvhRASLUkJZwdRB4A": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5424242424242425,
+          "y": 0.5402020171194366,
+          "unsure": true
+        },
+        {
+          "x": 0.3975757575757576,
+          "y": 0.5523232292406487,
+          "unsure": true
+        },
+        {
+          "x": 0.42424242424242425,
+          "y": 0.5511111080285275,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "yDV1n1O4f0QHWG869hAzbQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.030303030303030304,
+          "y": 0.5147474716648911,
+          "unsure": true
+        },
+        {
+          "x": 0.045454545454545456,
+          "y": 0.5147474716648911,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "yPUv9rk8acshJKXa9_jMag": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "yuwkp3XCUwSbB8q7Og99GQ": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "zcVgeJb6FkDw1z__YhM1tg": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.6321212121212121,
+          "y": 0.6298989868164062,
+          "unsure": true
+        },
+        {
+          "x": 0.9490909090909091,
+          "y": 0.5305050474224668,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "-6wL7HzdK7t8DTC_zDPOLw": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.443958343819509,
+          "y": 0.5435383697060274,
+          "unsure": true
+        },
+        {
+          "x": 0.4653501124887523,
+          "y": 0.5394949433297821,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "0SgaioiGd5Yi_5wc6m-nJg": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.47878787878787876,
+          "y": 0.5402020171194366
+        },
+        {
+          "x": 0.4632458989796055,
+          "y": 0.5346548862575057
+        },
+        {
+          "x": 0.4805962591920107,
+          "y": 0.5208787401456776,
+          "unsure": true
+        },
+        {
+          "x": 0.49490234814758394,
+          "y": 0.5209201655595096,
+          "unsure": true
+        },
+        {
+          "x": 0.5369325345142446,
+          "y": 0.5218091707287849
+        },
+        {
+          "x": 0.5631943863193485,
+          "y": 0.5248934320128277
+        },
+        {
+          "x": 0.5799105274979384,
+          "y": 0.5332663458216982
+        }
+      ],
+      "no_missed": false
+    },
+    "6WC0hdAYRsSAcluKSs5iRg": {
+      "group": "random",
+      "dets": [
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "7B5Vphda5PDmZJ5q1RQWdg": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5886915144316661,
+          "y": 0.6210457650015344,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "87nWq0hrTZLm2_UXRgPhZQ": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.056363636363636366,
+          "y": 0.5741414110588305
+        },
+        {
+          "x": 0.14464930328738287,
+          "y": 0.5526986622202845
+        }
+      ],
+      "no_missed": false
+    },
+    "8KtYwvo9b34f3zm-afipNg": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.6496969696969697,
+          "y": 0.5402020171194366
+        }
+      ],
+      "no_missed": false
+    },
+    "91IlnKR3b8rCc1Zx5XGy7w": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "A5AVKFhm7unr9Rs55aQ1Tw": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5327272727272727,
+          "y": 0.5305050474224668
+        }
+      ],
+      "no_missed": false
+    },
+    "BfLStXTTg1-0FjTrZcvYWg": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.683030303030303,
+          "y": 0.5668686837861032
+        }
+      ],
+      "no_missed": false
+    },
+    "CIdYXefgwcZw4L9PqIpuHQ": {
+      "group": "random",
+      "dets": [
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "DFx_w62mJn4Qm4upFTXytQ": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "HraXxn_y7_j4o8_4iS_JDQ": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.3412121212121212,
+          "y": 0.5498989868164063,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "IQT-DUkA06hxOus4rPb47A": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "JliGuAWGKCyOS1LBoywZlA": {
+      "group": "random",
+      "dets": [
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "LhpYKYMPIDXskyHjHW1nOQ": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5636363636363636,
+          "y": 0.5208080777254972
+        },
+        {
+          "x": 0.583030303030303,
+          "y": 0.5341414110588305,
+          "unsure": true
+        },
+        {
+          "x": 0.5636363636363636,
+          "y": 0.5498989868164063
+        }
+      ],
+      "no_missed": false
+    },
+    "NzRL8weHSGkfduBHnrgd5g": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.01090909090909091,
+          "y": 0.5402020171194366
+        },
+        {
+          "x": 0.03575757575757576,
+          "y": 0.5389898959073154
+        },
+        {
+          "x": 0.0703030303030303,
+          "y": 0.5341414110588305
+        },
+        {
+          "x": 0.9696969696969697,
+          "y": 0.5377777746951942
+        },
+        {
+          "x": 0.5745454545454546,
+          "y": 0.6129292898467092,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "UdLzRf1Yi67NOSMn6IZjHQ": {
+      "group": "random",
+      "dets": [
+        "unsure"
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "WGdZz7jOkmmmyQYpbw3F8w": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.22727272727272727,
+          "y": 0.5523232292406487
+        },
+        {
+          "x": 0.9244565295638657,
+          "y": 0.5513961301799177
+        }
+      ],
+      "no_missed": false
+    },
+    "X769L3ombUWjLtZDlE2fqg": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.553939393939394,
+          "y": 0.5850505019679214
+        },
+        {
+          "x": 0.41818181818181815,
+          "y": 0.5462626231800426
+        },
+        {
+          "x": 0.44,
+          "y": 0.5353535322709517
+        }
+      ],
+      "no_missed": false
+    },
+    "bVadNrPq_zXgbJjhhDSwDw": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.007272727272727273,
+          "y": 0.525656562573982
+        },
+        {
+          "x": 0.9951515151515151,
+          "y": 0.5280808049982244,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "gTM14tSsKuUwbSxtTb4xoQ": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.45746304846975494,
+          "y": 0.5315944897411992
+        },
+        {
+          "x": 0.47803300932780585,
+          "y": 0.5220083609810552,
+          "unsure": true
+        },
+        {
+          "x": 0.5586670497195473,
+          "y": 0.522872764272484,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "h_1bUHhTLKugR5XhzA1-nA": {
+      "group": "random",
+      "dets": [
+        false
+      ],
+      "missed": [
+        {
+          "x": 0.9581818181818181,
+          "y": 0.5159595928770123,
+          "unsure": true
+        },
+        {
+          "x": 0.03515151515151515,
+          "y": 0.5208080777254972
+        },
+        {
+          "x": 0.9777682889256585,
+          "y": 0.5223549776700578,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "kkDJcaa4ZmOKSqhbnM1MvQ": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "lijNEguHL6T106ODEBcylQ": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "m7R9z8VWIY94LLSiDgBdBQ": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.3466666666666667,
+          "y": 0.5583838353012547
+        }
+      ],
+      "no_missed": false
+    },
+    "o-cW-Lnr7Yd_VI9xiZ1DHw": {
+      "group": "random",
+      "dets": [
+        "unsure"
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "oKUCusv3jdVCLmevp-P3zw": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5606060606060606,
+          "y": 0.5329292898467093
+        },
+        {
+          "x": 0.5,
+          "y": 0.5159595928770123,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "qNYRurrxEhqZvO8GrwE9nA": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.05818181818181818,
+          "y": 0.5353535322709517
+        },
+        {
+          "x": 0.09696969696969697,
+          "y": 0.5414141383315577,
+          "unsure": true
+        },
+        {
+          "x": 0.4509090909090909,
+          "y": 0.5329292898467093,
+          "unsure": true
+        },
+        {
+          "x": 0.42527974550855174,
+          "y": 0.5294101033910589,
+          "unsure": true
+        },
+        {
+          "x": 0.45752257475376135,
+          "y": 0.5169268018792278,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "rQtHh0Wai-D1FvbvqBlWdw": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.3187878787878788,
+          "y": 0.605656562573982
+        },
+        {
+          "x": 0.14484848484848484,
+          "y": 0.5547474716648911,
+          "unsure": true
+        },
+        {
+          "x": 0.012121212121212121,
+          "y": 0.5620201989376183
+        },
+        {
+          "x": 0.9939393939393939,
+          "y": 0.5620201989376183,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "sLysKXt4_iSuR_gUCdxe5g": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "sUMfdZmScVLBGMjvZ0MjCA": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.05757575757575758,
+          "y": 0.5268686837861032
+        },
+        {
+          "x": 0.03272727272727273,
+          "y": 0.5438383807558002
+        },
+        {
+          "x": 0.9424045622625123,
+          "y": 0.5446351312168836,
+          "unsure": true
+        },
+        {
+          "x": 0.9566039102278434,
+          "y": 0.5303055048901323
+        },
+        {
+          "x": 0.03679428540038957,
+          "y": 0.5214729720499589
+        }
+      ],
+      "no_missed": false
+    },
+    "vX7HB8heH18fb_VkIUAagA": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.9412121212121212,
+          "y": 0.5353535322709517,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "xKoseQiPNzFwaWfw9Rl6hg": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.02909090909090909,
+          "y": 0.5498989868164063,
+          "unsure": true
+        },
+        {
+          "x": 0.046853580935992324,
+          "y": 0.5322778738004696,
+          "unsure": true
+        },
+        {
+          "x": 0.027447087302500003,
+          "y": 0.5276561478532982,
+          "unsure": true
+        },
+        {
+          "x": 0.9183838815400095,
+          "y": 0.5435353966915246
+        }
+      ],
+      "no_missed": false
+    },
+    "1k8PFgEWlZnrY-j007WMAQ": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "4ijauQusmQIJgw4YLTkYsA": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "9kW9cxpuj7q8DMzf-ClrQQ": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "RS0LXKWETF8PhWMbaexYlg": {
+      "group": "empty",
+      "dets": [],
+      "missed": [
+        {
+          "x": 0.5311111080285275,
+          "y": 0.5341414110588305,
+          "unsure": true
+        },
+        {
+          "x": 0.5463552924606246,
+          "y": 0.5278808427907844,
+          "unsure": true
+        },
+        {
+          "x": 0.53550857741866,
+          "y": 0.5195550729567796,
+          "unsure": true
+        },
+        {
+          "x": 0.5074791413051923,
+          "y": 0.5188819689344036,
+          "unsure": true
+        },
+        {
+          "x": 0.45871474300089526,
+          "y": 0.52162055280889,
+          "unsure": true
+        },
+        {
+          "x": 0.42955163993745055,
+          "y": 0.5288394082117984,
+          "unsure": true
+        },
+        {
+          "x": 0.43751803115367244,
+          "y": 0.5366482063414789,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "bCoStRGdrZB6z6QXF9w0yQ": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "lWmcJJwTxnbJ5OUloRKphA": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "mdQY8aMSdYrnHfHNXqj6GQ": {
+      "group": "empty",
+      "dets": [],
+      "missed": [
+        {
+          "x": 0.5238383807558001,
+          "y": 0.5280808049982244,
+          "unsure": true
+        },
+        {
+          "x": 0.5379109489050414,
+          "y": 0.5205811259965607,
+          "unsure": true
+        },
+        {
+          "x": 0.5488939614055528,
+          "y": 0.5246561222256392,
+          "unsure": true
+        },
+        {
+          "x": 0.47636365485913823,
+          "y": 0.5322222160570549
+        }
+      ],
+      "no_missed": false
+    },
+    "vxefPfMvnutF5i07I8rnuw": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "wuFHDmC43ImDlZMS6-opJQ": {
+      "group": "empty",
+      "dets": [],
+      "missed": [
+        {
+          "x": 0.45050504742246683,
+          "y": 0.5280808049982244,
+          "unsure": true
+        },
+        {
+          "x": 0.5214141383315578,
+          "y": 0.5317171686345881,
+          "unsure": true
+        },
+        {
+          "x": 0.44853662013482537,
+          "y": 0.5189460569011644,
+          "unsure": true
+        },
+        {
+          "x": 0.4721769994009656,
+          "y": 0.5165867621375522,
+          "unsure": true
+        },
+        {
+          "x": 0.5142119349192016,
+          "y": 0.5177424085512699,
+          "unsure": true
+        },
+        {
+          "x": 0.43376797810425305,
+          "y": 0.5241603733501503,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "zR6d6XkSFO-UYbgkD26kkw": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
     }
-   ],
-   "no_missed": false
-  },
-  "0FMaNGiSOoTGqLgh8jHfYQ": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    false,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "E15SCY6RTiDuNUu_trZk4Q": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [
-    {
-     "x": 0.3604040342388731,
-     "y": 0.5535353504527699
-    },
-    {
-     "x": 0.43373736757220643,
-     "y": 0.5777777746951941
-    }
-   ],
-   "no_missed": false
-  },
-  "Kv2haiYlkJCiaO61RVWwQA": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "LN819vhVLLeYwzRsBh2zAg": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [
-    {
-     "x": 0.3222222160570549,
-     "y": 0.5737373675722064
-    }
-   ],
-   "no_missed": false
-  },
-  "5NVgLhChZXnD_D-z3SLZyQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "Noi7DhIT3xbCjA2Ip4QOyg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [
-    {
-     "x": 0.6234343372691762,
-     "y": 0.5680808049982244
-    }
-   ],
-   "no_missed": false
-  },
-  "9DA1aapwjQcdUP2HEfrhfg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [
-    {
-     "x": 0.07070706454190341,
-     "y": 0.5692929262103457
-    }
-   ],
-   "no_missed": false
-  },
-  "VMjtxZNqxl9E6oUXnsdI8Q": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "ZlXmdBYkhIpp-wNfPlSIFw": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "rxF0qBiSbOEnMR9wwxpjEw": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "xU7xT5kREy_Jnq_vYaXc8w": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "yJmMJeV6PD3UZlAmm4cmWg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "DaCRMtjRrkxBB468GFSAvQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.10464645848129735,
-     "y": 0.5305050474224668,
-     "unsure": true
-    },
-    {
-     "x": 0.15131312514796402,
-     "y": 0.5268686837861032,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "Jv7Zl2erbO_g10pRN-IS_Q": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "DJ8Zp111zu6KnMZz-0PHgQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "bTkyJpLDQ7HCw4yOdqdNCg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.13494948878432766,
-     "y": 0.536565653483073,
-     "unsure": true
-    },
-    {
-     "x": 0.08646464029947917,
-     "y": 0.5353535322709517,
-     "unsure": true
-    },
-    {
-     "x": 0.9458585796934186,
-     "y": 0.5377777746951942,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "cqb7v_2KGHMeSy8VpvkcDQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "hu3-VWXlGi42PkY38XPJzQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "62TiKmlmxt_xn_68w1lgAw": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.6216161554509944,
-     "y": 0.56
-    }
-   ],
-   "no_missed": false
-  },
-  "NS7lT-itv0JiN6UHVvBxsg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.0997979736328125,
-     "y": 0.5406060606060606
-    },
-    {
-     "x": 0.04828282211766099,
-     "y": 0.5418181818181819
-    },
-    {
-     "x": 0.023434337269176136,
-     "y": 0.5490909090909091
-    }
-   ],
-   "no_missed": false
-  },
-  "PX5zU_2KkKO0Gr4FiSe9aw": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "ScnPNQ2cah0xzWlH28uoOw": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "VgWpqFkTwCIROvM0z-DkOw": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "Wnu3AyufxG1XD9JvU5K-hg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "ZO7V6RR9LtZT8l9-SjIQUg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "dUy9p1NputrGH7SFDmbCpg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "kJr7eKpZcJO_W6V5XlLtBw": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "pIcQQrFa8_XDG7-VSRhAfQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.2894949433297822,
-     "y": 0.5309090909090909
-    },
-    {
-     "x": 0.33252524636008524,
-     "y": 0.5490909090909091
-    }
-   ],
-   "no_missed": false
-  },
-  "tAnrbC_F_FXbg7kTiYywVA": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "woYJ5n0CfTGMuDWTBqcZAg": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5575757575757576,
-     "y": 0.5268686837861032,
-     "unsure": true
-    },
-    {
-     "x": 0.5327272727272727,
-     "y": 0.525656562573982,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "2S_Fj0bq7qkdKUBw9-g1XA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.11616160999644887,
-     "y": 0.6981818181818182
-    },
-    {
-     "x": 0.15131312514796402,
-     "y": 0.6509090909090909
-    }
-   ],
-   "no_missed": false
-  },
-  "3EUb8DGIsQCcw8z9LOBnAA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "5U3KS0M2Y8w3qsDGGV610g": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "8H6LgNn56hay95HiBYrhHw": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.46606060606060606,
-     "y": 0.525656562573982,
-     "unsure": true
-    },
-    {
-     "x": 0.4812121212121212,
-     "y": 0.525656562573982,
-     "unsure": true
-    },
-    {
-     "x": 0.5860606060606061,
-     "y": 0.5317171686345881,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "8VPbrd8XBzDOIVoo5Xwz8g": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "8cphEWdm85w5CwOw4rm0_A": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.3773737312085701,
-     "y": 0.5684848484848485
-    },
-    {
-     "x": 0.3585858524206913,
-     "y": 0.5442424242424242
-    }
-   ],
-   "no_missed": false
-  },
-  "E1wxX3pnvZdWrWnUkfkNkA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "I8Y9zDjNKL1k5HUv6BSyFA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.029696969696969697,
-     "y": 0.519595956513376,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "I_t9Bp1OzV2m-ZKFHssOdg": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "LMwVmdxU9opG4yzbotuw6g": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "OedGesfk606bGhg4OQESiQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "PeJlsIXjn8VkEoryRRBBMg": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.44727272727272727,
-     "y": 0.5280808049982244,
-     "unsure": true
-    },
-    {
-     "x": 0.5266666666666666,
-     "y": 0.5232323201497396,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "PgOXmiCTtEV4ip7AJDqf2Q": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.1393939393939394,
-     "y": 0.5511111080285275,
-     "unsure": true
-    },
-    {
-     "x": 0.09090909090909091,
-     "y": 0.5402020171194366
-    }
-   ],
-   "no_missed": false
-  },
-  "Ro8ZmvW9hyxIS4GVq1cpMQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "SM4RUwTVtTzgSm3LWvzwqA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "ShaAxuhgD3rK5__gON66zA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "Tn5W3kvbdH7_Fpk29a_hrQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "TzKDX5ADk6lqRtZ-F8r6XQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.10545454545454545,
-     "y": 0.5208080777254972,
-     "unsure": true
-    },
-    {
-     "x": 0.9412121212121212,
-     "y": 0.5292929262103456,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "VIMFndX_oqm7vJJD8gDyEA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.3018181818181818,
-     "y": 0.7014141383315577
-    },
-    {
-     "x": 0.2727272727272727,
-     "y": 0.6214141383315578
-    }
-   ],
-   "no_missed": false
-  },
-  "X3HUl4G0JyP3fwNYcFAXVw": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.28545454545454546,
-     "y": 0.5426262595436789
-    },
-    {
-     "x": 0.8121212121212121,
-     "y": 0.6905050474224669
-    }
-   ],
-   "no_missed": false
-  },
-  "f8KWeNBZLlwJXVSj5_0RAg": {
-   "group": "random",
-   "dets": [
-    true,
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "hKMeDFlSe7fPsZpi4kS-aA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "kjNgQrRlUM8VkFMli6aIPQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "kmEwK3ZUn80IJAPqjc4nnA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "mVwc04XB9DxuIb05ExnrdA": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "nd-z43_liOX80bmhO15urg": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "rB_gP9faDRSuiKVDu8h23A": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.44727272727272727,
-     "y": 0.5244444413618607,
-     "unsure": true
-    },
-    {
-     "x": 0.4672727272727273,
-     "y": 0.5220201989376184,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "rvwbAGgi-7mNlZHKSPC8WQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "s4e-NVzTyqcyZ6_5npv6Ow": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "tvNqBlxdm0rdkZgBOGVfog": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "ukV9s59lkyu-xEjUdK7CmQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.1606060606060606,
-     "y": 0.5583838353012547
-    },
-    {
-     "x": 0.09272727272727273,
-     "y": 0.5474747443921638
-    },
-    {
-     "x": 0.21333333333333335,
-     "y": 0.5244444413618607,
-     "unsure": true
-    },
-    {
-     "x": 0.20545454545454545,
-     "y": 0.5474747443921638,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "vwNiakvhRASLUkJZwdRB4A": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5424242424242425,
-     "y": 0.5402020171194366,
-     "unsure": true
-    },
-    {
-     "x": 0.3975757575757576,
-     "y": 0.5523232292406487,
-     "unsure": true
-    },
-    {
-     "x": 0.42424242424242425,
-     "y": 0.5511111080285275,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "yDV1n1O4f0QHWG869hAzbQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.030303030303030304,
-     "y": 0.5147474716648911,
-     "unsure": true
-    },
-    {
-     "x": 0.045454545454545456,
-     "y": 0.5147474716648911,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "yPUv9rk8acshJKXa9_jMag": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "yuwkp3XCUwSbB8q7Og99GQ": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "zcVgeJb6FkDw1z__YhM1tg": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.6321212121212121,
-     "y": 0.6298989868164062,
-     "unsure": true
-    },
-    {
-     "x": 0.9490909090909091,
-     "y": 0.5305050474224668,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "-6wL7HzdK7t8DTC_zDPOLw": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "0SgaioiGd5Yi_5wc6m-nJg": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.47878787878787876,
-     "y": 0.5402020171194366
-    }
-   ],
-   "no_missed": false
-  },
-  "6WC0hdAYRsSAcluKSs5iRg": {
-   "group": "random",
-   "dets": [
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "7B5Vphda5PDmZJ5q1RQWdg": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "87nWq0hrTZLm2_UXRgPhZQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.056363636363636366,
-     "y": 0.5741414110588305
-    }
-   ],
-   "no_missed": false
-  },
-  "8KtYwvo9b34f3zm-afipNg": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.6496969696969697,
-     "y": 0.5402020171194366
-    }
-   ],
-   "no_missed": false
-  },
-  "91IlnKR3b8rCc1Zx5XGy7w": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "A5AVKFhm7unr9Rs55aQ1Tw": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5327272727272727,
-     "y": 0.5305050474224668
-    }
-   ],
-   "no_missed": false
-  },
-  "BfLStXTTg1-0FjTrZcvYWg": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.683030303030303,
-     "y": 0.5668686837861032
-    }
-   ],
-   "no_missed": false
-  },
-  "CIdYXefgwcZw4L9PqIpuHQ": {
-   "group": "random",
-   "dets": [
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "DFx_w62mJn4Qm4upFTXytQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "HraXxn_y7_j4o8_4iS_JDQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.3412121212121212,
-     "y": 0.5498989868164063,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "IQT-DUkA06hxOus4rPb47A": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "JliGuAWGKCyOS1LBoywZlA": {
-   "group": "random",
-   "dets": [
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "LhpYKYMPIDXskyHjHW1nOQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5636363636363636,
-     "y": 0.5208080777254972
-    },
-    {
-     "x": 0.583030303030303,
-     "y": 0.5341414110588305,
-     "unsure": true
-    },
-    {
-     "x": 0.5636363636363636,
-     "y": 0.5498989868164063
-    }
-   ],
-   "no_missed": false
-  },
-  "NzRL8weHSGkfduBHnrgd5g": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.01090909090909091,
-     "y": 0.5402020171194366
-    },
-    {
-     "x": 0.03575757575757576,
-     "y": 0.5389898959073154
-    },
-    {
-     "x": 0.0703030303030303,
-     "y": 0.5341414110588305
-    },
-    {
-     "x": 0.9696969696969697,
-     "y": 0.5377777746951942
-    },
-    {
-     "x": 0.5745454545454546,
-     "y": 0.6129292898467092
-    }
-   ],
-   "no_missed": false
-  },
-  "UdLzRf1Yi67NOSMn6IZjHQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "WGdZz7jOkmmmyQYpbw3F8w": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.22727272727272727,
-     "y": 0.5523232292406487
-    }
-   ],
-   "no_missed": false
-  },
-  "X769L3ombUWjLtZDlE2fqg": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.553939393939394,
-     "y": 0.5850505019679214
-    },
-    {
-     "x": 0.41818181818181815,
-     "y": 0.5462626231800426
-    },
-    {
-     "x": 0.44,
-     "y": 0.5353535322709517
-    }
-   ],
-   "no_missed": false
-  },
-  "bVadNrPq_zXgbJjhhDSwDw": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.007272727272727273,
-     "y": 0.525656562573982
-    },
-    {
-     "x": 0.9951515151515151,
-     "y": 0.5280808049982244,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "gTM14tSsKuUwbSxtTb4xoQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "h_1bUHhTLKugR5XhzA1-nA": {
-   "group": "random",
-   "dets": [
-    false
-   ],
-   "missed": [
-    {
-     "x": 0.9581818181818181,
-     "y": 0.5159595928770123,
-     "unsure": true
-    },
-    {
-     "x": 0.03515151515151515,
-     "y": 0.5208080777254972
-    }
-   ],
-   "no_missed": false
-  },
-  "kkDJcaa4ZmOKSqhbnM1MvQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "lijNEguHL6T106ODEBcylQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "m7R9z8VWIY94LLSiDgBdBQ": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.3466666666666667,
-     "y": 0.5583838353012547
-    }
-   ],
-   "no_missed": false
-  },
-  "o-cW-Lnr7Yd_VI9xiZ1DHw": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "oKUCusv3jdVCLmevp-P3zw": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5606060606060606,
-     "y": 0.5329292898467093
-    },
-    {
-     "x": 0.5,
-     "y": 0.5159595928770123,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "qNYRurrxEhqZvO8GrwE9nA": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.05818181818181818,
-     "y": 0.5353535322709517
-    },
-    {
-     "x": 0.09696969696969697,
-     "y": 0.5414141383315577,
-     "unsure": true
-    },
-    {
-     "x": 0.4509090909090909,
-     "y": 0.5329292898467093,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "rQtHh0Wai-D1FvbvqBlWdw": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.3187878787878788,
-     "y": 0.605656562573982
-    },
-    {
-     "x": 0.14484848484848484,
-     "y": 0.5547474716648911,
-     "unsure": true
-    },
-    {
-     "x": 0.012121212121212121,
-     "y": 0.5620201989376183
-    },
-    {
-     "x": 0.9939393939393939,
-     "y": 0.5620201989376183,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "sLysKXt4_iSuR_gUCdxe5g": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "sUMfdZmScVLBGMjvZ0MjCA": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.9515151515151515,
-     "y": 0.5220201989376184
-    },
-    {
-     "x": 0.05757575757575758,
-     "y": 0.5268686837861032
-    },
-    {
-     "x": 0.03636363636363636,
-     "y": 0.5159595928770123
-    },
-    {
-     "x": 0.03272727272727273,
-     "y": 0.5438383807558002
-    }
-   ],
-   "no_missed": false
-  },
-  "vX7HB8heH18fb_VkIUAagA": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.9412121212121212,
-     "y": 0.5353535322709517,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "xKoseQiPNzFwaWfw9Rl6hg": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.9175757575757576,
-     "y": 0.5426262595436789,
-     "unsure": true
-    },
-    {
-     "x": 0.02909090909090909,
-     "y": 0.5498989868164063,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1k8PFgEWlZnrY-j007WMAQ": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "4ijauQusmQIJgw4YLTkYsA": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "9kW9cxpuj7q8DMzf-ClrQQ": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "RS0LXKWETF8PhWMbaexYlg": {
-   "group": "empty",
-   "dets": [],
-   "missed": [
-    {
-     "x": 0.4353535322709517,
-     "y": 0.5329292898467093,
-     "unsure": true
-    },
-    {
-     "x": 0.5311111080285275,
-     "y": 0.5341414110588305,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "bCoStRGdrZB6z6QXF9w0yQ": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "lWmcJJwTxnbJ5OUloRKphA": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "mdQY8aMSdYrnHfHNXqj6GQ": {
-   "group": "empty",
-   "dets": [],
-   "missed": [
-    {
-     "x": 0.4741414110588305,
-     "y": 0.5280808049982244,
-     "unsure": true
-    },
-    {
-     "x": 0.5238383807558001,
-     "y": 0.5280808049982244,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "vxefPfMvnutF5i07I8rnuw": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "wuFHDmC43ImDlZMS6-opJQ": {
-   "group": "empty",
-   "dets": [],
-   "missed": [
-    {
-     "x": 0.45050504742246683,
-     "y": 0.5280808049982244,
-     "unsure": true
-    },
-    {
-     "x": 0.5214141383315578,
-     "y": 0.5317171686345881,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "zR6d6XkSFO-UYbgkD26kkw": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
   }
- }
 }

--- a/benchmark/richmond/verdicts.json
+++ b/benchmark/richmond/verdicts.json
@@ -1,1589 +1,1873 @@
 {
- "run_key": "f96787285f24fb6f44d34a127d9347248778f1dcd38b082a85169b9853936fb1",
- "run_name": "richmond",
- "source": "runs\\richmond\\results.jsonl",
- "exported_at": "2026-07-22T18:19:45.418Z",
- "panos": {
-  "1273933840289887": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "934739365184374": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1130501775077894": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.31434342817826705,
-     "y": 0.5208080777254972,
-     "unsure": true
+  "run_key": "f96787285f24fb6f44d34a127d9347248778f1dcd38b082a85169b9853936fb1",
+  "run_name": "richmond",
+  "source": "benchmark\\richmond\\records.jsonl",
+  "exported_at": "2026-07-22T21:10:36.914Z",
+  "panos": {
+    "1273933840289887": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4668705772409098,
+          "y": 0.5262836569009756,
+          "unsure": true
+        },
+        {
+          "x": 0.48066206191356275,
+          "y": 0.5253442528977987,
+          "unsure": true
+        },
+        {
+          "x": 0.5389940149790596,
+          "y": 0.5229763011707995,
+          "unsure": true
+        },
+        {
+          "x": 0.5935664064174488,
+          "y": 0.5384636678464564
+        }
+      ],
+      "no_missed": false
     },
-    {
-     "x": 0.7537373675722064,
-     "y": 0.6080808142459754
+    "934739365184374": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false
+      ],
+      "missed": [],
+      "no_missed": true
     },
-    {
-     "x": 0.7943434281782671,
-     "y": 0.6032323293974905
-    }
-   ],
-   "no_missed": false
-  },
-  "1309093164014619": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [
-    {
-     "x": 0.8864646402994791,
-     "y": 0.5765656627308239
-    }
-   ],
-   "no_missed": false
-  },
-  "1847752429062443": {
-   "group": "top",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "461898606342872": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true,
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.7428282766631156,
-     "y": 0.5668686930338541
-    }
-   ],
-   "no_missed": false
-  },
-  "2263954690670646": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "593421160518191": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1044606157061812": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1092133469495462": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.28282827666311555,
-     "y": 0.5919191903779001
-    }
-   ],
-   "no_missed": false
-  },
-  "639645829096010": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    false,
-    "unsure",
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "872856994942214": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "911337534530260": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    "unsure",
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.7846464584812973,
-     "y": 0.6185858524206913
+    "1130501775077894": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.31434342817826705,
+          "y": 0.5208080777254972,
+          "unsure": true
+        },
+        {
+          "x": 0.7537373675722064,
+          "y": 0.6080808142459754
+        },
+        {
+          "x": 0.7943434281782671,
+          "y": 0.6032323293974905
+        },
+        {
+          "x": 0.3664040032844503,
+          "y": 0.5258051664947201,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
     },
-    {
-     "x": 0.16282827666311553,
-     "y": 0.5337373675722065,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1041352537628655": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.07676767060250947,
-     "y": 0.5458585796934186,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1051211967136526": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1107064934776754": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1263975528308076": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1288163659019705": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    "unsure",
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.2791919130267519,
-     "y": 0.6537373675722065
+    "1309093164014619": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false
+      ],
+      "missed": [
+        {
+          "x": 0.8864646402994791,
+          "y": 0.5765656627308239
+        }
+      ],
+      "no_missed": false
     },
-    {
-     "x": 0.32282827666311553,
-     "y": 0.6076767615116003
-    }
-   ],
-   "no_missed": false
-  },
-  "1335429861397399": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1483585545954157": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.22585857969341855,
-     "y": 0.708282822117661,
-     "unsure": true
+    "1847752429062443": {
+      "group": "top",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
     },
-    {
-     "x": 0.33555554939038823,
-     "y": 0.6367676706025095,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1701172050581812": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "2067733823644753": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "424364943656028": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "433987753066526": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "522346373509256": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    "unsure",
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "925077602773417": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1002881108606016": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1050503583329955": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1071700701728910": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1073049581231056": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1085890173202735": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    "unsure",
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1126712375884972": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.40282827666311555,
-     "y": 0.5361616099964489,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1179500609797636": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.0991919130267519,
-     "y": 0.5458585796934186,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1237376427883773": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.6525252463600852,
-     "y": 0.7240403978752368
+    "461898606342872": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.7428282766631156,
+          "y": 0.5668686930338541
+        }
+      ],
+      "no_missed": false
     },
-    {
-     "x": 0.6355555493903883,
-     "y": 0.6161616099964489
-    }
-   ],
-   "no_missed": false
-  },
-  "1427673368387929": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "2184370012043145": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "4102292636718018": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "514363767744061": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "723487737079243": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    "unsure",
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "996959015535106": {
-   "group": "random",
-   "dets": [
-    true,
-    true,
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.4428282766631155,
-     "y": 0.5204040342388732,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1108131584865233": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1119718896242677": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1180673306331763": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5591919130267519,
-     "y": 0.531313125147964,
-     "unsure": true
+    "2263954690670646": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
     },
-    {
-     "x": 0.3779797918146307,
-     "y": 0.5240403978752367,
-     "unsure": true
+    "593421160518191": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4114586336281223,
+          "y": 0.5620670533370702
+        },
+        {
+          "x": 0.7702458544241675,
+          "y": 0.5173858634506956
+        },
+        {
+          "x": 0.8414141845703125,
+          "y": 0.5112121397076231
+        }
+      ],
+      "no_missed": false
+    },
+    "1044606157061812": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1092133469495462": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.28282827666311555,
+          "y": 0.5919191903779001
+        }
+      ],
+      "no_missed": false
+    },
+    "639645829096010": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        false,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.23492423780036692,
+          "y": 0.5502974155481681
+        }
+      ],
+      "no_missed": false
+    },
+    "872856994942214": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.27420973138571514,
+          "y": 0.5460301969675229,
+          "unsure": true
+        },
+        {
+          "x": 0.2991919130267519,
+          "y": 0.5637373675722065,
+          "unsure": true
+        },
+        {
+          "x": 0.31414142030658143,
+          "y": 0.5807070645419035,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "911337534530260": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        "unsure",
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.7846464584812973,
+          "y": 0.6185858524206913
+        },
+        {
+          "x": 0.16282827666311553,
+          "y": 0.5337373675722065,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1041352537628655": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.07676767060250947,
+          "y": 0.5458585796934186,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1051211967136526": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1107064934776754": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1263975528308076": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.9712878880356297,
+          "y": 0.5335353504527698
+        }
+      ],
+      "no_missed": false
+    },
+    "1288163659019705": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        "unsure",
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.2791919130267519,
+          "y": 0.6537373675722065
+        },
+        {
+          "x": 0.32282827666311553,
+          "y": 0.6076767615116003
+        }
+      ],
+      "no_missed": false
+    },
+    "1335429861397399": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1483585545954157": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.22585857969341855,
+          "y": 0.708282822117661,
+          "unsure": true
+        },
+        {
+          "x": 0.33555554939038823,
+          "y": 0.6367676706025095,
+          "unsure": true
+        },
+        {
+          "x": 0.8424242609197443,
+          "y": 0.5992929724491004,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1701172050581812": {
+      "group": "random",
+      "dets": [
+        "unsure",
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.2494646476976799,
+          "y": 0.5781616173946496,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "2067733823644753": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "424364943656028": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "433987753066526": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.2419418948972789,
+          "y": 0.5450309172089488
+        },
+        {
+          "x": 0.5186392928059769,
+          "y": 0.532458711270457
+        }
+      ],
+      "no_missed": false
+    },
+    "522346373509256": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        "unsure",
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "925077602773417": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.06666668516216856,
+          "y": 0.5306060791015625,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1002881108606016": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1050503583329955": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1071700701728910": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1073049581231056": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.8335550178936885,
+          "y": 0.524498034945528,
+          "unsure": true
+        },
+        {
+          "x": 0.8480289567319798,
+          "y": 0.5239913430384191,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1085890173202735": {
+      "group": "random",
+      "dets": [
+        "unsure",
+        "unsure",
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.7172189249272664,
+          "y": 0.4898829187872938,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1126712375884972": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.40282827666311555,
+          "y": 0.5361616099964489,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1179500609797636": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.0991919130267519,
+          "y": 0.5458585796934186,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1237376427883773": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.6525252463600852,
+          "y": 0.7240403978752368
+        },
+        {
+          "x": 0.6355555493903883,
+          "y": 0.6161616099964489
+        }
+      ],
+      "no_missed": false
+    },
+    "1427673368387929": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "2184370012043145": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "4102292636718018": {
+      "group": "random",
+      "dets": [
+        "duplicate",
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.45582394840107127,
+          "y": 0.5276561547356382,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "514363767744061": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.41343178662408825,
+          "y": 0.5183337173106983,
+          "unsure": true
+        },
+        {
+          "x": 0.43636365485913825,
+          "y": 0.5144444876006156,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "723487737079243": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.006868693033854166,
+          "y": 0.5435353966915246
+        }
+      ],
+      "no_missed": false
+    },
+    "996959015535106": {
+      "group": "random",
+      "dets": [
+        true,
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.44606062455610795,
+          "y": 0.5233333703243371
+        }
+      ],
+      "no_missed": false
+    },
+    "1108131584865233": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1119718896242677": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5555555493903882,
+          "y": 0.5750505482066761,
+          "unsure": true
+        },
+        {
+          "x": 0.3773737312085701,
+          "y": 0.5677778209339489,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1180673306331763": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5591919130267519,
+          "y": 0.531313125147964,
+          "unsure": true
+        },
+        {
+          "x": 0.3779797918146307,
+          "y": 0.5240403978752367,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1187483045673326": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.8828282766631156,
+          "y": 0.6088888827237215
+        },
+        {
+          "x": 0.9519191857540246,
+          "y": 0.5419191857540246
+        }
+      ],
+      "no_missed": false
+    },
+    "1279553583800599": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1294705618516185": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1327023138707493": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.451313125147964,
+          "y": 0.5252525190873579,
+          "unsure": true
+        },
+        {
+          "x": 0.6194735556850449,
+          "y": 0.560975050759821,
+          "unsure": true
+        },
+        {
+          "x": 0.5511111542672822,
+          "y": 0.5386869118430397
+        }
+      ],
+      "no_missed": false
+    },
+    "1473003156922360": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.0315773409832226,
+          "y": 0.511705967385052,
+          "unsure": true
+        },
+        {
+          "x": 0.9633127956874424,
+          "y": 0.5159166133676861,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1589004208714002": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.10202021743312026,
+          "y": 0.5513089222503977,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1599497457585207": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1739689546844035": {
+      "group": "random",
+      "dets": [
+        "unsure",
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1759178911495771": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4460757821051315,
+          "y": 0.5233485093778587
+        },
+        {
+          "x": 0.459005214757595,
+          "y": 0.5217732532878832
+        },
+        {
+          "x": 0.5197303339935238,
+          "y": 0.5219953845879944
+        }
+      ],
+      "no_missed": false
+    },
+    "1828524234403425": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1905003193597285": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5622222160570549,
+          "y": 0.5288888827237216,
+          "unsure": true
+        },
+        {
+          "x": 0.8046464584812973,
+          "y": 0.5749494887843276
+        },
+        {
+          "x": 0.4137373675722064,
+          "y": 0.5058585796934185,
+          "unsure": true
+        },
+        {
+          "x": 0.8658585796934185,
+          "y": 0.5693939578894412
+        },
+        {
+          "x": 0.8905050936612215,
+          "y": 0.5596969881924716
+        },
+        {
+          "x": 0.9204040342388731,
+          "y": 0.5475757760712595
+        }
+      ],
+      "no_missed": false
+    },
+    "2111278956050786": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4410100948449337,
+          "y": 0.5264646402994791,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "2141681583023863": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.731313125147964,
+          "y": 0.5677777654474432,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "27724402107145083": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5995960027521307,
+          "y": 0.574242461233428
+        }
+      ],
+      "no_missed": false
+    },
+    "372149922554566": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.9527272912227747,
+          "y": 0.533838426994555
+        },
+        {
+          "x": 0.03474748091264204,
+          "y": 0.5273737312085701
+        }
+      ],
+      "no_missed": false
+    },
+    "383880874806933": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.21252524636008524,
+          "y": 0.5361616099964489
+        },
+        {
+          "x": 0.1397979736328125,
+          "y": 0.5301010039358428,
+          "unsure": true
+        },
+        {
+          "x": 0.19393941243489585,
+          "y": 0.5297979736328124
+        }
+      ],
+      "no_missed": false
+    },
+    "386363531219281": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4905050936612216,
+          "y": 0.5144444876006156
+        },
+        {
+          "x": 0.5579797918146306,
+          "y": 0.5160606245561079
+        }
+      ],
+      "no_missed": false
+    },
+    "3956582084664486": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.46505054820667613,
+          "y": 0.5192929169625947
+        },
+        {
+          "x": 0.5402850979625293,
+          "y": 0.5182507727523443
+        }
+      ],
+      "no_missed": false
+    },
+    "3980741912187626": {
+      "group": "random",
+      "dets": [
+        "unsure",
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.3773737312085701,
+          "y": 0.5846464584812974
+        },
+        {
+          "x": 0.6088888827237215,
+          "y": 0.6064646402994792
+        },
+        {
+          "x": 0.6108941345557353,
+          "y": 0.5709128544012171
+        }
+      ],
+      "no_missed": false
+    },
+    "423989957171190": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.42667711943494924,
+          "y": 0.5250655456146334
+        },
+        {
+          "x": 0.5133691152905883,
+          "y": 0.5247863607532633
+        },
+        {
+          "x": 0.5291509811918936,
+          "y": 0.5252428801194406
+        },
+        {
+          "x": 0.5474366110477303,
+          "y": 0.5438915753113823
+        }
+      ],
+      "no_missed": false
+    },
+    "432356313302579": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.2701010039358428,
+          "y": 0.6210100948449337
+        },
+        {
+          "x": 0.271313125147964,
+          "y": 0.6573737312085701
+        },
+        {
+          "x": 0.33737373120857006,
+          "y": 0.5325252463600852
+        },
+        {
+          "x": 0.28585857969341855,
+          "y": 0.5361616099964489,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "662385816800591": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.44464645848129736,
+          "y": 0.5070707009055397
+        },
+        {
+          "x": 0.5236363821318656,
+          "y": 0.5209091094045928
+        }
+      ],
+      "no_missed": false
+    },
+    "780391337668333": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.9624242609197443,
+          "y": 0.5322222345525568
+        }
+      ],
+      "no_missed": false
+    },
+    "893023542323690": {
+      "group": "random",
+      "dets": [
+        true,
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1023400645666420": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.7919191857540246,
+          "y": 0.6331313069661458
+        },
+        {
+          "x": 0.2294949433297822,
+          "y": 0.5919191857540246
+        },
+        {
+          "x": 0.43434342817826704,
+          "y": 0.5419191857540246
+        }
+      ],
+      "no_missed": false
+    },
+    "1069666650973873": {
+      "group": "random",
+      "dets": [
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1089573432664131": {
+      "group": "random",
+      "dets": [
+        false
+      ],
+      "missed": [
+        {
+          "x": 0.0791919130267519,
+          "y": 0.5288888827237216,
+          "unsure": true
+        },
+        {
+          "x": 0.9536616099964488,
+          "y": 0.5459090909090908
+        },
+        {
+          "x": 0.9656815877072948,
+          "y": 0.5246841627463606,
+          "unsure": true
+        },
+        {
+          "x": 0.04221146015126483,
+          "y": 0.5214825916524172,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1110314244387816": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.4101010039358428,
+          "y": 0.6367676706025095,
+          "unsure": true
+        },
+        {
+          "x": 0.4819725424417728,
+          "y": 0.5769238621475898
+        },
+        {
+          "x": 0.6961413694097003,
+          "y": 0.5019622085748252
+        },
+        {
+          "x": 0.5260899962249893,
+          "y": 0.5462150503817342
+        }
+      ],
+      "no_missed": false
+    },
+    "1185319949364085": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.531313125147964,
+          "y": 0.5361616099964489,
+          "unsure": true
+        },
+        {
+          "x": 0.5131313069661458,
+          "y": 0.5119191857540246
+        },
+        {
+          "x": 0.4458585796934186,
+          "y": 0.508282822117661,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1193579455857033": {
+      "group": "random",
+      "dets": [
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1260990361757674": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.46702477127592434,
+          "y": 0.5269179634248174
+        },
+        {
+          "x": 0.5593004053574665,
+          "y": 0.5336089345216305
+        },
+        {
+          "x": 0.4724393565982695,
+          "y": 0.5111218285123551,
+          "unsure": true
+        },
+        {
+          "x": 0.5258016954643915,
+          "y": 0.5088655007558952,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1294684158910702": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1315788070079167": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5610100948449337,
+          "y": 0.47313130696614586
+        }
+      ],
+      "no_missed": false
+    },
+    "1315844333300588": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.07676767060250947,
+          "y": 0.5494949433297822,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1338631107629110": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5325252463600852,
+          "y": 0.4973737312085701
+        }
+      ],
+      "no_missed": false
+    },
+    "1408179757063785": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1441274599876577": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.05026338366770002,
+          "y": 0.5263919001449772
+        },
+        {
+          "x": 0.9440247579367571,
+          "y": 0.5328431364003076
+        },
+        {
+          "x": 0.9674920439657715,
+          "y": 0.5249494887843277,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1809151763043139": {
+      "group": "random",
+      "dets": [
+        false
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "1991198475040883": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5416161554509943,
+          "y": 0.5204040342388732,
+          "unsure": true
+        },
+        {
+          "x": 0.3028282766631155,
+          "y": 0.5240403978752367,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1991876994661275": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.022222216057054923,
+          "y": 0.531313125147964
+        },
+        {
+          "x": 0.1188302236550056,
+          "y": 0.5312825529464339
+        },
+        {
+          "x": 0.9781819106593277,
+          "y": 0.5491919130267519,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "2026086521187684": {
+      "group": "random",
+      "dets": [
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.9584308466253451,
+          "y": 0.5349567108800729,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "2147631415757748": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "3901547360084831": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.12966896839839284,
+          "y": 0.536770189658779,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "4116269558691031": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5252525190873579,
+          "y": 0.5894949433297823,
+          "unsure": true
+        },
+        {
+          "x": 0.4294949433297822,
+          "y": 0.6670707009055398
+        },
+        {
+          "x": 0.7088888827237216,
+          "y": 0.5337373675722065,
+          "unsure": true
+        },
+        {
+          "x": 0.7337373675722064,
+          "y": 0.5264646402994791,
+          "unsure": true
+        },
+        {
+          "x": 0.8640403978752368,
+          "y": 0.47676767060250946,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "552315380916113": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5349494887843277,
+          "y": 0.5628282766631155,
+          "unsure": true
+        },
+        {
+          "x": 0.43434342817826704,
+          "y": 0.5179797918146307,
+          "unsure": true
+        },
+        {
+          "x": 0.5164770785435311,
+          "y": 0.517956004077946
+        }
+      ],
+      "no_missed": false
+    },
+    "559372759847379": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "562637219504223": {
+      "group": "random",
+      "dets": [
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.42646464029947917,
+          "y": 0.5640403978752367,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "563961506051153": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.5510773409029864,
+          "y": 0.5215509977006512,
+          "unsure": true
+        },
+        {
+          "x": 0.5333987771931066,
+          "y": 0.5139936838989869,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "591584463734236": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [],
+      "no_missed": true
+    },
+    "681333794968062": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.6004040342388731,
+          "y": 0.5500000184955018
+        }
+      ],
+      "no_missed": false
+    },
+    "700668799338315": {
+      "group": "random",
+      "dets": [
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.5558273567679088,
+          "y": 0.5642667296707485
+        },
+        {
+          "x": 0.5632683512775729,
+          "y": 0.5495080628105492,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "775828278323576": {
+      "group": "random",
+      "dets": [
+        "unsure"
+      ],
+      "missed": [
+        {
+          "x": 0.5076767615116003,
+          "y": 0.4428282766631155,
+          "unsure": true
+        },
+        {
+          "x": 0.67737373120857,
+          "y": 0.5373737312085701,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "822353906794602": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.7175757760712594,
+          "y": 0.773838426994555,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "839655921736413": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.8406462580343929,
+          "y": 0.5744880586392555
+        }
+      ],
+      "no_missed": false
+    },
+    "843075271274817": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.45889648493034435,
+          "y": 0.5133680100763909,
+          "unsure": true
+        },
+        {
+          "x": 0.515750513198484,
+          "y": 0.5139141006090218,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "8726984263984099": {
+      "group": "random",
+      "dets": [
+        true
+      ],
+      "missed": [
+        {
+          "x": 0.502222216057055,
+          "y": 0.5228282766631155,
+          "unsure": true
+        },
+        {
+          "x": 0.10161615545099432,
+          "y": 0.5143434281782671,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1021092976148975": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1078560817421587": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1119166219764581": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1120239902858678": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1148968923952346": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1154113539910333": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1277351374404839": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1279326226723010": {
+      "group": "empty",
+      "dets": [],
+      "missed": [
+        {
+          "x": 0.9763636363636363,
+          "y": 0.5232323201497396,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "1297225628792280": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1403202260886086": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "1976970169406126": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "24127338963626294": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "2456904447834971": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "3808624879384438": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "382838731271782": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "4002322973363581": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "4042244719362475": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "481381621684815": {
+      "group": "empty",
+      "dets": [],
+      "missed": [
+        {
+          "x": 0.9802043990384082,
+          "y": 0.5305680892936887,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "612758008575849": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "667461712321088": {
+      "group": "empty",
+      "dets": [],
+      "missed": [
+        {
+          "x": 0.48484848484848486,
+          "y": 0.5353535322709517,
+          "unsure": true
+        },
+        {
+          "x": 0.573939393939394,
+          "y": 0.5183838353012548,
+          "unsure": true
+        },
+        {
+          "x": 0.5614071264403424,
+          "y": 0.5146196071141356,
+          "unsure": true
+        },
+        {
+          "x": 0.49845814574141567,
+          "y": 0.5300513299098771,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "724492966635485": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "761421883101179": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "785854814030175": {
+      "group": "empty",
+      "dets": [],
+      "missed": [
+        {
+          "x": 0.4672727272727273,
+          "y": 0.4965656534830729,
+          "unsure": true
+        },
+        {
+          "x": 0.5289139006269361,
+          "y": 0.4988890378011472,
+          "unsure": true
+        }
+      ],
+      "no_missed": false
+    },
+    "888167256831303": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
+    },
+    "896345989301021": {
+      "group": "empty",
+      "dets": [],
+      "missed": [],
+      "no_missed": true
     }
-   ],
-   "no_missed": false
-  },
-  "1187483045673326": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.8828282766631156,
-     "y": 0.6088888827237215
-    },
-    {
-     "x": 0.9488888827237216,
-     "y": 0.5434343372691761,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1279553583800599": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1294705618516185": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1327023138707493": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.451313125147964,
-     "y": 0.5252525190873579,
-     "unsure": true
-    },
-    {
-     "x": 0.5616161554509943,
-     "y": 0.5373737312085701,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1473003156922360": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1589004208714002": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1599497457585207": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1739689546844035": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1759178911495771": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.44828282211766096,
-     "y": 0.5264646402994791,
-     "unsure": true
-    },
-    {
-     "x": 0.5319191857540246,
-     "y": 0.5191919130267519,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1828524234403425": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1905003193597285": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5622222160570549,
-     "y": 0.5288888827237216,
-     "unsure": true
-    },
-    {
-     "x": 0.8046464584812973,
-     "y": 0.5749494887843276
-    },
-    {
-     "x": 0.865252519087358,
-     "y": 0.5676767615116004,
-     "unsure": true
-    },
-    {
-     "x": 0.891313125147964,
-     "y": 0.5579797918146306,
-     "unsure": true
-    },
-    {
-     "x": 0.9246464584812973,
-     "y": 0.5410100948449337,
-     "unsure": true
-    },
-    {
-     "x": 0.4137373675722064,
-     "y": 0.5058585796934185,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "2111278956050786": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.4410100948449337,
-     "y": 0.5264646402994791,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "2141681583023863": {
-   "group": "random",
-   "dets": [
-    true,
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.7325252463600852,
-     "y": 0.5628282766631155,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "27724402107145083": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5973737312085701,
-     "y": 0.5737373675722064,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "372149922554566": {
-   "group": "random",
-   "dets": [
-    true,
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.039191913026751894,
-     "y": 0.5240403978752367,
-     "unsure": true
-    },
-    {
-     "x": 0.9537373675722064,
-     "y": 0.5337373675722065,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "383880874806933": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.21252524636008524,
-     "y": 0.5361616099964489
-    },
-    {
-     "x": 0.19555554939038824,
-     "y": 0.5301010039358428,
-     "unsure": true
-    },
-    {
-     "x": 0.1397979736328125,
-     "y": 0.5301010039358428,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "386363531219281": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.488282822117661,
-     "y": 0.5143434281782671,
-     "unsure": true
-    },
-    {
-     "x": 0.5585858524206913,
-     "y": 0.5131313069661458,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "3956582084664486": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.46222221605705494,
-     "y": 0.5191919130267519,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "3980741912187626": {
-   "group": "random",
-   "dets": [
-    "unsure",
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.3773737312085701,
-     "y": 0.5846464584812974
-    },
-    {
-     "x": 0.6088888827237215,
-     "y": 0.6064646402994792
-    }
-   ],
-   "no_missed": false
-  },
-  "423989957171190": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5264646402994791,
-     "y": 0.5191919130267519,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "432356313302579": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.2701010039358428,
-     "y": 0.6210100948449337
-    },
-    {
-     "x": 0.271313125147964,
-     "y": 0.6573737312085701
-    },
-    {
-     "x": 0.33737373120857006,
-     "y": 0.5325252463600852
-    },
-    {
-     "x": 0.28585857969341855,
-     "y": 0.5361616099964489,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "662385816800591": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5252525190873579,
-     "y": 0.5143434281782671,
-     "unsure": true
-    },
-    {
-     "x": 0.44464645848129736,
-     "y": 0.5070707009055397
-    }
-   ],
-   "no_missed": false
-  },
-  "780391337668333": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.9604040342388731,
-     "y": 0.531313125147964,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "893023542323690": {
-   "group": "random",
-   "dets": [
-    true,
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1023400645666420": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.7919191857540246,
-     "y": 0.6331313069661458
-    },
-    {
-     "x": 0.2294949433297822,
-     "y": 0.5919191857540246
-    },
-    {
-     "x": 0.43434342817826704,
-     "y": 0.5422222160570549,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1069666650973873": {
-   "group": "random",
-   "dets": [
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1089573432664131": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.0791919130267519,
-     "y": 0.5288888827237216,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1110314244387816": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.4101010039358428,
-     "y": 0.6367676706025095,
-     "unsure": true
-    },
-    {
-     "x": 0.5264646402994791,
-     "y": 0.5470707009055398,
-     "unsure": true
-    },
-    {
-     "x": 0.6985858524206913,
-     "y": 0.5034343372691762,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1185319949364085": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.531313125147964,
-     "y": 0.5361616099964489,
-     "unsure": true
-    },
-    {
-     "x": 0.5131313069661458,
-     "y": 0.5119191857540246
-    },
-    {
-     "x": 0.4458585796934186,
-     "y": 0.508282822117661,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1193579455857033": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1260990361757674": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1294684158910702": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1315788070079167": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5610100948449337,
-     "y": 0.47313130696614586
-    }
-   ],
-   "no_missed": false
-  },
-  "1315844333300588": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.07676767060250947,
-     "y": 0.5494949433297822,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1338631107629110": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5325252463600852,
-     "y": 0.4973737312085701
-    }
-   ],
-   "no_missed": false
-  },
-  "1408179757063785": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1441274599876577": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.046464640299479165,
-     "y": 0.5216161554509943,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1809151763043139": {
-   "group": "random",
-   "dets": [
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "1991198475040883": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5416161554509943,
-     "y": 0.5204040342388732,
-     "unsure": true
-    },
-    {
-     "x": 0.3028282766631155,
-     "y": 0.5240403978752367,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1991876994661275": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.13070706454190342,
-     "y": 0.5288888827237216,
-     "unsure": true
-    },
-    {
-     "x": 0.022222216057054923,
-     "y": 0.531313125147964
-    },
-    {
-     "x": 0.04101009484493371,
-     "y": 0.531313125147964,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "2026086521187684": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "2147631415757748": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "3901547360084831": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "4116269558691031": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5252525190873579,
-     "y": 0.5894949433297823,
-     "unsure": true
-    },
-    {
-     "x": 0.4294949433297822,
-     "y": 0.6670707009055398
-    },
-    {
-     "x": 0.7088888827237216,
-     "y": 0.5337373675722065,
-     "unsure": true
-    },
-    {
-     "x": 0.7337373675722064,
-     "y": 0.5264646402994791,
-     "unsure": true
-    },
-    {
-     "x": 0.8640403978752368,
-     "y": 0.47676767060250946,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "552315380916113": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.5349494887843277,
-     "y": 0.5628282766631155,
-     "unsure": true
-    },
-    {
-     "x": 0.43434342817826704,
-     "y": 0.5179797918146307,
-     "unsure": true
-    },
-    {
-     "x": 0.531313125147964,
-     "y": 0.5167676706025095,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "559372759847379": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "562637219504223": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.42646464029947917,
-     "y": 0.5640403978752367,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "563961506051153": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "591584463734236": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "681333794968062": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "700668799338315": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "775828278323576": {
-   "group": "random",
-   "dets": [
-    "unsure"
-   ],
-   "missed": [
-    {
-     "x": 0.5076767615116003,
-     "y": 0.4428282766631155,
-     "unsure": true
-    },
-    {
-     "x": 0.67737373120857,
-     "y": 0.5373737312085701,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "822353906794602": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "839655921736413": {
-   "group": "random",
-   "dets": [
-    false
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "843075271274817": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [],
-   "no_missed": true
-  },
-  "8726984263984099": {
-   "group": "random",
-   "dets": [
-    true
-   ],
-   "missed": [
-    {
-     "x": 0.502222216057055,
-     "y": 0.5228282766631155,
-     "unsure": true
-    },
-    {
-     "x": 0.10161615545099432,
-     "y": 0.5143434281782671,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1021092976148975": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1078560817421587": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1119166219764581": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1120239902858678": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1148968923952346": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1154113539910333": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1277351374404839": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1279326226723010": {
-   "group": "empty",
-   "dets": [],
-   "missed": [
-    {
-     "x": 0.9763636363636363,
-     "y": 0.5232323201497396,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "1297225628792280": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1403202260886086": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "1976970169406126": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "24127338963626294": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "2456904447834971": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "3808624879384438": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "382838731271782": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "4002322973363581": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "4042244719362475": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "481381621684815": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "612758008575849": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "667461712321088": {
-   "group": "empty",
-   "dets": [],
-   "missed": [
-    {
-     "x": 0.48484848484848486,
-     "y": 0.5353535322709517,
-     "unsure": true
-    },
-    {
-     "x": 0.573939393939394,
-     "y": 0.5183838353012548,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "724492966635485": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "761421883101179": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "785854814030175": {
-   "group": "empty",
-   "dets": [],
-   "missed": [
-    {
-     "x": 0.526060606060606,
-     "y": 0.4965656534830729,
-     "unsure": true
-    },
-    {
-     "x": 0.4672727272727273,
-     "y": 0.4965656534830729,
-     "unsure": true
-    }
-   ],
-   "no_missed": false
-  },
-  "888167256831303": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
-  },
-  "896345989301021": {
-   "group": "empty",
-   "dets": [],
-   "missed": [],
-   "no_missed": true
   }
- }
 }

--- a/rampnet/validation.py
+++ b/rampnet/validation.py
@@ -16,8 +16,11 @@ loads its ``results.jsonl`` + verdicts and calls :func:`collect` / :func:`format
 Verdict schema (one entry per reviewed pano, keyed by pano id):
   - ``dets``:   per-detection verdict, aligned with the pano's detections —
                 ``True`` (correct), ``False`` (incorrect), ``"unsure"``
-                (abstains from both metrics), or ``None`` (not yet judged; the
-                pano is then partially judged and unusable for either metric).
+                (abstains from both metrics), ``"duplicate"`` (a redundant hit on
+                a ramp already counted — a second detection on one physical ramp;
+                scored as a false positive by default, see ``lenient_duplicates``),
+                or ``None`` (not yet judged; the pano is then partially judged and
+                unusable for either metric).
   - ``missed``: reviewer marks for ramps the model missed. Each is a point dict;
                 ``{"unsure": True}`` abstains (kept out of the recall denominator).
   - ``no_missed``: present on entries exported by a gallery with the missed-ramp
@@ -48,6 +51,7 @@ Pools = namedtuple('Pools', [
     'n_judged',       # of those, fully judged (no None verdicts)
     'n_unconfirmed',  # fully-judged panos held out of recall (missed-ramp check unconfirmed)
     'n_unsure',       # detections marked 'unsure' (abstained)
+    'n_duplicate',    # detections marked 'duplicate' (redundant hit on a counted ramp)
     'missed_unsure',  # missed marks flagged unsure (abstained)
     'warnings',       # human-readable notes (e.g. verdict/results mismatch) — presentation-free
 ])
@@ -64,7 +68,8 @@ def wilson_interval(successes, n, z=1.96):
     return (max(0.0, center - margin), min(1.0, center + margin))
 
 
-def collect(panos, confs_by_pid, exclude_top=False, assume_scanned=False):
+def collect(panos, confs_by_pid, exclude_top=False, assume_scanned=False,
+            lenient_duplicates=False):
     """Turn reviewer verdicts into precision/recall pools.
 
     panos:        {pano_id: verdict entry} (see the schema in the module docstring).
@@ -74,6 +79,15 @@ def collect(panos, confs_by_pid, exclude_top=False, assume_scanned=False):
     judged. Recall additionally requires the pano's missed-ramp check to be
     confirmed, so its numerator (correct detections) and denominator (those plus
     confident missed marks) cover the same panos.
+
+    'duplicate' detections (a second hit on a physical ramp already counted) are
+    scored as false positives **by default** — matching rampnet.metrics' one-to-one
+    matching, where the 2nd hit on a GT ramp is an FP, so human-validation and
+    gold-set numbers stay comparable. ``lenient_duplicates=True`` instead abstains
+    on them (the "redundant, excluded" variant, arguably fairer to a deployment
+    whose clustering absorbs duplicate labels). They are always recorded distinctly
+    from 'incorrect' (``n_duplicate``), so both scorings are computable from one
+    verdicts.json.
 
     ``assume_scanned=True`` treats every fully-judged pano as false-negative
     checked, regardless of the per-pano flag — reviewer attestation that they
@@ -94,7 +108,7 @@ def collect(panos, confs_by_pid, exclude_top=False, assume_scanned=False):
     two in sync. Returns a :class:`Pools`.
     """
     judged, recall_judged, missed_total, missed_unsure = [], [], 0, 0
-    n_seen = n_judged = n_unconfirmed = n_unsure = 0
+    n_seen = n_judged = n_unconfirmed = n_unsure = n_duplicate = 0
     warnings = []
     for pid, entry in panos.items():
         if exclude_top and entry.get('group') == 'top':
@@ -108,8 +122,19 @@ def collect(panos, confs_by_pid, exclude_top=False, assume_scanned=False):
             continue  # partially judged: unusable for either metric
         n_judged += 1
         n_unsure += sum(1 for d in entry['dets'] if d == 'unsure')
-        # Decided verdicts only (True/False); 'unsure' abstains from both metrics.
-        pano_judged = [(c, d) for c, d in zip(confs, entry['dets']) if d != 'unsure']
+        n_duplicate += sum(1 for d in entry['dets'] if d == 'duplicate')
+        # Decided verdicts only. 'unsure' abstains from both metrics. 'duplicate'
+        # folds to a false positive (or abstains, under lenient_duplicates); either
+        # way it stays counted separately in n_duplicate.
+        pano_judged = []
+        for c, d in zip(confs, entry['dets']):
+            if d == 'unsure':
+                continue
+            if d == 'duplicate':
+                if lenient_duplicates:
+                    continue
+                d = False
+            pano_judged.append((c, d))
         judged += pano_judged
         fn_checked = True if assume_scanned else (
             (entry['no_missed'] or entry['missed']) if 'no_missed' in entry else True)
@@ -120,7 +145,7 @@ def collect(panos, confs_by_pid, exclude_top=False, assume_scanned=False):
         else:
             n_unconfirmed += 1
     return Pools(judged, recall_judged, missed_total, n_seen, n_judged,
-                 n_unconfirmed, n_unsure, missed_unsure, warnings)
+                 n_unconfirmed, n_unsure, n_duplicate, missed_unsure, warnings)
 
 
 # --- Shared precision/recall primitives -----------------------------------
@@ -161,6 +186,10 @@ def format_report(title, pools, thresholds=THRESHOLDS):
     tp, n_judged_dets = _precision_at(pools.judged)
     fp = n_judged_dets - tp
     lines.append(f"Detections judged:    {n_judged_dets}  (correct {tp}, incorrect {fp})")
+    if pools.n_duplicate:
+        lines.append(f"Detections duplicate: {pools.n_duplicate}  "
+                     f"(redundant hits on an already-counted ramp; folded into the "
+                     f"numbers above per this run's duplicate scoring)")
     if pools.n_unsure:
         lines.append(f"Detections unsure:    {pools.n_unsure}  (abstained — not in precision or recall)")
     lines.append(f"Missed ramps marked:  {pools.missed_total}"

--- a/scripts/gt_gallery.py
+++ b/scripts/gt_gallery.py
@@ -1,0 +1,911 @@
+"""Ground-truth labeling tool: the spot-check gallery, ported onto the benchmark bundle.
+
+Renders a self-contained, single-pano-at-a-time viewer (``index.html``) for producing
+and revising the human ground truth that :mod:`rampnet.validation` scores. A reviewer
+judges every model detection (correct / false positive / duplicate / unsure) *and*
+scans the whole panorama for ramps the model missed, exporting a ``verdicts.json`` that
+``scripts/score_validation.py`` turns into precision/recall.
+
+This is the RampNet home of the tool that used to live in the deployment repo
+(sidewalk-auto-labeler) and re-download imagery through its ``sources/``. Here it
+instead consumes the **benchmark bundle** (issue #21): ``benchmark/<city>/`` with
+``panos/<id>.<ext>`` (native-res images), ``records.jsonl`` (Stage-1 detections + pano
+metadata), and an optional ``verdicts.json`` to prefill for revision. Nothing is
+fetched from the network — the bundle is the single source of pixels and detections.
+
+Fairness note (issue #26 #1): crops and the full-pano view are rendered at the model's
+input resolution (4096x2048), **never** the native image. Mapillary panos are commonly
+11000x5500; showing the reviewer more than the model saw would bias recall. The full
+pano gets pan/zoom so a reviewer scanning for misses sees exactly the model's pixels.
+
+The viewer's verdict schema and its "reviewed" gate mirror :func:`rampnet.validation.collect`
+(``dets`` values ``true``/``false``/``"unsure"``/``"duplicate"``, ``missed`` marks, the
+``no_missed`` false-negative confirmation) — keep the two in sync.
+
+Usage:
+    python scripts/gt_gallery.py benchmark/bend
+    python scripts/gt_gallery.py benchmark/richmond --out /tmp/richmond_gallery
+    python scripts/gt_gallery.py benchmark/bend --resample --sample 80   # re-sample a raw bundle
+
+Then open the printed ``index.html`` (VS Code Live Server, ``python -m http.server``, or
+just open the file), review, click "Export verdicts", and save the download back over
+``benchmark/<city>/verdicts.json`` to re-score.
+"""
+import argparse
+import json
+import math
+import random
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from PIL import Image
+
+# The pipeline runs the model at a fixed 2048x4096 input, so the gallery renders at that
+# same resolution — the fair comparison. Native panos (up to 16384x8192 here) are only
+# ever downscaled to this; they are never shown at full size. See issue #26 #1.
+MODEL_WIDTH, MODEL_HEIGHT = 4096, 2048
+CROP_SIZE = 512        # per-detection close-up, taken at model resolution
+TOP_N_BY_COUNT = 5     # the densest panos are always included (group "top")
+RENDER_WORKERS = 8
+
+# Native panos exceed PIL's decompression-bomb guard (16384x8192 = 134 MP). These are
+# our own vetted benchmark images, so lift the cap rather than have the resize error out.
+Image.MAX_IMAGE_PIXELS = None
+
+# Two validation panos closer than this almost certainly show the same physical curb
+# ramps, so the sampler keeps selected panos at least this far apart: a reviewer never
+# judges the same ramps twice, and precision/recall aren't inflated by correlated
+# duplicates. Well above the Mapillary thinning spacing (~5 m) since that's coverage.
+DEFAULT_MIN_SPACING_M = 30
+
+
+# --- Spatially de-clustered sampler (ported verbatim from the deployment tool) -------
+
+def _haversine_m(lat1, lng1, lat2, lng2):
+    R = 6371000.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp, dl = math.radians(lat2 - lat1), math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * R * math.asin(math.sqrt(a))
+
+
+def _coords(record):
+    """(lat, lng) for a record, or None if it carries no position."""
+    p = record['pano']
+    lat, lng = p.get('lat'), p.get('lng')
+    return (lat, lng) if lat is not None and lng is not None else None
+
+
+class _SpatialIndex:
+    """Grid of accepted points for fast 'is anything within min_spacing?' checks.
+
+    Cell size == min_spacing, so any point within range lies in one of the nine
+    neighbouring cells — the acceptance test touches a handful of points, not the
+    whole accepted set, so selection stays cheap on city-sized candidate pools.
+    """
+
+    def __init__(self, min_spacing):
+        self.s = max(min_spacing, 1e-9)
+        self.cells = {}
+
+    def _key(self, lat, lng):
+        clat = self.s / 111320.0
+        clng = self.s / (111320.0 * max(0.01, math.cos(math.radians(lat))))
+        return (math.floor(lat / clat), math.floor(lng / clng))
+
+    def far_enough(self, lat, lng):
+        kx, ky = self._key(lat, lng)
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for plat, plng in self.cells.get((kx + dx, ky + dy), ()):
+                    if _haversine_m(lat, lng, plat, plng) < self.s:
+                        return False
+        return True
+
+    def add(self, lat, lng):
+        self.cells.setdefault(self._key(lat, lng), []).append((lat, lng))
+
+
+def _spread(candidates, k, index, min_spacing):
+    """Greedily take up to k candidates (in the given order) that sit at least
+    min_spacing metres from every already-accepted point in the shared `index`.
+
+    Records without coordinates are accepted without constraint (graceful degradation —
+    a coordinate-less run can't be de-clustered, but must still render). Returns
+    (picked, rejected_for_spacing)."""
+    picked, rejected = [], 0
+    for rec in candidates:
+        if len(picked) >= k:
+            break
+        c = _coords(rec)
+        if c is None:
+            picked.append(rec)
+        elif min_spacing <= 0 or index.far_enough(*c):
+            picked.append(rec)
+            index.add(*c)
+        else:
+            rejected += 1
+    return picked, rejected
+
+
+def choose_panos(records, sample, empty_sample, seed, min_spacing=DEFAULT_MIN_SPACING_M):
+    """Return [(record, group)] for a spatially de-clustered validation sample.
+
+    Three strata, all held at least `min_spacing` metres apart — *across* strata as well
+    as within — so a reviewer never judges the same physical ramps twice and the
+    precision/recall estimate isn't inflated by correlated duplicates:
+      - 'top':    the densest *distinct* intersections (up to TOP_N_BY_COUNT) — a
+                  dense-scene stress test, excluded from unbiased scoring.
+      - 'random': a spatially spread sample of panos with detections.
+      - 'empty':  a spatially spread sample of zero-detection panos (for recall).
+
+    Deterministic given `seed`. `min_spacing=0` disables spacing (pure random). Records
+    without lat/lng are included unconstrained. City-agnostic by design.
+    """
+    rng = random.Random(seed)
+    with_det = [r for r in records if r['detections']]
+    without_det = [r for r in records if not r['detections']]
+    index = _SpatialIndex(min_spacing)
+
+    # top: densest first, but only one pano per distinct location.
+    by_density = sorted(with_det, key=lambda r: len(r['detections']), reverse=True)
+    top, _ = _spread(by_density, TOP_N_BY_COUNT, index, min_spacing)
+    top_ids = {r['pano']['panorama_id'] for r in top}
+
+    # random: spread across the remaining detection panos.
+    rest = [r for r in with_det if r['pano']['panorama_id'] not in top_ids]
+    rng.shuffle(rest)
+    n_random = max(0, sample - len(top))
+    random_sel, rej_r = _spread(rest, n_random, index, min_spacing)
+
+    # empty: spread across the zero-detection panos.
+    empties = list(without_det)
+    rng.shuffle(empties)
+    empty_sel, rej_e = _spread(empties, empty_sample, index, min_spacing)
+
+    # No silent caps: if spacing (not scarcity) kept us short of a target, say so.
+    if min_spacing > 0 and rej_r and len(random_sel) < n_random:
+        print(f"  spatial sampling: kept {len(random_sel)}/{n_random} detection panos "
+              f"at >= {min_spacing} m spacing (area too dense for more).")
+    if min_spacing > 0 and rej_e and len(empty_sel) < empty_sample:
+        print(f"  spatial sampling: kept {len(empty_sel)}/{empty_sample} empty panos "
+              f"at >= {min_spacing} m spacing.")
+
+    return ([(r, 'top') for r in top]
+            + [(r, 'random') for r in random_sel]
+            + [(r, 'empty') for r in empty_sel])
+
+
+# --- Bundle I/O + rendering ----------------------------------------------------------
+
+def load_bundle(bundle_dir):
+    """Read a benchmark bundle: records, the panos dir, and any existing verdicts.
+
+    Returns (records, panos_dir, verdicts_panos, run_key, run_name). verdicts_panos is
+    the ``panos`` map from an existing verdicts.json (for prefill/revision) or {}.
+    """
+    d = Path(bundle_dir)
+    records_path, panos_dir = d / "records.jsonl", d / "panos"
+    if not records_path.exists():
+        sys.exit(f"Bundle must contain records.jsonl: {records_path}")
+    if not panos_dir.is_dir():
+        sys.exit(f"Bundle must contain a panos/ directory (native-res images): {panos_dir}")
+
+    with open(records_path, encoding="utf-8") as f:
+        records = [json.loads(line) for line in f if line.strip()]
+
+    verdicts_panos, run_key, run_name = {}, d.name, d.name
+    verdicts_path = d / "verdicts.json"
+    if verdicts_path.exists():
+        vj = json.load(open(verdicts_path, encoding="utf-8"))
+        verdicts_panos = vj.get("panos", {})
+        run_key = vj.get("run_key", run_key)
+        run_name = vj.get("run_name", run_name)
+    return records, panos_dir, verdicts_panos, run_key, run_name
+
+
+def _find_pano_image(panos_dir, pid):
+    """The on-disk image for a pano id (any extension), or None."""
+    for p in sorted(panos_dir.glob(f"{pid}.*")):
+        if p.suffix.lower() in (".jpg", ".jpeg", ".png", ".webp"):
+            return p
+    return None
+
+
+def _crop_boxes(record):
+    """Per-detection (crop-box, geometry-dict) at model resolution. Geometry is a pure
+    function of the normalized detections and the fixed model size (no pixels needed),
+    so it's shared by image rendering and the --html-only path.
+    """
+    pid, sx, sy = record['pano']['panorama_id'], MODEL_WIDTH, MODEL_HEIGHT
+    out = []
+    for i, det in enumerate(record['detections']):
+        px, py = det['x_normalized'] * sx, det['y_normalized'] * sy
+        half = CROP_SIZE // 2
+        left = int(min(max(px - half, 0), sx - CROP_SIZE))
+        top = int(min(max(py - half, 0), sy - CROP_SIZE))
+        geom = {'img': f"{pid}_det{i}.jpg", 'conf': round(det['confidence'], 4),
+                # detection center: normalized in the pano, and in the crop
+                'x': round(det['x_normalized'], 5),
+                'y': round(det['y_normalized'], 5),
+                'cx': round((px - left) / CROP_SIZE, 4),
+                'cy': round((py - top) / CROP_SIZE, 4)}
+        out.append(((left, top, left + CROP_SIZE, top + CROP_SIZE), geom))
+    return out
+
+
+def entry_meta(record, group):
+    """The viewer entry (pano metadata + crop geometry) for one record, without any I/O."""
+    pano = record['pano']
+    return {
+        'pid': pano['panorama_id'],
+        'source': pano.get('source', ''),
+        'date': str(pano.get('capture_date', '')),
+        'group': group,
+        'full': f"{pano['panorama_id']}_full.jpg",
+        'crops': [g for _, g in _crop_boxes(record)],
+    }
+
+
+def render_pano(record, group, images_dir, panos_dir):
+    """Downscale one native pano to model resolution, save the clean full image and
+    per-detection crops, and return the viewer entry (see :func:`entry_meta`).
+
+    Images are saved clean (no burned-in markers) so the viewer can recolor detections
+    live as verdicts change. Crops and the full image are taken at MODEL_WIDTH x
+    MODEL_HEIGHT — the model's input size, never the native resolution (#26 #1).
+    """
+    pid = record['pano']['panorama_id']
+    src = _find_pano_image(panos_dir, pid)
+    if src is None:
+        raise FileNotFoundError(f"no image in {panos_dir} for {pid}")
+
+    # Downscale native -> model resolution once; all geometry is relative to that.
+    img = Image.open(src).convert('RGB')
+    if img.size != (MODEL_WIDTH, MODEL_HEIGHT):
+        img = img.resize((MODEL_WIDTH, MODEL_HEIGHT), Image.BILINEAR)
+
+    for box, geom in _crop_boxes(record):
+        img.crop(box).save(images_dir / geom['img'], quality=85)
+    img.save(images_dir / f"{pid}_full.jpg", quality=82)
+    return entry_meta(record, group)
+
+
+def initial_verdicts(verdicts_panos):
+    """Convert a bundle verdicts.json ``panos`` map to the viewer's localStorage schema,
+    so an existing bundle prefills for revision (e.g. to add the duplicate marks #26 #5
+    calls out on Richmond). Bundle uses ``no_missed``; the viewer uses ``noMissed`` +
+    ``seen``. dets values (incl. ``"duplicate"``) carry over unchanged.
+    """
+    out = {}
+    for pid, e in verdicts_panos.items():
+        out[pid] = {'dets': e.get('dets', []), 'missed': e.get('missed', []),
+                    'noMissed': bool(e.get('no_missed', False)), 'seen': True}
+    return out
+
+
+HTML_TEMPLATE = r"""<!doctype html>
+<meta charset="utf-8">
+<title>RampNet ground-truth labeler</title>
+<style>
+  :root{--ok:#1a9c3e;--bad:#d23;--dup:#8338ec;--unsure:#ff9f1c;--missed:#e534eb;--todo:#ffd400}
+  body{font-family:sans-serif;margin:16px auto;max-width:1650px;background:#fafafa;color:#222}
+  a{color:#06c}
+  .bar{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px}
+  .bar button,.bar select{font-size:15px;padding:6px 13px;cursor:pointer}
+  .meta{color:#666;font-size:13px}
+  .badge{font-size:12px;padding:2px 8px;border-radius:10px;background:#eee;color:#555}
+  #intro{background:#fff6e6;border:1px solid var(--unsure);border-radius:8px;padding:10px 14px;
+         margin:0 0 12px;font-size:14px;line-height:1.45}
+  #intro b{color:#a35a00}
+  #legend{display:flex;gap:16px;flex-wrap:wrap;align-items:center;background:#fff;border:1px solid #e2e2e2;
+          border-radius:8px;padding:7px 12px;margin:0 0 12px;font-size:13px;position:sticky;top:0;z-index:5}
+  #legend .k{display:inline-flex;align-items:center;gap:6px}
+  #legend .sw{width:16px;height:16px;border-radius:50%;border:4px solid #000;box-sizing:border-box}
+  /* Swatch modifiers are namespaced (k-*) so they never collide with the functional
+     overlay/crop classes (e.g. a bare `.missed` would drag the swatch out of flow), and
+     scoped under #legend so their colour out-specifies the `#legend .sw` base. */
+  #legend .sw.k-todo{border-color:var(--todo)}
+  #legend .sw.k-ok{border-color:var(--ok)}
+  #legend .sw.k-bad{border-color:var(--bad)}
+  #legend .sw.k-dup{border-color:var(--dup)}
+  #legend .sw.k-unsure{border-color:var(--unsure)}
+  #legend .sw.k-missed{border-color:var(--missed);border-style:dashed}
+  #rev{font-weight:bold;padding:3px 10px;border-radius:12px}
+  #rev.done{background:var(--ok);color:#fff}
+  #rev.todo{background:#fde2e2;color:var(--bad);border:1px solid var(--bad)}
+  #panoview{position:relative;width:100%;aspect-ratio:2/1;overflow:hidden;background:#111;
+            border-radius:6px;cursor:crosshair;touch-action:none}
+  #zoompill{position:absolute;top:8px;right:8px;background:rgba(0,0,0,.72);color:#fff;
+            font:600 12px/1 sans-serif;padding:4px 9px;border-radius:12px;pointer-events:none;
+            z-index:6;display:none}
+  /* Transient label that names the verdict right after a click, so the state change
+     is legible without hunting for the crop's caption. */
+  #vflash{position:fixed;transform:translate(-50%,-100%);background:#000;color:#fff;
+          font:bold 13px/1 sans-serif;padding:4px 10px;border-radius:12px;white-space:nowrap;
+          pointer-events:none;opacity:0;z-index:50;box-shadow:0 1px 6px rgba(0,0,0,.5)}
+  #vflash.show{animation:vflash 1.1s ease forwards}
+  @keyframes vflash{0%{opacity:0}12%{opacity:1}70%{opacity:1}100%{opacity:0}}
+  #panolayer{position:absolute;inset:0;transform-origin:0 0;will-change:transform}
+  #panolayer img{width:100%;height:100%;display:block;user-select:none;-webkit-user-drag:none}
+  .det{position:absolute;width:34px;height:34px;transform:translate(-50%,-50%) scale(var(--iz,1));
+       border-radius:50%;border:4px solid var(--todo);
+       box-shadow:0 0 0 3px rgba(255,255,255,.85),0 0 6px #000;cursor:pointer}
+  .det.ok{border-color:var(--ok)}
+  .det.bad{border-color:var(--bad)}
+  .det.dup{border-color:var(--dup)}
+  .det.unsure{border-color:var(--unsure)}
+  .det .num{position:absolute;top:-21px;left:50%;transform:translateX(-50%);
+            font:bold 13px/1 sans-serif;color:#fff;text-shadow:0 0 3px #000,0 0 3px #000}
+  .missed{position:absolute;width:36px;height:36px;transform:translate(-50%,-50%) scale(var(--iz,1));
+          border:4px dashed var(--missed);border-radius:50%;box-shadow:0 0 4px #000;
+          cursor:pointer;background:rgba(229,52,235,.12)}
+  .missed.unsure{border-color:var(--unsure);background:rgba(255,159,28,.14)}
+  #zoombar{display:flex;gap:6px;align-items:center;margin:6px 0 0}
+  #zoombar button{font-size:14px;padding:3px 10px;cursor:pointer}
+  #fnbar{margin:10px 0 0;padding:10px 14px;border-radius:8px;display:flex;gap:12px;
+         align-items:center;flex-wrap:wrap;border:2px solid}
+  #fnbar.pending{background:#fde8e8;border-color:var(--bad)}
+  #fnbar.done{background:#e9f7ee;border-color:var(--ok)}
+  #fnbar button{font-size:15px;padding:6px 14px;cursor:pointer}
+  #nomiss.active{background:var(--ok);border:1px solid var(--ok);color:#fff}
+  h3.section{margin:16px 0 6px;font-size:15px}
+  .crops{display:flex;flex-wrap:wrap;gap:10px;line-height:0}
+  .crops figure{margin:0;text-align:center;font-size:13px;line-height:1.3;cursor:pointer}
+  .cropwrap{position:relative;display:inline-block;line-height:0;border:5px solid #bbb;border-radius:4px}
+  .crops img{width:256px;height:256px;border-radius:2px;display:block}
+  .crops .ok .cropwrap{border-color:var(--ok)}
+  .crops .bad .cropwrap{border-color:var(--bad)}
+  .crops .dup .cropwrap{border-color:var(--dup)}
+  .crops .unsure .cropwrap{border-color:var(--unsure)}
+  .cropring{position:absolute;width:15.6%;height:15.6%;transform:translate(-50%,-50%);
+            border:3px solid var(--todo);border-radius:50%;
+            box-shadow:0 0 0 2px rgba(255,255,255,.85);pointer-events:none}
+  .ok .cropring{border-color:var(--ok)}.bad .cropring{border-color:var(--bad)}
+  .dup .cropring{border-color:var(--dup)}.unsure .cropring{border-color:var(--unsure)}
+  .crops .verdict{font-weight:bold}
+  .ok .verdict{color:var(--ok)}.bad .verdict{color:var(--bad)}
+  .dup .verdict{color:var(--dup)}.unsure .verdict{color:var(--unsure)}
+  #missedpanel figure{border:4px solid var(--missed);border-radius:4px;padding:0;background:#fff}
+  #missedpanel figure.unsure{border-color:var(--unsure)}
+  #missedpanel canvas{width:180px;height:180px;display:block;border-radius:2px}
+  #missedpanel figcaption{font-size:12px;padding:3px}
+  #missedpanel .mbtn{font-size:12px;padding:2px 6px;margin:0 2px 3px;cursor:pointer}
+  #missedempty{color:#888;font-size:13px}
+  #help{font-size:13px;color:#666;margin-top:16px;line-height:1.5}
+  kbd{background:#eee;border:1px solid #ccc;border-radius:3px;padding:0 4px;font-size:12px}
+</style>
+
+<div id="intro">
+  <b>This is a two-sided check.</b> For every pano you must do <b>both</b>:
+  (1) judge each model detection — correct, false positive, duplicate (a 2nd hit on one
+  ramp), or unsure; and (2) <b>scan the whole panorama</b> for curb ramps the model
+  <b>missed</b>, then mark them or confirm there are none. Reviewers consistently
+  under-count misses, so a pano is not <b>done</b> until every detection is judged
+  <b>and</b> the missed-ramp pass is confirmed. Use pan/zoom to inspect at the model's
+  full resolution.
+</div>
+
+<div id="legend">
+  <span class="meta">Legend:</span>
+  <span class="k"><span class="sw k-todo"></span>unjudged</span>
+  <span class="k"><span class="sw k-ok"></span>correct</span>
+  <span class="k"><span class="sw k-bad"></span>false positive</span>
+  <span class="k"><span class="sw k-dup"></span>duplicate</span>
+  <span class="k"><span class="sw k-unsure"></span>unsure</span>
+  <span class="k"><span class="sw k-missed"></span>reviewer-marked missed</span>
+</div>
+
+<div class="bar">
+  <button id="prev">&#8592; Prev</button>
+  <button id="next">Next &#8594;</button>
+  <button id="nexttodo">Next unreviewed &#8608;</button>
+  <select id="filter">
+    <option value="all">All panos</option>
+    <option value="det">With detections</option>
+    <option value="empty">Zero detections</option>
+    <option value="todo">Unreviewed</option>
+  </select>
+  <span id="pos" class="meta"></span>
+  <span id="progress" class="meta"></span>
+  <span style="flex:1"></span>
+  <button id="export">Export verdicts</button>
+</div>
+
+<h2 id="title" style="margin:6px 0;font-size:17px"></h2>
+<div id="panoview"><div id="panolayer"><img id="panoimg" alt=""></div><div id="zoompill"></div></div>
+<div id="zoombar">
+  <button id="zoomout">&#8722;</button><button id="zoomin">+</button>
+  <button id="zoomreset">Reset</button>
+  <span class="meta">scroll to zoom, drag to pan, click empty pano to mark a missed ramp
+    &mdash; this pano <b>is</b> the model's input (4096&times;2048); the pill shows how much of that
+    resolution you're seeing. Zoom reaches model 1:1 but never beyond &mdash; magnifying shows the
+    same pixels bigger, never more than the model saw.</span>
+</div>
+
+<div id="fnbar">
+  <button id="nomiss">No missed ramps (m)</button>
+  <span id="fnstate" class="meta"></span>
+</div>
+
+<h3 class="section">Detection crops <span class="meta">&mdash; click or press 1&ndash;9 to cycle a verdict</span></h3>
+<div class="crops" id="crops"></div>
+
+<h3 class="section">Reviewer-marked missed ramps</h3>
+<div class="crops" id="missedpanel"></div>
+<div id="missedempty">None marked yet. Scan the pano above and click any curb ramp the model missed.</div>
+
+<p id="help">
+  <kbd>&#8592;</kbd>/<kbd>&#8594;</kbd> pano &nbsp;&middot;&nbsp;
+  <kbd>1</kbd>&#8211;<kbd>9</kbd> cycle a crop's verdict
+  (unjudged &#8594; <span style="color:var(--ok)">correct</span> &#8594;
+  <span style="color:var(--bad)">false positive</span> &#8594;
+  <span style="color:var(--dup)">duplicate</span> &#8594;
+  <span style="color:var(--unsure)">unsure</span>) &nbsp;&middot;&nbsp;
+  click the pano to mark a <span style="color:var(--missed)">missed</span> ramp (click the marker to
+  make it <span style="color:var(--unsure)">unsure</span>, again to remove), or press <kbd>m</kbd> if
+  there are none &nbsp;&middot;&nbsp; <b>duplicate</b> = a redundant hit on a ramp already counted
+  (scored as a false positive by default) &nbsp;&middot;&nbsp; <b>unsure</b> abstains (dropped from
+  precision &amp; recall) &nbsp;&middot;&nbsp; verdicts autosave locally; Export downloads
+  <span id="vname"></span> &mdash; save it back over <code>benchmark/&lt;city&gt;/verdicts.json</code>, then
+  <code>python scripts/score_validation.py benchmark/&lt;city&gt;</code>
+</p>
+
+<script>
+const ENTRIES = __ENTRIES__;
+const MODEL_W = __MODEL_W__;   // the served pano is exactly this wide (the model's input res)
+const RUN_KEY = __RUN_KEY__;
+const RUN_NAME = __RUN_NAME__;
+const SOURCE = __SOURCE__;
+const INITIAL = __INITIAL__;   // prefill from the bundle's verdicts.json (schema below)
+const STORE = 'verdicts:' + RUN_KEY;
+
+let verdicts = JSON.parse(localStorage.getItem(STORE) || '{}');
+// verdicts[pid] = {dets: [null|true|false|'unsure'|'duplicate', ...],
+//                  missed: [{x, y, unsure?: bool}, ...],
+//                  noMissed: bool (reviewer confirmed no missed ramps), seen: bool}
+// 'unsure' (crop) and unsure:true (missed) mean "can't tell" — the scorer abstains on
+// them. 'duplicate' is a redundant hit on a ramp already counted (scored as an FP by
+// default). Kept in sync with rampnet.validation.collect().
+// Prefill from the bundle without clobbering any local progress already in this browser.
+for (const pid in INITIAL) if (!(pid in verdicts)) verdicts[pid] = INITIAL[pid];
+
+function save() { localStorage.setItem(STORE, JSON.stringify(verdicts)); }
+function v(pid, n) {
+  if (!verdicts[pid]) verdicts[pid] = {dets: Array(n).fill(null), missed: [], noMissed: false, seen: false};
+  const s = verdicts[pid];
+  // A re-render with a different detection count (new model/threshold) invalidates the
+  // stored crop verdicts; reset them (missed marks + no-missed are pano-level, kept).
+  if (s.dets.length !== n) s.dets = Array(n).fill(null);
+  return s;
+}
+
+let filterMode = 'all', view = ENTRIES.slice(), idx = 0;
+
+// vcls/fnChecked/reviewed define what "reviewed" means; rampnet.validation.collect()
+// applies the same gate to the exported verdicts — keep the two in sync.
+function vcls(d) { return d === true ? 'ok' : d === false ? 'bad'
+                       : d === 'duplicate' ? 'dup' : d === 'unsure' ? 'unsure' : ''; }
+function vlabel(d) { return d === true ? 'correct' : d === false ? 'FALSE POSITIVE'
+                       : d === 'duplicate' ? 'duplicate' : d === 'unsure' ? 'unsure' : 'unjudged'; }
+function fnChecked(s) { return s.missed.length > 0 || !!s.noMissed; }
+function reviewed(e) {
+  const s = verdicts[e.pid];
+  if (!s || !s.seen || !fnChecked(s)) return false;
+  if (s.dets.length !== e.crops.length) return false; // stale entry, see v()
+  return s.dets.every(d => d !== null);
+}
+
+function applyFilter() {
+  const cur = view[idx] && view[idx].pid;
+  view = ENTRIES.filter(e =>
+    filterMode === 'det' ? e.crops.length > 0 :
+    filterMode === 'empty' ? e.crops.length === 0 :
+    filterMode === 'todo' ? !reviewed(e) : true);
+  if (!view.length) { idx = 0; render(); return; }
+  const keep = view.findIndex(e => e.pid === cur);
+  idx = keep >= 0 ? keep : 0;
+  render();
+}
+
+// --- Pan/zoom (capped at model resolution: the served image is already 4096-wide, so
+// zooming never reveals more than the model saw; issue #26 #1). -----------------------
+const view_el = document.getElementById('panoview');
+const layer = document.getElementById('panolayer');
+const panoImg = document.getElementById('panoimg');
+let zoom = 1, panX = 0, panY = 0;
+const MAXZOOM = 8;
+
+function vp() { const r = view_el.getBoundingClientRect(); return {w: r.width, h: r.height}; }
+function clampPan() {
+  const {w, h} = vp();
+  panX = Math.min(0, Math.max(w - w * zoom, panX));
+  panY = Math.min(0, Math.max(h - h * zoom, panY));
+}
+function applyTransform() {
+  clampPan();
+  layer.style.transform = 'translate(' + panX + 'px,' + panY + 'px) scale(' + zoom + ')';
+  // Counter-scale overlays so markers stay a constant, clickable size at any zoom.
+  document.querySelectorAll('.det, .missed').forEach(m => m.style.setProperty('--iz', 1 / zoom));
+  updatePill();
+}
+
+// The pill answers "am I seeing what the model saw?" — NOT a zoom factor. The served
+// pano is exactly the model's input width (MODEL_W), so `frac` is the share of the
+// model's horizontal resolution actually resolved on screen right now (device pixels
+// included). It tops out at 1:1: you can reach model parity but never exceed it — past
+// that you're only magnifying the same model pixels, seeing them bigger, not seeing more.
+function updatePill() {
+  const zp = document.getElementById('zoompill');
+  const dpr = window.devicePixelRatio || 1;
+  const frac = vp().w * zoom * dpr / MODEL_W;
+  zp.style.display = 'block';
+  zp.textContent = frac < 0.995 ? Math.round(frac * 100) + '% of model res'
+    : 'model res 1:1' + (frac > 1.05 ? ' · ' + frac.toFixed(1) + '× magnified' : '');
+}
+window.addEventListener('resize', () => { if (view.length) applyTransform(); });
+function resetZoom() { zoom = 1; panX = 0; panY = 0; applyTransform(); }
+function zoomAt(cx, cy, factor) {
+  const oldZoom = zoom;
+  zoom = Math.min(MAXZOOM, Math.max(1, zoom * factor));
+  panX = cx - (cx - panX) * (zoom / oldZoom);
+  panY = cy - (cy - panY) * (zoom / oldZoom);
+  applyTransform();
+}
+view_el.addEventListener('wheel', ev => {
+  ev.preventDefault();
+  const r = view_el.getBoundingClientRect();
+  zoomAt(ev.clientX - r.left, ev.clientY - r.top, ev.deltaY < 0 ? 1.2 : 1 / 1.2);
+}, {passive: false});
+document.getElementById('zoomin').onclick = () => { const {w, h} = vp(); zoomAt(w / 2, h / 2, 1.4); };
+document.getElementById('zoomout').onclick = () => { const {w, h} = vp(); zoomAt(w / 2, h / 2, 1 / 1.4); };
+document.getElementById('zoomreset').onclick = resetZoom;
+
+// Drag to pan; a press that barely moves is a click-to-mark instead.
+let down = null;
+view_el.addEventListener('pointerdown', ev => {
+  if (ev.target.closest('.det, .missed')) return;   // let marker handlers run
+  down = {x: ev.clientX, y: ev.clientY, panX, panY, moved: false};
+  view_el.setPointerCapture(ev.pointerId);
+});
+view_el.addEventListener('pointermove', ev => {
+  if (!down) return;
+  const dx = ev.clientX - down.x, dy = ev.clientY - down.y;
+  if (Math.abs(dx) > 4 || Math.abs(dy) > 4) down.moved = true;
+  if (down.moved) { panX = down.panX + dx; panY = down.panY + dy; applyTransform(); }
+});
+view_el.addEventListener('pointerup', ev => {
+  if (!down) return;
+  const wasDrag = down.moved;
+  down = null;
+  if (wasDrag || !view.length) return;
+  // Click on empty pano -> mark a missed ramp. Map screen px back through the transform.
+  const r = view_el.getBoundingClientRect();
+  const nx = ((ev.clientX - r.left) - panX) / (r.width * zoom);
+  const ny = ((ev.clientY - r.top) - panY) / (r.height * zoom);
+  if (nx < 0 || nx > 1 || ny < 0 || ny > 1) return;
+  const e = view[idx], s = v(e.pid, e.crops.length);
+  s.missed.push({x: nx, y: ny});
+  s.noMissed = false;
+  save(); render();
+});
+
+// --- Rendering -----------------------------------------------------------------------
+function render() {
+  const done = ENTRIES.filter(reviewed).length;
+  document.getElementById('progress').textContent = done + '/' + ENTRIES.length + ' fully reviewed';
+  document.querySelectorAll('.missed, .det').forEach(m => m.remove());
+  if (!view.length) {
+    document.getElementById('title').textContent = 'No panos match this filter';
+    panoImg.removeAttribute('src');
+    document.getElementById('crops').innerHTML = '';
+    document.getElementById('fnbar').style.display = 'none';
+    document.getElementById('pos').textContent = '';
+    renderMissed();
+    return;
+  }
+  document.getElementById('fnbar').style.display = '';
+  const e = view[idx];
+  const s = v(e.pid, e.crops.length);
+  s.seen = true; save();
+  resetZoom();
+
+  document.getElementById('pos').textContent = (idx + 1) + ' / ' + view.length;
+  const viewerUrl = e.source === 'mapillary'
+    ? 'https://www.mapillary.com/app/?pKey=' + e.pid + '&focus=photo'
+    : 'https://www.google.com/maps/@?api=1&map_action=pano&pano=' + e.pid;
+  const isDone = reviewed(e);
+  document.getElementById('title').innerHTML =
+    '<a href="' + viewerUrl + '" target="_blank">' + e.pid + '</a> ' +
+    '<span class="meta">captured ' + e.date + ' &mdash; ' + e.crops.length + ' detection(s)</span> ' +
+    '<span class="badge">' + e.group + '</span> ' +
+    '<span id="rev" class="' + (isDone ? 'done' : 'todo') + '">' +
+      (isDone ? '✓ REVIEWED' : '● NEEDS REVIEW') + '</span>';
+  panoImg.src = 'images/' + e.full;
+
+  // Detection circles overlaid on the clean pano image.
+  e.crops.forEach((c, i) => {
+    const d = document.createElement('div');
+    d.className = ('det ' + vcls(s.dets[i])).trim();
+    d.style.left = (c.x * 100) + '%';
+    d.style.top = (c.y * 100) + '%';
+    d.innerHTML = '<span class="num">' + (i + 1) + '</span>';
+    d.title = 'detection ' + (i + 1) + ' — click to cycle verdict';
+    d.onclick = ev => { ev.stopPropagation(); cycle(i, 'pano'); };
+    layer.appendChild(d);
+  });
+  s.missed.forEach((m, i) => {
+    const d = document.createElement('div');
+    d.className = 'missed' + (m.unsure ? ' unsure' : '');
+    d.style.left = (m.x * 100) + '%';
+    d.style.top = (m.y * 100) + '%';
+    d.title = m.unsure ? 'unsure missed ramp — click to remove'
+                       : 'missed ramp — click to mark unsure, again to remove';
+    d.onclick = ev => { ev.stopPropagation();
+      if (!m.unsure) m.unsure = true; else s.missed.splice(i, 1);
+      save(); render();
+    };
+    layer.appendChild(d);
+  });
+  applyTransform();
+
+  // Missed-ramp confirmation bar — structural: it stays "pending" (red) until the
+  // reviewer marks a miss or affirms none, so the FN pass can't be silently skipped.
+  const affirmed = !!s.noMissed && !s.missed.length;
+  const nSure = s.missed.filter(m => !m.unsure).length;
+  const nUnsure = s.missed.filter(m => m.unsure).length;
+  const fnbar = document.getElementById('fnbar');
+  const nm = document.getElementById('nomiss');
+  const fnDone = fnChecked(s);
+  fnbar.className = fnDone ? 'done' : 'pending';
+  nm.disabled = s.missed.length > 0;
+  nm.classList.toggle('active', affirmed);
+  nm.textContent = affirmed ? '✓ No missed ramps' : 'No missed ramps (m)';
+  document.getElementById('fnstate').textContent =
+    s.missed.length ? (nSure + ' missed ramp(s) marked' + (nUnsure ? ', ' + nUnsure + ' unsure' : '')) :
+    affirmed ? 'missed-ramp check confirmed' :
+    'REQUIRED: scan the whole panorama for ramps the model missed, then mark them or confirm none';
+
+  // Detection crops with verdict state.
+  const crops = document.getElementById('crops');
+  crops.innerHTML = '';
+  e.crops.forEach((c, i) => {
+    const fig = document.createElement('figure');
+    fig.className = vcls(s.dets[i]);
+    fig.innerHTML = '<span class="cropwrap"><img src="images/' + c.img + '" loading="lazy">' +
+      '<span class="cropring" style="left:' + (c.cx * 100) + '%;top:' + (c.cy * 100) + '%"></span></span>' +
+      '<figcaption>[' + (i + 1) + '] conf ' + c.conf.toFixed(2) +
+      ' &mdash; <span class="verdict">' + vlabel(s.dets[i]) + '</span></figcaption>';
+    fig.onclick = () => cycle(i, 'crop');
+    crops.appendChild(fig);
+  });
+  renderMissed();
+}
+
+// Missed-ramp panel: crop each marked location client-side from the full (model-res)
+// pano so added false-negatives are reviewable/removable at a glance (issue #26 #2).
+function renderMissed() {
+  const panel = document.getElementById('missedpanel');
+  const empty = document.getElementById('missedempty');
+  panel.innerHTML = '';
+  const e = view[idx];
+  const s = e && verdicts[e.pid];
+  const marks = (s && s.missed) || [];
+  empty.style.display = (view.length && !marks.length) ? '' : 'none';
+  if (!marks.length) return;
+  const NW = panoImg.naturalWidth, NH = panoImg.naturalHeight;
+  marks.forEach((m, i) => {
+    const fig = document.createElement('figure');
+    if (m.unsure) fig.className = 'unsure';
+    const cv = document.createElement('canvas');
+    cv.width = 180; cv.height = 180;
+    if (NW && panoImg.complete) {
+      const C = Math.min(512, NW, NH);
+      let sx = Math.round(m.x * NW - C / 2), sy = Math.round(m.y * NH - C / 2);
+      sx = Math.max(0, Math.min(sx, NW - C)); sy = Math.max(0, Math.min(sy, NH - C));
+      try { cv.getContext('2d').drawImage(panoImg, sx, sy, C, C, 0, 0, 180, 180); } catch (err) {}
+    }
+    fig.appendChild(cv);
+    const cap = document.createElement('figcaption');
+    cap.innerHTML = 'missed' + (m.unsure ? ' <b style="color:var(--unsure)">(unsure)</b>' : '') + '<br>';
+    const bU = document.createElement('button');
+    bU.className = 'mbtn'; bU.textContent = m.unsure ? 'mark sure' : 'mark unsure';
+    bU.onclick = () => { m.unsure = !m.unsure; save(); render(); };
+    const bX = document.createElement('button');
+    bX.className = 'mbtn'; bX.textContent = 'remove';
+    bX.onclick = () => { s.missed.splice(i, 1); save(); render(); };
+    cap.appendChild(bU); cap.appendChild(bX);
+    fig.appendChild(cap);
+    panel.appendChild(fig);
+  });
+}
+// The full image may still be decoding when render() runs; fill the crops once it loads.
+panoImg.addEventListener('load', renderMissed);
+
+// Transient "correct / false positive / ..." label next to whatever the reviewer just
+// clicked, so the new state registers immediately (issue #26 feedback).
+const VCOLOR = {ok: 'var(--ok)', bad: 'var(--bad)', dup: 'var(--dup)', unsure: 'var(--unsure)'};
+let flashEl = null;
+function flashVerdict(anchor, d) {
+  if (!anchor) return;
+  if (!flashEl) { flashEl = document.createElement('div'); flashEl.id = 'vflash'; document.body.appendChild(flashEl); }
+  const r = anchor.getBoundingClientRect();
+  flashEl.textContent = vlabel(d);
+  flashEl.style.color = VCOLOR[vcls(d)] || '#fff';
+  flashEl.style.left = (r.left + r.width / 2) + 'px';
+  flashEl.style.top = (r.top - 6) + 'px';
+  flashEl.classList.remove('show'); void flashEl.offsetWidth; flashEl.classList.add('show');  // restart anim
+}
+
+function cycle(i, origin) {
+  const e = view[idx];
+  if (!e || i >= e.crops.length) return;
+  const s = v(e.pid, e.crops.length);
+  s.dets[i] = s.dets[i] === null ? true
+            : s.dets[i] === true ? false
+            : s.dets[i] === false ? 'duplicate'
+            : s.dets[i] === 'duplicate' ? 'unsure'
+            : null;
+  save(); render();
+  // Anchor the flash to whatever was clicked (the crop, or the pano circle / keyboard).
+  const anchor = origin === 'crop'
+    ? document.getElementById('crops').children[i]
+    : layer.querySelectorAll('.det')[i];
+  flashVerdict(anchor, s.dets[i]);
+}
+
+// --- Controls ------------------------------------------------------------------------
+document.getElementById('prev').onclick = () => { if (view.length) { idx = (idx - 1 + view.length) % view.length; render(); } };
+document.getElementById('next').onclick = () => { if (view.length) { idx = (idx + 1) % view.length; render(); } };
+document.getElementById('nexttodo').onclick = () => {
+  if (!view.length) return;
+  for (let k = 1; k <= view.length; k++) {
+    const j = (idx + k) % view.length;
+    if (!reviewed(view[j])) { idx = j; render(); return; }
+  }
+  alert('Every pano in this view is fully reviewed. Switch the filter to "All panos" to double-check, then Export.');
+};
+document.getElementById('filter').onchange = ev => { filterMode = ev.target.value; applyFilter(); };
+document.getElementById('nomiss').onclick = () => {
+  if (!view.length) return;
+  const e = view[idx], s = v(e.pid, e.crops.length);
+  if (s.missed.length) return;
+  s.noMissed = !s.noMissed;
+  save(); render();
+};
+document.addEventListener('keydown', ev => {
+  // Never hijack browser chords (Ctrl+M mutes, Cmd+M minimizes, Ctrl+1..9 switch tabs).
+  if (ev.ctrlKey || ev.metaKey || ev.altKey) return;
+  if (ev.target.tagName === 'SELECT') return;
+  if (ev.key === 'ArrowLeft') document.getElementById('prev').click();
+  else if (ev.key === 'ArrowRight') document.getElementById('next').click();
+  else if (ev.key === 'm' || ev.key === 'M') document.getElementById('nomiss').click();
+  else if (ev.key >= '1' && ev.key <= '9') cycle(Number(ev.key) - 1);
+});
+
+document.getElementById('export').onclick = () => {
+  // Structural FN check (issue #26 #6): surface incomplete panos instead of exporting
+  // silently, so a skipped missed-ramp pass is visible rather than quietly biasing recall.
+  let partial = 0, unconfirmed = 0;
+  for (const e of ENTRIES) {
+    const s = verdicts[e.pid];
+    if (!s || !s.seen) continue;
+    if (s.dets.length !== e.crops.length || s.dets.some(d => d === null)) partial++;
+    else if (!fnChecked(s)) unconfirmed++;
+  }
+  if (partial || unconfirmed) {
+    const msg = 'Some engaged panos are not fully reviewed:\n' +
+      (partial ? '  • ' + partial + ' with detections still unjudged\n' : '') +
+      (unconfirmed ? '  • ' + unconfirmed + ' judged but the missed-ramp check was never confirmed\n' : '') +
+      '\nThose are excluded from recall by the scorer. Export anyway?\n' +
+      '("Next unreviewed" jumps straight to them.)';
+    if (!confirm(msg)) return;
+  }
+  const out = {run_key: RUN_KEY, run_name: RUN_NAME, source: SOURCE,
+               exported_at: new Date().toISOString(), panos: {}};
+  for (const e of ENTRIES) {
+    const s = verdicts[e.pid];
+    if (!s || !s.seen) continue;
+    out.panos[e.pid] = {group: e.group, dets: s.dets, missed: s.missed, no_missed: !!s.noMissed};
+  }
+  const blob = new Blob([JSON.stringify(out, null, 2)], {type: 'application/json'});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = RUN_NAME + '_verdicts.json';
+  a.click();
+};
+
+document.getElementById('vname').textContent = RUN_NAME + '_verdicts.json';
+save();  // persist any bundle prefill merged in above
+render();
+</script>
+"""
+
+
+def build_html(entries, initial, run_key, run_name, source):
+    return (HTML_TEMPLATE
+            .replace('__ENTRIES__', json.dumps(entries))
+            .replace('__MODEL_W__', str(MODEL_WIDTH))
+            .replace('__INITIAL__', json.dumps(initial))
+            .replace('__RUN_KEY__', json.dumps(run_key))
+            .replace('__RUN_NAME__', json.dumps(run_name))
+            .replace('__SOURCE__', json.dumps(str(source))))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build the RampNet ground-truth labeler over a benchmark bundle.")
+    parser.add_argument("bundle", help="Benchmark bundle dir (e.g. benchmark/bend).")
+    parser.add_argument("--out", type=Path,
+                        help="Output gallery dir (default: <bundle>/gallery).")
+    parser.add_argument("--resample", action="store_true",
+                        help="Re-run the spatial sampler over records.jsonl instead of "
+                             "rendering every record in the bundle (use on a raw, "
+                             "un-sampled bundle).")
+    parser.add_argument("--html-only", action="store_true",
+                        help="Rebuild index.html from existing images (skip re-rendering "
+                             "panos). For iterating on the viewer.")
+    parser.add_argument("--sample", type=int, default=100,
+                        help="With --resample: detection panos to include (default: %(default)s).")
+    parser.add_argument("--empty-sample", type=int, default=10,
+                        help="With --resample: zero-detection panos to include (default: %(default)s).")
+    parser.add_argument("--seed", type=int, default=0,
+                        help="With --resample: sampling seed (default: %(default)s).")
+    parser.add_argument("--min-spacing", type=float, default=DEFAULT_MIN_SPACING_M,
+                        help="With --resample: min metres between sampled panos "
+                             "(default: %(default)s; 0 disables).")
+    args = parser.parse_args()
+
+    bundle = Path(args.bundle)
+    records, panos_dir, verdicts_panos, run_key, run_name = load_bundle(bundle)
+
+    if args.resample:
+        chosen = choose_panos(records, args.sample, args.empty_sample, args.seed, args.min_spacing)
+    else:
+        # The bundle's records.jsonl already *is* the validated sample; render all of it,
+        # taking each pano's stratum from the existing verdicts (or 'random' if unlabeled).
+        chosen = [(r, verdicts_panos.get(r['pano']['panorama_id'], {}).get('group', 'random'))
+                  for r in records]
+    print(f"{len(records)} records; rendering {len(chosen)} panos "
+          f"({sum(1 for r, _ in chosen if r['detections'])} with detections).")
+
+    out_dir = args.out or bundle / "gallery"
+    images_dir = out_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.html_only:
+        # Geometry is independent of the pixels, so entries rebuild without any I/O;
+        # only panos whose full image is already on disk are included.
+        entries = [entry_meta(r, g) for r, g in chosen
+                   if (images_dir / f"{r['pano']['panorama_id']}_full.jpg").exists()]
+        print(f"  --html-only: {len(entries)} panos with existing images.")
+    else:
+        entries, done = [], 0
+        with ThreadPoolExecutor(max_workers=RENDER_WORKERS) as pool:
+            futures = {pool.submit(render_pano, r, g, images_dir, panos_dir): r for r, g in chosen}
+            for future in as_completed(futures):
+                pid = futures[future]['pano']['panorama_id']
+                done += 1
+                try:
+                    entries.append(future.result())
+                except Exception as e:
+                    print(f"  skipped {pid}: {e}")
+                if done % 25 == 0 or done == len(futures):
+                    print(f"  rendered {done}/{len(futures)}")
+
+    entries.sort(key=lambda e: (-len(e['crops']), e['pid']))
+    initial = initial_verdicts(verdicts_panos)
+    index_path = out_dir / "index.html"
+    with open(index_path, 'w', encoding='utf-8') as f:
+        f.write(build_html(entries, initial, run_key, run_name, bundle / "records.jsonl"))
+
+    print(f"Gallery: {index_path}")
+    if verdicts_panos:
+        print(f"Prefilled {len(verdicts_panos)} panos from {bundle / 'verdicts.json'} for revision.")
+    print(f"Open it, review, Export, then save the download over {bundle / 'verdicts.json'}")
+    print(f"and re-score with: python scripts/score_validation.py {bundle}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_validation.py
+++ b/scripts/score_validation.py
@@ -43,6 +43,9 @@ def main():
     ap.add_argument("bundle", help="Bundle dir with records.jsonl + verdicts.json (e.g. benchmark/richmond).")
     ap.add_argument("--assume-scanned", action="store_true",
                     help="Count every fully-judged pano toward recall (reviewer attestation).")
+    ap.add_argument("--lenient-duplicates", action="store_true",
+                    help="Score 'duplicate' detections as redundant (abstained) instead of "
+                         "the default false positive. The headline number uses the default.")
     args = ap.parse_args()
 
     for stream in (sys.stdout, sys.stderr):  # tolerate cp1252 consoles
@@ -50,18 +53,26 @@ def main():
             stream.reconfigure(errors="replace")
 
     confs_by_pid, panos = load_bundle(args.bundle)
+    lenient = args.lenient_duplicates
 
-    pools = collect(panos, confs_by_pid, assume_scanned=args.assume_scanned)
+    pools = collect(panos, confs_by_pid, assume_scanned=args.assume_scanned,
+                    lenient_duplicates=lenient)
     for w in pools.warnings:
         print(f"! {w}")
     print(format_report("All reviewed panos", pools))
     print()
 
-    unbiased = collect(panos, confs_by_pid, exclude_top=True, assume_scanned=args.assume_scanned)
+    unbiased = collect(panos, confs_by_pid, exclude_top=True,
+                       assume_scanned=args.assume_scanned, lenient_duplicates=lenient)
     if unbiased.n_seen != pools.n_seen:  # top panos existed
         print(format_report("Unbiased subset (random + empty samples only)", unbiased))
         print()
 
+    if pools.n_duplicate:
+        mode = ("lenient: duplicates abstain (redundant, excluded)" if lenient
+                else "default: duplicates scored as false positives")
+        print(f"Duplicate scoring — {mode}. "
+              f"Re-run with{'out' if lenient else ''} --lenient-duplicates for the other variant.")
     print("Recall = per-pano-comprehensive, as judged by the reviewer on the sampled panos.")
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -100,6 +100,32 @@ def test_collect_unsure_abstains_from_both_metrics():
     assert (pools.n_unsure, pools.missed_total, pools.missed_unsure) == (1, 0, 1)
 
 
+def test_collect_duplicate_is_false_positive_by_default():
+    # Two dets on one physical ramp: the reviewer keeps the first 'correct' and
+    # marks the second 'duplicate'. By default the duplicate scores as a false
+    # positive (matching rampnet.metrics' one-to-one matching), but stays counted
+    # distinctly from a plain 'incorrect'.
+    panos = {"P_TWO_DETS": {"group": "random", "dets": [True, "duplicate"],
+                            "missed": [], "no_missed": True}}
+    pools = collect(panos, {"P_TWO_DETS": [0.91, 0.63]})
+    assert pools.n_judged == 1 and pools.n_duplicate == 1 and pools.n_unsure == 0
+    # Folded to False in the pools, so precision sees 1 correct of 2 (an FP).
+    assert sorted(pools.judged) == [(0.63, False), (0.91, True)]
+    assert sorted(pools.recall_judged) == [(0.63, False), (0.91, True)]
+    assert total_ramps(pools) == 1  # only the one correct det is a real ramp
+
+
+def test_collect_duplicate_lenient_abstains():
+    # The lenient variant drops duplicates from both metrics entirely (like unsure),
+    # so precision/recall are computed as if the redundant hit never fired.
+    panos = {"P_TWO_DETS": {"group": "random", "dets": [True, "duplicate"],
+                            "missed": [], "no_missed": True}}
+    pools = collect(panos, {"P_TWO_DETS": [0.91, 0.63]}, lenient_duplicates=True)
+    assert pools.n_duplicate == 1
+    assert pools.judged == [(0.91, True)] and pools.recall_judged == [(0.91, True)]
+    assert total_ramps(pools) == 1
+
+
 def test_collect_skips_partially_judged():
     panos = {"P_TWO_DETS": {"group": "random", "dets": [True, None],
                             "missed": [], "no_missed": True}}


### PR DESCRIPTION
Ports the ground-truth labeling tool into RampNet, decoupled onto the benchmark bundle, and adopts the corrected model-resolution ground truth it produced for both cities.

## What's here

**GT labeling tool — `scripts/gt_gallery.py` (#26).** Ports the spot-check gallery from sidewalk-auto-labeler and decouples it: it reads `benchmark/<city>/{panos,records.jsonl}` and prefills any existing `verdicts.json`, with no network access. The spatial sampler, crop/overlay geometry, and the viewer's verdict schema + recall gate carry over and stay in sync with `rampnet.validation`. Six UX/scoring improvements, the load-bearing ones being:
- **Pan/zoom on the full pano at the model's input resolution (4096×2048), never native** — with a pill reporting how much of model resolution is resolved on screen (you reach model 1:1 but never exceed it, so a reviewer never sees more than the model saw).
- **A structural false-negative check** — per-pano REVIEWED state, an "X/N fully reviewed" counter, a "Next unreviewed" jump, and an export that surfaces incomplete panos instead of skipping the missed-ramp pass silently.
- A client-side crop panel for reviewer-marked missed ramps; one consistent amber "unsure" colour + a keyed legend; and a distinct **`duplicate`** verdict.

**Scorer — `rampnet.validation`.** Adds the `duplicate` verdict, scored as a false positive by default (matching `rampnet.metrics`' one-to-one matching) but recorded distinctly so the lenient "redundant, excluded" variant stays computable via `--lenient-duplicates`. Also fixes a latent bug where a `"duplicate"` string would have scored as *correct*. New tests cover both scorings.

**Corrected ground truth (#30).** Both splits were re-reviewed at model resolution, which surfaced small/distant curb ramps the earlier 1600 px overview could not resolve — correcting recall down from optimistic numbers; precision essentially unchanged. The effect is consistent across both imagery sources:

| City | Precision | Recall |
|------|-----------|--------|
| richmond | 0.965 → 0.960 | 0.895 → 0.765 |
| bend | 0.958 → 0.954 | 0.831 → 0.758 |

Both still reproduce with a plain `python scripts/score_validation.py benchmark/<city>`.

## Notes for reviewers

- Anyone can regenerate the labeling UI for a split and reproduce the exact review with `python scripts/gt_gallery.py benchmark/<city>` (native panos are git-ignored; they ship with the HF benchmark, #21).
- The corrected figures supersede the numbers in #21's issue text; they should flow into the HF publish.

Closes #26. Re-review tracked in #30 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)