### PR TITLE
HF publishing prep: re-package model (#29) + benchmark dataset builder (#21)

### DIFF
--- a/scripts/build_benchmark_dataset.py
+++ b/scripts/build_benchmark_dataset.py
@@ -1,0 +1,381 @@
+"""Build the RampNet deployment-validation benchmark as a HuggingFace dataset (issue #21).
+
+Packs the committed benchmark bundles (``benchmark/{bend,richmond}/`` — native-res
+panoramas + model detections + human verdicts) into a ``DatasetDict`` with one
+split per city, writes a domain-labeled dataset card, and verifies that scoring
+the reloaded dataset reproduces the documented precision/recall. Does NOT push
+(review first, then push with the printed command).
+
+    python scripts/build_benchmark_dataset.py --output-dir hf_benchmark_export
+
+Two splits, two very different measurements — kept separate on purpose:
+
+* ``bend``     — Google Street View, one of the three training cities. An
+  **in-distribution** reference point (same city distribution, same imagery
+  source as training).
+* ``richmond`` — Mapillary, a city never seen in training. The **out-of-
+  distribution** deployment test (unseen city AND unseen imagery source).
+
+Four Bend benchmark panoramas whose ids appear in the training split of
+``projectsidewalk/rampnet-dataset`` are dropped (see ``LEAKED_BEND_IDS``); their
+removal shifts Bend precision/recall by <=0.5 pt (inside the Wilson CIs).
+Richmond has zero training overlap.
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+import PIL.Image
+from datasets import Dataset, Features, Image, Value, load_dataset
+
+# Bend GSV panoramas run up to 16384x8192 (134 MP), above Pillow's default
+# decompression-bomb ceiling. These are trusted local files, so lift the cap.
+PIL.Image.MAX_IMAGE_PIXELS = None
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+from rampnet.validation import collect, format_report  # noqa: E402
+
+BENCHMARK_DIR = os.path.join(REPO_ROOT, "benchmark")
+
+# Bend benchmark panos whose ids are in projectsidewalk/rampnet-dataset train/val
+# (exact-id overlap check, 2026-07-22). Dropped from the published benchmark.
+LEAKED_BEND_IDS = {
+    "6WC0hdAYRsSAcluKSs5iRg", "9kW9cxpuj7q8DMzf-ClrQQ",
+    "DJ8Zp111zu6KnMZz-0PHgQ", "VgWpqFkTwCIROvM0z-DkOw",
+}
+
+CITY_IMAGERY = {"bend": "gsv", "richmond": "mapillary"}
+
+FEATURES = Features({
+    "pano_id": Value("string"),
+    "city": Value("string"),
+    "imagery_source": Value("string"),      # gsv | mapillary
+    # True iff this exact pano id is in a projectsidewalk/rampnet-dataset training
+    # split. Nothing is dropped — filter on this to score the clean subset.
+    "train_overlap": Value("bool"),
+    "group": Value("string"),               # top | random | empty (sampling stratum)
+    "image": Image(),
+    "lat": Value("float64"),
+    "lng": Value("float64"),
+    "capture_date": Value("string"),
+    "width": Value("int64"),
+    "height": Value("int64"),
+    "camera_heading": Value("float64"),
+    "copyright": Value("string"),
+    # Model detections at the panorama, normalized coords + confidence
+    # (list-of-structs; the [{...}] wrapper keeps list-of-dict input, not columnar).
+    "detections": [{
+        "x_normalized": Value("float64"),
+        "y_normalized": Value("float64"),
+        "confidence": Value("float64"),
+    }],
+    # Human verdict per detection, aligned 1:1 with `detections`:
+    # "true" (correct) | "false" (false positive) | "unsure" (abstain) | "duplicate".
+    "det_verdicts": [Value("string")],
+    # Ground-truth ramps the model missed (false negatives); `unsure` abstains.
+    "missed": [{
+        "x": Value("float64"),
+        "y": Value("float64"),
+        "unsure": Value("bool"),
+    }],
+    "no_missed": Value("bool"),
+    # Full raw panorama metadata (superset of the surfaced columns), as JSON.
+    "pano_metadata_json": Value("string"),
+})
+
+
+def encode_verdict(v):
+    """bool/str verdict -> homogeneous string for a parquet list column."""
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    return str(v)  # "unsure" | "duplicate"
+
+
+def load_city(city):
+    cdir = os.path.join(BENCHMARK_DIR, city)
+    records = {}
+    with open(os.path.join(cdir, "records.jsonl"), encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                r = json.loads(line)
+                records[r["pano"]["panorama_id"]] = r
+    verdicts = json.load(open(os.path.join(cdir, "verdicts.json"), encoding="utf-8"))["panos"]
+    return records, verdicts, os.path.join(cdir, "panos")
+
+
+def build_rows(city, read_images=True):
+    """Build one split's row dicts. ``read_images=False`` skips the ~GB of JPEG
+    reads (image set to None) for fast, image-free checks/tests. Nothing is
+    dropped; panos with training-split id overlap are flagged via ``train_overlap``.
+    Returns ``(rows, flagged_ids)``."""
+    records, verdicts, panos_dir = load_city(city)
+    flagged = []
+    rows = []
+    for pid, ver in verdicts.items():
+        overlap = city == "bend" and pid in LEAKED_BEND_IDS
+        if overlap:
+            flagged.append(pid)
+        rec = records[pid]
+        pano = rec["pano"]
+        img_path = os.path.join(panos_dir, f"{pid}.jpg")
+        # Embed the raw JPEG bytes: a bare path is stored as an unresolved
+        # reference (to_parquet does not read it), so the Hub parquet would ship
+        # imageless. bytes-in, and the image travels with the row.
+        image = None
+        if read_images:
+            with open(img_path, "rb") as fh:
+                image = {"path": f"{pid}.jpg", "bytes": fh.read()}
+        rows.append({
+            "pano_id": pid,
+            "city": city,
+            "imagery_source": CITY_IMAGERY[city],
+            "train_overlap": overlap,
+            "group": ver["group"],
+            "image": image,
+            "lat": pano.get("lat"),
+            "lng": pano.get("lng"),
+            "capture_date": pano.get("capture_date"),
+            "width": pano.get("width"),
+            "height": pano.get("height"),
+            "camera_heading": pano.get("camera_heading"),
+            "copyright": pano.get("copyright"),
+            "detections": [
+                {"x_normalized": d["x_normalized"], "y_normalized": d["y_normalized"],
+                 "confidence": d["confidence"]}
+                for d in rec["detections"]
+            ],
+            "det_verdicts": [encode_verdict(v) for v in ver["dets"]],
+            "missed": [
+                {"x": m["x"], "y": m["y"], "unsure": bool(m.get("unsure", False))}
+                for m in ver.get("missed", [])
+            ],
+            "no_missed": ver["no_missed"],
+            "pano_metadata_json": json.dumps(pano, ensure_ascii=False),
+        })
+    return rows, flagged
+
+
+def decode_verdicts_for_scoring(split_ds):
+    """Reconstruct the (verdicts, confs) inputs rampnet.validation.collect expects
+    from a built split — the round-trip used to verify the published numbers."""
+    def decode(v):
+        return {"true": True, "false": False}.get(v, v)  # keep unsure/duplicate strings
+
+    verdicts, confs = {}, {}
+    for row in split_ds:
+        pid = row["pano_id"]
+        verdicts[pid] = {
+            "group": row["group"],
+            "dets": [decode(v) for v in row["det_verdicts"]],
+            "missed": row["missed"],
+            "no_missed": row["no_missed"],
+        }
+        confs[pid] = [d["confidence"] for d in row["detections"]]
+    return verdicts, confs
+
+
+def score_split(split_ds, title):
+    verdicts, confs = decode_verdicts_for_scoring(split_ds)
+    # Default flags: the splits bake complete-scan attestation into `no_missed`,
+    # so the numbers reproduce without --assume-scanned (see benchmark/README.md).
+    pools = collect(verdicts, confs)
+    return format_report(title, pools)
+
+
+def pr_from_report(report):
+    """Extract ('0.960', '0.765') from a format_report block."""
+    import re
+    p = re.search(r"Precision:\s*([\d.]+)", report).group(1)
+    r = re.search(r"Recall:\s*([\d.]+)", report).group(1)
+    return p, r
+
+
+def render_card(counts, reports, bend_clean):
+    """bend_clean = (precision, recall) strings for Bend with train_overlap rows
+    excluded — the numbers reproduced by filtering `train_overlap == False`."""
+    leaked = ", ".join(f"`{i}`" for i in sorted(LEAKED_BEND_IDS))
+    bend_clean_p, bend_clean_r = bend_clean
+    return f"""---
+license: cc-by-sa-4.0
+task_categories:
+  - keypoint-detection
+tags:
+  - curb-ramp-detection
+  - accessibility
+  - street-view
+  - benchmark
+  - deployment-validation
+pretty_name: RampNet Deployment-Validation Benchmark
+configs:
+  - config_name: default
+    data_files:
+      - split: bend
+        path: bend/*.parquet
+      - split: richmond
+        path: richmond/*.parquet
+---
+
+# RampNet Deployment-Validation Benchmark
+
+Human-verified ground truth for evaluating the
+[projectsidewalk/rampnet-model](https://huggingface.co/projectsidewalk/rampnet-model)
+curb-ramp detector **in deployment**, on real street-view panoramas. Each panorama carries
+the model's detections, a human verdict per detection (correct / false-positive / unsure /
+duplicate), and any ground-truth ramps the model **missed** — enough to reproduce precision and
+recall exactly (see [Scoring](#scoring)).
+
+This complements the training-distribution gold set reported with the model. It measures the two
+things a deployment actually cares about, kept in **separate splits** because they answer different
+questions:
+
+| Split | Imagery | City vs. training | Measures | n |
+| :--- | :--- | :--- | :--- | ---: |
+| `bend` | Google Street View | **in-distribution** (a training city, same imagery source) | in-domain reference point | {counts['bend']} |
+| `richmond` | Mapillary | **out-of-distribution** (unseen city **and** unseen imagery source) | true deployment generalization | {counts['richmond']} |
+
+Do **not** pool these into one number: `bend` tells you how the model does on data like what it was
+trained on; `richmond` tells you how it transfers to a new city and a new camera. That the OOD
+Richmond split scores on par with the in-distribution Bend split is the headline result.
+
+## Results (recommended operating threshold 0.55, flip-TTA)
+
+{reports['bend']}
+
+{reports['richmond']}
+
+Precision = correct detections / all detections; recall = matched ground-truth ramps / all visible
+ground-truth ramps in the recall pool. `unsure` verdicts abstain (excluded from both); `duplicate`
+detections count as false positives by default. 95% Wilson confidence intervals are shown because
+the splits are small. These supersede all earlier figures (the original 1600 px review overstated
+recall; these were re-reviewed at model input resolution).
+
+## Training overlap (important)
+
+Bend is one of RampNet's three training cities, so its imagery distribution is **not held out** —
+treat the `bend` split as an in-distribution reference, not a generalization test. Beyond the
+distribution overlap, four Bend panoramas have exact ids present in the `train`/`val` split of
+[projectsidewalk/rampnet-dataset](https://huggingface.co/datasets/projectsidewalk/rampnet-dataset):
+{leaked}. They are **kept** in the split but flagged with `train_overlap = true` — nothing is
+dropped, so you can score either way. Excluding them (`train_overlap == False`, n={counts['bend'] - 4})
+gives precision {bend_clean_p} / recall {bend_clean_r} — a shift of <=0.5 pt, within the confidence
+intervals. **Richmond has zero id overlap** with any training split (`train_overlap` all false) and is
+a clean out-of-distribution test.
+
+The headline Bend numbers above are on the full split (n={counts['bend']}), matching the in-repo
+`benchmark/bend` bundle.
+
+## Columns
+
+- `pano_id`, `city`, `imagery_source` (`gsv` | `mapillary`), `train_overlap` (bool; see
+  [Training overlap](#training-overlap-important)), `group` (`top` | `random` | `empty` sampling
+  stratum), `image` (the panorama), plus panorama metadata (`lat`, `lng`, `capture_date`, `width`,
+  `height`, `camera_heading`, `copyright`, and the full raw `pano_metadata_json`).
+- `detections`: model detections — normalized `x`/`y` + `confidence`.
+- `det_verdicts`: aligned 1:1 with `detections` — `"true"` | `"false"` | `"unsure"` | `"duplicate"`.
+- `missed`: ground-truth ramps the model missed (false negatives), normalized `x`/`y`; `unsure`
+  abstains.
+- `no_missed`: reviewer attestation that the panorama was fully scanned for misses.
+
+## Scoring
+
+The scorer lives in the training repo
+([`rampnet/validation.py`](https://github.com/ProjectSidewalk/RampNet/blob/main/rampnet/validation.py)):
+
+```python
+from datasets import load_dataset
+from rampnet.validation import collect, format_report
+
+ds = load_dataset("projectsidewalk/rampnet-benchmark", split="richmond")
+
+def decode(v):
+    return {{"true": True, "false": False}}.get(v, v)  # keep unsure/duplicate
+
+verdicts, confs = {{}}, {{}}
+for row in ds:
+    verdicts[row["pano_id"]] = {{
+        "group": row["group"], "dets": [decode(v) for v in row["det_verdicts"]],
+        "missed": row["missed"], "no_missed": row["no_missed"],
+    }}
+    confs[row["pano_id"]] = [d["confidence"] for d in row["detections"]]
+
+print(format_report("richmond", collect(verdicts, confs)))
+```
+
+(The splits bake complete-scan attestation into `no_missed`, so scoring needs no
+`assume_scanned` override — see the [results](#results-recommended-operating-threshold-055-flip-tta).)
+
+## Provenance
+
+Detections are from `projectsidewalk/rampnet-model` (`model_training_date` 2025-08-21). Imagery ©
+Google (Bend, GSV) and © the respective Mapillary contributors (Richmond, CC BY-SA 4.0); see each
+panorama's `copyright`. Built by
+[`scripts/build_benchmark_dataset.py`](https://github.com/ProjectSidewalk/RampNet/blob/main/scripts/build_benchmark_dataset.py).
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Build the RampNet deployment-validation benchmark dataset (#21).")
+    ap.add_argument("--output-dir", default="hf_benchmark_export",
+                    help="Where to write the dataset (save_to_disk) + README.md")
+    ap.add_argument("--repo-id", default="projectsidewalk/rampnet-benchmark",
+                    help="Target Hub dataset id (used only in the printed push instructions)")
+    args = ap.parse_args()
+
+    # ~500 MB/shard target; Bend native-res GSV is the large split.
+    SHARDS = {"bend": 4, "richmond": 1}
+
+    counts, flagged_all, reports = {}, {}, {}
+    bend_clean = None
+    os.makedirs(args.output_dir, exist_ok=True)
+    for city in ("bend", "richmond"):
+        rows, flagged = build_rows(city)
+        ds = Dataset.from_list(rows, features=FEATURES)
+        counts[city] = len(ds)
+        flagged_all[city] = flagged
+        reports[city] = score_split(ds, f"{city} (n={len(ds)}, {CITY_IMAGERY[city]})")
+        print(f"[{city}] {len(ds)} panos"
+              + (f"; {len(flagged)} flagged train_overlap: {flagged}" if flagged else ""))
+
+        if city == "bend":  # numbers with the training-overlap panos excluded
+            clean = ds.filter(lambda r: not r["train_overlap"])
+            bend_clean = pr_from_report(score_split(clean, "bend (clean)"))
+
+        # Write the exact repo layout the card's `configs` block declares:
+        # <out>/<city>/data-<i>-of-<n>.parquet (self-contained, image bytes embedded).
+        city_dir = os.path.join(args.output_dir, city)
+        os.makedirs(city_dir, exist_ok=True)
+        n = SHARDS[city]
+        for i in range(n):
+            shard = ds.shard(num_shards=n, index=i, contiguous=True)
+            shard.to_parquet(os.path.join(city_dir, f"data-{i:05d}-of-{n:05d}.parquet"))
+
+    card = render_card(counts, reports, bend_clean)
+    with open(os.path.join(args.output_dir, "README.md"), "w", encoding="utf-8") as f:
+        f.write(card)
+    print(f"\nSaved parquet splits + README.md to {args.output_dir}")
+
+    # Verify: scoring the reloaded parquet reproduces the just-computed reports.
+    for city in ("bend", "richmond"):
+        reloaded = load_dataset("parquet",
+                                data_files=os.path.join(args.output_dir, city, "*.parquet"),
+                                split="train")
+        again = score_split(reloaded, f"{city} (reloaded)")
+        line = next(l for l in reports[city].splitlines() if l.strip().startswith("Precision"))
+        line2 = next(l for l in again.splitlines() if l.strip().startswith("Precision"))
+        assert line == line2, f"{city} round-trip mismatch:\n{line}\n{line2}"
+    print("Round-trip verified: reloaded parquet re-scores to the documented numbers.")
+
+    print("\nNOT pushed. To publish (after review), upload the staged folder as-is:")
+    print(f'  from huggingface_hub import HfApi')
+    print(f'  api = HfApi(); api.create_repo("{args.repo_id}", repo_type="dataset", exist_ok=True)')
+    print(f'  api.upload_folder(folder_path="{args.output_dir}", repo_id="{args.repo_id}", '
+          f'repo_type="dataset")')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_hf_model.py
+++ b/scripts/export_hf_model.py
@@ -2,14 +2,28 @@
 
 Produces a local trust_remote_code package (config + modeling files + weights +
 model card) that reproduces projectsidewalk/rampnet-model from this repo, and
-optionally pushes it to the Hub. Run from the repo root:
+optionally pushes it to the Hub. Run from the repo root.
+
+Export a freshly trained checkpoint:
 
     python scripts/export_hf_model.py --checkpoint stage_two/checkpoints/epoch_1_step_9378.pth \
-        --metrics-json stage_two/evaluation_results/metrics_manual_r0.022_pt0.55.json \
+        --metrics-json stage_two/evaluation_results_new/metrics_manual_r0.022_pt0.55.json \
+        --ap-json      stage_two/evaluation_results_new/metrics_manual_r0.022_pt0.0.json \
         [--push --repo-id projectsidewalk/rampnet-model]
 
-Generate the metrics JSON first with stage_two/evaluate.py (at the recommended
-operating threshold, with TTA) so the model card carries real gold-set numbers.
+Re-package the weights already on the Hub (issue #29 — same weights, fixed
+wrapper + corrected card; no retrain). Tag the current Hub revision first so it
+stays addressable, then:
+
+    python scripts/export_hf_model.py --from-hub-revision <old-revision> \
+        --source-fingerprint b0c3ff7a10fc --source-name epoch_1_step_9378.pth \
+        --metrics-json stage_two/evaluation_results_new/metrics_manual_r0.022_pt0.55.json \
+        --ap-json      stage_two/evaluation_results_new/metrics_manual_r0.022_pt0.0.json
+
+Precision/recall come from the operating-threshold metrics JSON; Average
+Precision must come from a full-sweep run (--ap-json, evaluate.py with
+PEAK_THRESHOLD_ABS=0.0). Generate these with stage_two/evaluate.py (with TTA)
+so the model card carries real gold-set numbers.
 """
 import argparse
 import datetime
@@ -30,10 +44,27 @@ PACKAGE_DIR = os.path.join(REPO_ROOT, "scripts", "hf_package")
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Export a stage-2 checkpoint as a HuggingFace model package.")
-    parser.add_argument('--checkpoint', required=True, help="Trained stage-2 checkpoint (.pth)")
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument('--checkpoint', help="Trained stage-2 checkpoint (.pth) to export")
+    src.add_argument('--from-hub-revision',
+                     help="Re-export the weights already on the Hub: download model.safetensors from "
+                          "--repo-id at this revision and load them (strict) into the canonical "
+                          "KeypointModel. Use for a re-packaging (e.g. issue #29) where the weights are "
+                          "unchanged and only the wrapper/card are being fixed. Requires --source-fingerprint.")
+    parser.add_argument('--source-fingerprint', default=None,
+                        help="Override the checkpoint sha256 prefix recorded in the card. Required with "
+                             "--from-hub-revision, where the local file hash is not the canonical "
+                             "training-checkpoint identity (pass the original checkpoint's fingerprint).")
+    parser.add_argument('--source-name', default=None,
+                        help="Override the 'Source checkpoint' name shown in the card (default: the "
+                             "checkpoint filename).")
     parser.add_argument('--output-dir', default='hf_export', help="Where to write the package (default: hf_export)")
     parser.add_argument('--metrics-json', default=None,
-                        help="metrics_*.json produced by stage_two/evaluate.py; embedded in the model card")
+                        help="metrics_*.json (at the operating threshold) produced by stage_two/evaluate.py; "
+                             "supplies the card's precision/recall")
+    parser.add_argument('--ap-json', default=None,
+                        help="Full-sweep metrics_*.json (evaluate.py with PEAK_THRESHOLD_ABS=0.0); supplies "
+                             "the card's Average Precision. AP from a threshold-truncated run is wrong.")
     parser.add_argument('--dataset-revision', default='main',
                         help="Revision of projectsidewalk/rampnet-dataset the checkpoint was trained on")
     parser.add_argument('--recommended-threshold', type=float, default=0.55,
@@ -46,6 +77,43 @@ def parse_args():
     return parser.parse_args()
 
 
+def load_reference_model(args):
+    """Build the canonical KeypointModel and load the weights to export into it.
+
+    Returns ``(model, fingerprint, source_name)``. Two sources:
+
+    * ``--checkpoint`` — a local ``.pth``, loaded strict; fingerprint is the file
+      sha256 prefix (unless overridden by ``--source-fingerprint``).
+    * ``--from-hub-revision`` — ``model.safetensors`` from ``--repo-id`` at that
+      revision, loaded strict (the published weights use bare KeypointModel keys).
+      The fingerprint is not derivable from the re-downloaded file, so
+      ``--source-fingerprint`` is required and names the canonical training
+      checkpoint the weights came from.
+    """
+    reference_model = KeypointModel(heatmap_size=PANO_HEATMAP_SIZE)
+
+    if args.from_hub_revision:
+        if not args.source_fingerprint:
+            raise SystemExit("--from-hub-revision requires --source-fingerprint "
+                             "(the canonical training-checkpoint sha256 prefix).")
+        from huggingface_hub import hf_hub_download
+        from safetensors.torch import load_file
+        print(f"Downloading weights from {args.repo_id}@{args.from_hub_revision} (model.safetensors)...")
+        weights_path = hf_hub_download(args.repo_id, "model.safetensors", revision=args.from_hub_revision)
+        state_dict = load_file(weights_path)
+        reference_model.load_state_dict(state_dict, strict=True)
+        fingerprint = args.source_fingerprint
+        source_name = args.source_name or f"weights from {args.repo_id}@{args.from_hub_revision}"
+    else:
+        print(f"Loading checkpoint {args.checkpoint} (strict)...")
+        load_checkpoint(reference_model, args.checkpoint, map_location='cpu')
+        fingerprint = args.source_fingerprint or checkpoint_fingerprint(args.checkpoint)
+        source_name = args.source_name or os.path.basename(args.checkpoint)
+
+    reference_model.eval()
+    return reference_model, fingerprint, source_name
+
+
 def git_commit():
     try:
         return subprocess.check_output(
@@ -54,16 +122,36 @@ def git_commit():
         return 'unknown'
 
 
-def render_eval_section(metrics_json_path):
+def render_eval_section(metrics_json_path, ap_json_path=None):
+    """Render the model-card metrics table.
+
+    Precision/recall are read at the operating threshold from ``metrics_json_path``
+    (a ``stage_two/evaluate.py`` run with ``PEAK_THRESHOLD_ABS`` set to that
+    threshold). Average Precision must come from a **full confidence sweep**
+    (``PEAK_THRESHOLD_ABS = 0.0``), so pass that run separately as
+    ``ap_json_path``; an AP taken from a threshold-truncated run integrates only
+    the tail of the curve and reads far too low. If ``ap_json_path`` is omitted,
+    AP falls back to ``metrics_json_path`` (correct only when it is itself a
+    full-sweep run).
+    """
     if metrics_json_path is None:
         return ("*No evaluation metrics were supplied at export time. Run `stage_two/evaluate.py "
                 "--threshold <t>` and re-export with `--metrics-json` to fill this in.*")
     with open(metrics_json_path) as f:
         m = json.load(f)
+    ap_source = m
+    if ap_json_path is not None:
+        with open(ap_json_path) as f:
+            ap_source = json.load(f)
+    if ap_source.get('peak_threshold_abs', 0.0) not in (0.0, 0):
+        raise ValueError(
+            f"AP must come from a full-sweep run (peak_threshold_abs=0.0); got "
+            f"{ap_source.get('peak_threshold_abs')} in {ap_json_path or metrics_json_path}. "
+            "Pass the pt0.0 metrics file via --ap-json.")
     lines = [
         "| Metric | Value |",
         "| :--- | :--- |",
-        f"| Average Precision (interpolated) | {m['ap']:.4f} |",
+        f"| Average Precision (interpolated, full sweep) | {ap_source['ap']:.4f} |",
         f"| Precision @ threshold {m['peak_threshold_abs']} | {m['precision_at_threshold']:.4f} |",
         f"| Recall @ threshold {m['peak_threshold_abs']} | {m['recall_at_threshold']:.4f} |",
         f"| Ground-truth points | {m['total_gt_points']} |",
@@ -128,11 +216,7 @@ def verify_roundtrip(output_dir, reference_model):
 def main():
     args = parse_args()
 
-    print(f"Loading checkpoint {args.checkpoint} (strict)...")
-    reference_model = KeypointModel(heatmap_size=PANO_HEATMAP_SIZE)
-    load_checkpoint(reference_model, args.checkpoint, map_location='cpu')
-    reference_model.eval()
-    fingerprint = checkpoint_fingerprint(args.checkpoint)
+    reference_model, fingerprint, source_name = load_reference_model(args)
 
     assemble_package(args.output_dir, reference_model,
                      recommended_threshold=args.recommended_threshold)
@@ -142,11 +226,11 @@ def main():
         template = f.read()
     card = template.format(
         git_commit=git_commit(),
-        checkpoint_name=os.path.basename(args.checkpoint),
+        checkpoint_name=source_name,
         checkpoint_fingerprint=fingerprint,
         dataset_revision=args.dataset_revision,
         export_date=datetime.date.today().isoformat(),
-        eval_section=render_eval_section(args.metrics_json),
+        eval_section=render_eval_section(args.metrics_json, args.ap_json),
         recommended_threshold=args.recommended_threshold,
         repo_id=args.repo_id,
     )
@@ -162,7 +246,7 @@ def main():
         api = HfApi()
         api.create_repo(args.repo_id, repo_type='model', exist_ok=True)
         api.upload_folder(folder_path=args.output_dir, repo_id=args.repo_id, repo_type='model',
-                          commit_message=f"Export {os.path.basename(args.checkpoint)} "
+                          commit_message=f"Export {source_name} "
                                          f"(sha256 {fingerprint}) from commit {git_commit()}")
         print(f"Pushed to https://huggingface.co/{args.repo_id}")
     else:

--- a/scripts/hf_package/README.model_card.template.md
+++ b/scripts/hf_package/README.model_card.template.md
@@ -7,6 +7,10 @@ tags:
   - accessibility
   - street-view
   - keypoint-heatmap
+datasets:
+  - projectsidewalk/rampnet-dataset
+base_model:
+  - timm/convnextv2_base.fcmae_ft_in22k_in1k_384
 ---
 
 # RampNet Curb Ramp Detection Model
@@ -27,6 +31,11 @@ Takes a 2048x4096 equirectangular street-view panorama (ImageNet-normalized) and
 | Training dataset | [projectsidewalk/rampnet-dataset](https://huggingface.co/datasets/projectsidewalk/rampnet-dataset) revision `{dataset_revision}` |
 | Exported | {export_date} by `scripts/export_hf_model.py` |
 
+The model **weights are unchanged** from the originally published artifact — this revision only
+fixes the packaging (a `transformers`-compatible wrapper; see [Requirements](#requirements)) and
+corrects the evaluation numbers (see [Erratum](#erratum-evaluation-metrics)). The prior artifact
+remains addressable at its tagged Hub revision.
+
 ## Evaluation (1,000-panorama manually labeled gold set)
 
 {eval_section}
@@ -34,7 +43,31 @@ Takes a 2048x4096 equirectangular street-view panorama (ImageNet-normalized) and
 **Important:** these numbers were measured **with horizontal-flip test-time augmentation**
 (evaluate the original and mirrored panorama, combine heatmaps with elementwise max). Single-pass
 inference will land somewhat below them; derive your own threshold curve without TTA before
-choosing an operating point.
+choosing an operating point. Average Precision is the interpolated area under the full
+precision–recall sweep; precision and recall are reported at the operating threshold.
+
+### Erratum: Evaluation Metrics
+
+After publication we found that the evaluation protocol described in §3.3 of the paper (and
+implemented at tag [`v1.0-iccv2025`](https://github.com/ProjectSidewalk/RampNet/tree/v1.0-iccv2025))
+differs from standard detection evaluation in two ways that bias precision and recall upward:
+predictions matching an already-claimed ground-truth point were counted as additional true
+positives rather than false positives, and one prediction could satisfy multiple ground-truth
+points. The numbers above use corrected one-to-one matching. For transparency, the originally
+published figures are kept here alongside the corrected ones:
+
+| Metric | Originally published | Corrected (this revision) |
+| :--- | :--- | :--- |
+| Precision @ 0.55 | 0.938 | **0.949** |
+| Recall @ 0.55 | 0.935 | **0.873** |
+| Average Precision | 0.9236 | **0.9205** |
+
+Swapping only the matching rule on identical model outputs moves precision by −1.0 points and
+recall by −4.4 points; the remainder is reproduction drift (environment, JPEG re-encoding). The
+comparison with prior work is unaffected (both systems were scored under the same protocol, and the
+gap is far larger than the correction). Full write-up:
+[`docs/eval_protocol_verification.html`](https://github.com/ProjectSidewalk/RampNet/blob/main/docs/eval_protocol_verification.html)
+and the repository README's erratum.
 
 ## Choosing a detection threshold
 
@@ -55,9 +88,12 @@ Loads via `trust_remote_code`, so a compatible `transformers` is required:
 Both are covered by a round-trip load smoke test (`tests/test_hf_load.py` in the
 training repo). Earlier revisions of this model fail to load on
 `transformers >= 5.13` with `AttributeError: ... 'KeypointModel' has no attribute
-'register_for_auto_class'` — pull the current revision.
+'register_for_auto_class'` (or `... has no attribute 'generate'`) — pull the current revision.
 
 ## Usage
+
+*For a step-by-step walkthrough, see the [Google Colab notebook](https://colab.research.google.com/drive/1TOtScud5ac2McXJmg1n_YkOoZBchdn3w?usp=sharing),
+which adds a visualization to the code below.*
 
 ```python
 import torch

--- a/tests/test_benchmark_dataset.py
+++ b/tests/test_benchmark_dataset.py
@@ -1,0 +1,54 @@
+"""Guards for the #21 benchmark dataset builder (scripts/build_benchmark_dataset.py).
+
+Covers the parts that must not drift without touching the heavy image packing:
+the verdict encode/decode round-trip (the mixed bool / "unsure" / "duplicate"
+values must survive the parquet string column) and the training-overlap drop.
+Uses the committed image-free bundles (records.jsonl + verdicts.json).
+"""
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
+from build_benchmark_dataset import (  # noqa: E402
+    LEAKED_BEND_IDS, build_rows, encode_verdict,
+)
+
+
+def _decode(v):
+    return {"true": True, "false": False}.get(v, v)
+
+
+def test_verdict_encode_decode_roundtrip():
+    for original in (True, False, "unsure", "duplicate"):
+        assert _decode(encode_verdict(original)) == original
+
+
+def test_encoding_is_homogeneous_strings():
+    # Parquet list column can't mix bool and str; every encoded value is a str.
+    for original in (True, False, "unsure", "duplicate"):
+        assert isinstance(encode_verdict(original), str)
+
+
+def test_bend_flags_overlap_but_drops_nothing():
+    rows, flagged = build_rows("bend", read_images=False)
+    assert set(flagged) == LEAKED_BEND_IDS
+    # Nothing dropped: the overlapping panos are kept, just flagged.
+    flagged_rows = {r["pano_id"] for r in rows if r["train_overlap"]}
+    assert flagged_rows == LEAKED_BEND_IDS
+    assert {r["pano_id"] for r in rows} >= LEAKED_BEND_IDS
+    assert all(r["imagery_source"] == "gsv" for r in rows)
+
+
+def test_richmond_has_no_overlap_and_is_mapillary():
+    rows, flagged = build_rows("richmond", read_images=False)
+    assert flagged == []
+    assert all(r["train_overlap"] is False for r in rows)
+    assert all(r["imagery_source"] == "mapillary" for r in rows)
+
+
+def test_det_verdicts_align_with_detections():
+    for city in ("bend", "richmond"):
+        rows, _ = build_rows(city, read_images=False)
+        for r in rows:
+            assert len(r["det_verdicts"]) == len(r["detections"])

--- a/tests/test_export_card.py
+++ b/tests/test_export_card.py
@@ -1,0 +1,60 @@
+"""Guards for the model-card metrics rendering in scripts/export_hf_model.py.
+
+The load-bearing correctness rule: Average Precision on the card must come from a
+full confidence sweep (evaluate.py with PEAK_THRESHOLD_ABS=0.0), while precision
+and recall come from the run at the operating threshold. AP taken from a
+threshold-truncated run integrates only the tail of the PR curve and reads far
+too low (e.g. 0.86 instead of 0.92 for the released checkpoint).
+"""
+import json
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
+from export_hf_model import render_eval_section  # noqa: E402
+
+# Mirrors the committed stage_two/evaluation_results_new/ files.
+THRESHOLD_METRICS = {
+    "ap": 0.8615, "total_gt_points": 3919, "peak_threshold_abs": 0.55,
+    "precision_at_threshold": 0.9492, "recall_at_threshold": 0.8727,
+    "radius_threshold_normalized": 0.022, "tta": True,
+}
+FULL_SWEEP_METRICS = {
+    "ap": 0.9205, "total_gt_points": 3919, "peak_threshold_abs": 0.0,
+    "precision_at_threshold": 0.0322, "recall_at_threshold": 0.9408,
+    "radius_threshold_normalized": 0.022, "tta": True,
+}
+
+
+def _write(tmp_path, name, obj):
+    p = tmp_path / name
+    p.write_text(json.dumps(obj))
+    return str(p)
+
+
+def test_ap_from_full_sweep_pr_from_threshold(tmp_path):
+    threshold = _write(tmp_path, "pt55.json", THRESHOLD_METRICS)
+    full = _write(tmp_path, "pt0.json", FULL_SWEEP_METRICS)
+    section = render_eval_section(threshold, full)
+    # AP is the full-sweep 0.9205, not the truncated 0.8615.
+    assert "0.9205" in section
+    assert "0.8615" not in section
+    # P/R are read at the operating threshold.
+    assert "0.9492" in section and "0.8727" in section
+    assert "threshold 0.55" in section
+
+
+def test_rejects_truncated_ap_source(tmp_path):
+    threshold = _write(tmp_path, "pt55.json", THRESHOLD_METRICS)
+    # Passing the threshold file as the AP source is the exact mistake to catch.
+    with pytest.raises(ValueError, match="full-sweep"):
+        render_eval_section(threshold, threshold)
+
+
+def test_ap_falls_back_to_metrics_when_it_is_full_sweep(tmp_path):
+    full = _write(tmp_path, "pt0.json", FULL_SWEEP_METRICS)
+    section = render_eval_section(full)  # no separate ap-json
+    assert "0.9205" in section


### PR DESCRIPTION
Staging for two Hugging Face publishes so they can be reviewed and pushed in one pass. **Nothing is pushed to the Hub by this PR** — it adds/repairs the tooling and was used to stage both artifacts locally. The actual Hub uploads (and tagging the current model revision) need credentials + sign-off.

## #29 — re-package `projectsidewalk/rampnet-model`
The live artifact is a bare `KeypointModel` that fails to load under `transformers >= 5.13` and predates the eval correction. The loading fix landed in #19; this makes the exporter able to ship it.

- `export_hf_model.py`: `--from-hub-revision` re-exports the **weights already on the Hub** (same tensors, fixed `RampNetModel` wrapper), with `--source-fingerprint`/`--source-name` for honest provenance.
- Split AP sourcing — `--ap-json` (full sweep) for AP, `--metrics-json` (operating threshold) for P/R. The old single-file path would have printed the truncated AP (0.86 vs the correct 0.92); `render_eval_section` now rejects a non-full-sweep AP source.
- Model card: corrected metrics + an **Erratum** block keeping the old paper numbers visible, plus a "weights unchanged, packaging fixed" note.
- `tests/test_export_card.py` locks the AP rule.

**Verified:** re-packaging revision `1078bcd` is bit-identical (max abs diff `0.0`) and loads via `AutoModel(trust_remote_code=True)` on transformers 5.14.1. Card: AP 0.9205, P@0.55 0.9492, R@0.55 0.8727.

## #21 — deployment-validation benchmark dataset
`build_benchmark_dataset.py` packs `benchmark/{bend,richmond}` into a parquet `DatasetDict` (one split per city) for `projectsidewalk/rampnet-benchmark`.

- **Domain-labeled, not pooled:** `bend` = in-distribution (GSV, a training city), `richmond` = OOD (Mapillary, unseen city + source). OOD Richmond scoring on par with in-dist Bend is the headline.
- **Training overlap handled transparently:** 4 Bend panos with exact ids in the training split are **kept but flagged** (`train_overlap` bool) — nothing dropped, both scorings reproducible. Excluding them shifts Bend P/R by ≤0.5 pt (inside the Wilson CIs). Richmond has zero overlap.
- Self-contained + re-scoreable via `rampnet.validation` (images, detections, per-detection verdicts, missed-ramp FNs, full metadata). Build self-verifies by reloading the parquet and re-scoring.
- Headline (default flags): bend n=110 **0.954/0.758**, richmond n=124 **0.960/0.765** — matching `benchmark/README.md`.
- `tests/test_benchmark_dataset.py` covers verdict round-trip, overlap flagging, alignment.

## Reviewer notes / follow-ups (not in this PR)
- Tag the current model Hub revision (`1078bcd`) as `v1.0-paper` before pushing #29.
- The ~2 GB benchmark imagery + both Hub uploads are staged locally, pending review.
- Exact-overlap check (Bend 4/110, Richmond 0/124) was run against `projectsidewalk/rampnet-dataset` (train 150,066 / val 42,878 / test 21,441).

36 tests pass locally (RTX 3070 CUDA venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)