### PR TITLE
Model-comparison harness: RampNet vs VLMs on the benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ benchmark/*/panos/
 benchmark/*/gallery/
 .env
 view_dump/
+.model_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dataset
 *.egg-info/
 benchmark/*/panos/
 benchmark/*/gallery/
+.env
+view_dump/

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -116,25 +116,38 @@ git-ignored repo-root `.env` (so nothing lands in the shell or transcript). Two 
   ```
   GOOGLE_GENAI_USE_VERTEXAI=true
   GOOGLE_CLOUD_PROJECT=your-project-id
-  GOOGLE_CLOUD_LOCATION=us-central1
+  GOOGLE_CLOUD_LOCATION=global
   ```
-  and once, in your own terminal: `gcloud auth application-default login` (the SDK finds the
-  ADC file automatically at runtime; gcloud itself isn't needed after login).
+  and once, in your own terminal:
+  `gcloud auth application-default login && gcloud auth application-default set-quota-project <project>`
+  (the SDK finds the ADC file automatically at runtime; gcloud itself isn't needed after login).
 - **API key** (if allowed): `GOOGLE_API_KEY=...` in `.env`.
 
-Vertex model ids can differ from the AI-Studio names; override with `--gemini-model` if
-`gemini-flash-latest` isn't recognized for your project.
+**Location matters for model availability.** The newest Gemini flash ids
+(`gemini-3.6-flash`, `gemini-3.5-flash`) are served only on the `global` Vertex location;
+regional endpoints (e.g. `us-west1`) lag — there they cap at `gemini-2.5-flash`. Use
+`global` unless an org data-residency policy requires a region (the benchmark imagery is
+public GSV/Mapillary, so residency is not a concern here). Vertex model ids differ from the
+AI-Studio aliases (`gemini-flash-latest` only resolves on `global`); pin them explicitly with
+`gemini:<model-id>` in `--models`.
 
 ## Running it
 
 ```bash
 # RampNet baseline (no GPU, no keys — reads detections from the bundle):
 python scripts/model_comparison/compare.py benchmark/richmond --models rampnet
-python scripts/model_comparison/compare.py benchmark/bend --models rampnet
 
-# Once a VLM is wired (below), add it; unwired models are skipped with a clear note:
-python scripts/model_comparison/compare.py benchmark/richmond --models rampnet,gemini,qwen
+# RampNet vs Gemini variants (needs credentials above). Each --models token is a
+# provider or provider:model_id; variants of one provider become separate rows:
+python scripts/model_comparison/compare.py benchmark/richmond \
+    --models rampnet,gemini:gemini-2.5-flash,gemini:gemini-3.6-flash
+
+# Cost control / smoke: cap panos; whole-pano lower bound instead of tiling:
+python scripts/model_comparison/compare.py benchmark/richmond --models rampnet,gemini --limit 20
+python scripts/model_comparison/compare.py benchmark/richmond --models gemini --tiling none
 ```
+
+Unwired models (Qwen) are skipped with a clear note rather than crashing the run.
 
 ## Next increments
 

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -1,0 +1,107 @@
+# Model comparison: RampNet vs. VLMs
+
+Uses the standardized curb-ramp benchmark (`benchmark/{bend,richmond}/`) to compare
+RampNet against general-purpose vision-language models that now do bounding-box detection —
+**Gemini (Flash 3.5)** via API and the latest open **Qwen3-VL** (intended to run on Hyak).
+The question: does a general VLM match or beat the purpose-trained RampNet on real
+deployment imagery (GSV + Mapillary 360)? The harness is model-agnostic, so future models
+(issue #20) plug in the same way.
+
+## Why the benchmark verdicts can't be reused directly
+
+The bundle's `verdicts.json` holds a human judgment for **each RampNet detection** (aligned
+positionally to `records.jsonl`). Those verdicts describe RampNet's points and can't score a
+different model, which produces different boxes. So we derive a **model-agnostic ground
+truth** from the same review and score every model against it identically.
+
+## Methodology
+
+Per pano (`rampnet/detection_eval.py`):
+
+- **GT ramp points** = detections the reviewer confirmed real (`True`) **∪** ramps they
+  marked as missed (non-`unsure`). This is the reviewer's complete enumeration of the real
+  curb ramps in the pano.
+- **Ignore points** = `unsure` detections **∪** `unsure` missed marks. A prediction landing
+  here is scored as **neither** TP nor FP (mirrors `validation.collect`'s `unsure`
+  abstention) — the reviewer couldn't tell from the imagery, so no model is rewarded or
+  penalized there.
+- `False` / `duplicate` detections join neither set. A duplicate is a second hit on a ramp
+  already in GT, so it becomes a false positive naturally under greedy 1:1 matching.
+
+Scoring is uniform across models: every detector's output is reduced to center points
+`(x, y[, confidence])` — a VLM box → its center — and greedily matched to GT within the
+normalized radius **0.022** (the pano value in `rampnet/metrics.py`), with the same
+anisotropic 1024/512 scaling. **Precision** counts detections on every pano; **recall** counts
+only panos whose missed-ramp check is confirmed (`no_missed` set, or a missed mark exists), so
+un-scanned panos can't bias it — the same gate `validation.collect` uses. Each of P/R/F1
+carries a **Wilson 95% CI** (`rampnet.validation.wilson_interval`).
+
+## Harness self-validation
+
+Scoring RampNet's **own** bundle detections against this derived GT reproduces the published
+verdict-based numbers within a small tolerance, which validates the harness before any VLM
+spend:
+
+| City | Harness (derived GT) | Published (verdict-based) |
+|------|----------------------|---------------------------|
+| richmond | P 0.964 / R 0.768 | P 0.960 / R 0.765 |
+| bend | P 0.961 / R 0.761 | P 0.954 / R 0.758 |
+
+The ~0.005 upward drift is expected: a RampNet `False` detection occasionally falls within
+radius of a real GT point, which the per-detection human verdict scored differently. The
+`compare.py` CLI prints both side by side.
+
+## Caveats (read before quoting numbers)
+
+- **RampNet-anchored GT.** The GT was assembled during a RampNet review. A reviewer scanning
+  fresh for another model might catch a few more ramps; the complete-scan attestation
+  (`no_missed`) mitigates this, but it is a known asymmetry.
+- **Box → point reduction.** VLM boxes are scored by their centers, at the same radius as
+  RampNet's point detections. Localization differences finer than the radius aren't measured.
+- **Equirectangular projection disadvantages VLMs.** RampNet was trained on 2048×4096
+  equirect panos; Gemini/Qwen were not, and ramps are tiny in a warped 4k+ pano. The current
+  **whole-pano** input is therefore a **lower bound** for the VLMs — see tiling below.
+- **No AP for VLMs.** VLM box detection carries no calibrated per-box confidence, so we report
+  **operating-point** P/R for all models; AP / PR-curve (via `rampnet.metrics`) applies only
+  where confidences exist (RampNet).
+
+## Status
+
+- **Shipped:** the model-agnostic scorer (`rampnet/detection_eval.py`), the comparison CLI
+  (`scripts/model_comparison/compare.py`), and the RampNet-from-bundle baseline
+  (`BundleRampNetDetector`). Tested (`tests/test_detection_eval.py`, `tests/test_model_comparison.py`).
+- **Scaffolded (this increment does not run VLMs):** `GeminiDetector` / `QwenDetector`. Their
+  image prep (whole-pano downscale) and box→point parsing (`gemini_boxes_to_points`,
+  `qwen_boxes_to_points`) are real and unit-tested; the live model call (`_raw_detect`) raises
+  `NotImplementedError` with wiring instructions.
+
+## Running it
+
+```bash
+# RampNet baseline (no GPU, no keys — reads detections from the bundle):
+python scripts/model_comparison/compare.py benchmark/richmond --models rampnet
+python scripts/model_comparison/compare.py benchmark/bend --models rampnet
+
+# Once a VLM is wired (below), add it; unwired models are skipped with a clear note:
+python scripts/model_comparison/compare.py benchmark/richmond --models rampnet,gemini,qwen
+```
+
+## Next increments
+
+1. **Wire the live VLM calls.** Implement `GeminiDetector._raw_detect` (against the current
+   `google-genai` SDK; needs `GOOGLE_API_KEY`) and `QwenDetector._raw_detect` (load Qwen3-VL
+   once in `_ensure_ready`, run on **Hyak** — the A40 OOMs at native res). Deps:
+   `pip install -r requirements-vlm.txt`. The parse functions already exist.
+2. **Equirectangular tiling** (`# TODO(tiling)` in `detectors.py`): slice each pano into
+   overlapping crops, detect per tile, remap boxes to pano-normalized coords, dedup at seams —
+   the fair-comparison input. Report whole-pano and tiled side by side.
+3. **Add the `clovis` split** once the auto-labeler hands back its bundle; the harness is
+   city-generic (it just needs `records.jsonl` + `verdicts.json` + `panos/`).
+
+## Files
+
+- `rampnet/detection_eval.py` — model-agnostic GT + scorer (pure, torch-free).
+- `scripts/model_comparison/detectors.py` — `Detector` protocol, RampNet baseline, VLM scaffolds.
+- `scripts/model_comparison/compare.py` — CLI.
+- `requirements-vlm.txt` — optional VLM deps.
+- `tests/test_detection_eval.py`, `tests/test_model_comparison.py` — guards.

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -59,21 +59,54 @@ radius of a real GT point, which the per-detection human verdict scored differen
 - **Box → point reduction.** VLM boxes are scored by their centers, at the same radius as
   RampNet's point detections. Localization differences finer than the radius aren't measured.
 - **Equirectangular projection disadvantages VLMs.** RampNet was trained on 2048×4096
-  equirect panos; Gemini/Qwen were not, and ramps are tiny in a warped 4k+ pano. The current
-  **whole-pano** input is therefore a **lower bound** for the VLMs — see tiling below.
+  equirect panos; Gemini/Qwen were not, and ramps are tiny in a warped 4k+ pano. The fair
+  input is **perspective reprojection** (default, below): the pano is reprojected into
+  overlapping rectilinear views. Whole-pano (`--tiling none`) remains available as a lower
+  bound.
 - **No AP for VLMs.** VLM box detection carries no calibrated per-box confidence, so we report
   **operating-point** P/R for all models; AP / PR-curve (via `rampnet.metrics`) applies only
   where confidences exist (RampNet).
 
+## VLM input: perspective reprojection (fair) vs whole-pano (lower bound)
+
+`--tiling perspective` (default) reprojects the pano into a ring of overlapping rectilinear
+views (`equirect_tiling.default_views`: 90° FOV, −30° pitch toward the ground, 6 yaws 60°
+apart → 30° overlap), runs the detector per view, maps each detection's center back to pano
+coordinates (`perspective_point_to_equirect`), and merges detections across the overlaps
+(`dedup_points`, with 0/1 seam wrap). This is what a VLM expects — undistorted photos —
+so it's the fair comparison. `--tiling none` sends one downscaled whole-pano call as a
+lower bound.
+
+**Seams.** Neighboring views overlap by 30°, so a ramp near a tile boundary is seen whole
+in at least one view; the duplicate detection from the adjacent view is merged by
+`dedup_points` (within the match radius). Residual nuance: a ramp truncated at a tile edge
+can yield a box whose center is offset enough to escape the dedup radius and double-count as
+a false positive — the mitigation is enough overlap that each ramp is near-centered in some
+view, which is a rig-tuning question (`fov_h_deg` / `n_yaw` / `pitch_deg`) to calibrate
+empirically once the live VLM runs.
+
+## Validating the reprojection
+
+- **Numerical** (`tests/test_equirect_tiling.py`): round-trip identity (view point → pano →
+  view recovers the original), the view center looks at its (yaw, pitch), and the
+  gnomonic-correctness invariants — the horizon renders as a straight horizontal and
+  meridians as straight verticals (a warped projection would bend them). Plus renderer/scalar
+  agreement.
+- **Visual** (`scripts/model_comparison/dump_views.py`): renders a real pano's views with a
+  graticule overlay. Great-circle meridians + the equator must render as **straight lines**;
+  buildings/poles should look like normal photos. `python scripts/model_comparison/dump_views.py
+  benchmark/richmond --out <dir>`.
+
 ## Status
 
 - **Shipped:** the model-agnostic scorer (`rampnet/detection_eval.py`), the comparison CLI
-  (`scripts/model_comparison/compare.py`), and the RampNet-from-bundle baseline
-  (`BundleRampNetDetector`). Tested (`tests/test_detection_eval.py`, `tests/test_model_comparison.py`).
+  (`scripts/model_comparison/compare.py`), the RampNet-from-bundle baseline
+  (`BundleRampNetDetector`), and the **perspective reprojection + dedup**
+  (`equirect_tiling.py`), validated numerically and visually. Tested
+  (`test_detection_eval.py`, `test_model_comparison.py`, `test_equirect_tiling.py`).
 - **Scaffolded (this increment does not run VLMs):** `GeminiDetector` / `QwenDetector`. Their
-  image prep (whole-pano downscale) and box→point parsing (`gemini_boxes_to_points`,
-  `qwen_boxes_to_points`) are real and unit-tested; the live model call (`_raw_detect`) raises
-  `NotImplementedError` with wiring instructions.
+  image prep, reprojection wiring, and box→point parsing are real and tested; only the live
+  model call (`_raw_detect`) raises `NotImplementedError` with wiring instructions.
 
 ## Running it
 
@@ -91,10 +124,11 @@ python scripts/model_comparison/compare.py benchmark/richmond --models rampnet,g
 1. **Wire the live VLM calls.** Implement `GeminiDetector._raw_detect` (against the current
    `google-genai` SDK; needs `GOOGLE_API_KEY`) and `QwenDetector._raw_detect` (load Qwen3-VL
    once in `_ensure_ready`, run on **Hyak** — the A40 OOMs at native res). Deps:
-   `pip install -r requirements-vlm.txt`. The parse functions already exist.
-2. **Equirectangular tiling** (`# TODO(tiling)` in `detectors.py`): slice each pano into
-   overlapping crops, detect per tile, remap boxes to pano-normalized coords, dedup at seams —
-   the fair-comparison input. Report whole-pano and tiled side by side.
+   `pip install -r requirements-vlm.txt`. Reprojection and the parse functions already exist.
+2. **Calibrate the reprojection rig** against the first live VLM run: tune `fov_h_deg`,
+   `n_yaw`, `pitch_deg` (and consider trimming the wasted nadir/hood region) so ramps land
+   near-centered in some view, minimizing seam-truncation false positives. Report perspective
+   vs `--tiling none` side by side.
 3. **Add the `clovis` split** once the auto-labeler hands back its bundle; the harness is
    city-generic (it just needs `records.jsonl` + `verdicts.json` + `panos/`).
 
@@ -102,6 +136,9 @@ python scripts/model_comparison/compare.py benchmark/richmond --models rampnet,g
 
 - `rampnet/detection_eval.py` — model-agnostic GT + scorer (pure, torch-free).
 - `scripts/model_comparison/detectors.py` — `Detector` protocol, RampNet baseline, VLM scaffolds.
-- `scripts/model_comparison/compare.py` — CLI.
+- `scripts/model_comparison/equirect_tiling.py` — perspective reprojection + point mapping + dedup.
+- `scripts/model_comparison/compare.py` — comparison CLI.
+- `scripts/model_comparison/dump_views.py` — visual de-distortion QA (graticule overlay).
 - `requirements-vlm.txt` — optional VLM deps.
-- `tests/test_detection_eval.py`, `tests/test_model_comparison.py` — guards.
+- `tests/test_detection_eval.py`, `tests/test_model_comparison.py`,
+  `tests/test_equirect_tiling.py` — guards.

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -2,7 +2,7 @@
 
 Uses the standardized curb-ramp benchmark (`benchmark/{bend,richmond}/`) to compare
 RampNet against general-purpose vision-language models that now do bounding-box detection —
-**Gemini (Flash 3.5)** via API and the latest open **Qwen3-VL** (intended to run on Hyak).
+**Gemini Flash** (default `gemini-3.6-flash`) via API and the latest open **Qwen3-VL** (intended to run on Hyak).
 The question: does a general VLM match or beat the purpose-trained RampNet on real
 deployment imagery (GSV + Mapillary 360)? The harness is model-agnostic, so future models
 (issue #20) plug in the same way.

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -101,12 +101,29 @@ empirically once the live VLM runs.
 
 - **Shipped:** the model-agnostic scorer (`rampnet/detection_eval.py`), the comparison CLI
   (`scripts/model_comparison/compare.py`), the RampNet-from-bundle baseline
-  (`BundleRampNetDetector`), and the **perspective reprojection + dedup**
-  (`equirect_tiling.py`), validated numerically and visually. Tested
+  (`BundleRampNetDetector`), the **perspective reprojection + dedup** (`equirect_tiling.py`),
+  and the **live `GeminiDetector`** (google-genai; API key or Vertex+ADC). Tested
   (`test_detection_eval.py`, `test_model_comparison.py`, `test_equirect_tiling.py`).
-- **Scaffolded (this increment does not run VLMs):** `GeminiDetector` / `QwenDetector`. Their
-  image prep, reprojection wiring, and box→point parsing are real and tested; only the live
-  model call (`_raw_detect`) raises `NotImplementedError` with wiring instructions.
+- **Scaffolded:** `QwenDetector` (Qwen3-VL on Hyak) — image prep, reprojection wiring, and
+  box→point parsing are real and tested; only the live `_raw_detect` raises `NotImplementedError`.
+
+## Gemini credentials
+
+The `GeminiDetector` reads credentials from the environment; `compare.py` auto-loads a
+git-ignored repo-root `.env` (so nothing lands in the shell or transcript). Two options:
+
+- **Vertex AI + ADC** (for orgs that disallow API keys). In `.env`:
+  ```
+  GOOGLE_GENAI_USE_VERTEXAI=true
+  GOOGLE_CLOUD_PROJECT=your-project-id
+  GOOGLE_CLOUD_LOCATION=us-central1
+  ```
+  and once, in your own terminal: `gcloud auth application-default login` (the SDK finds the
+  ADC file automatically at runtime; gcloud itself isn't needed after login).
+- **API key** (if allowed): `GOOGLE_API_KEY=...` in `.env`.
+
+Vertex model ids can differ from the AI-Studio names; override with `--gemini-model` if
+`gemini-flash-latest` isn't recognized for your project.
 
 ## Running it
 
@@ -121,10 +138,10 @@ python scripts/model_comparison/compare.py benchmark/richmond --models rampnet,g
 
 ## Next increments
 
-1. **Wire the live VLM calls.** Implement `GeminiDetector._raw_detect` (against the current
-   `google-genai` SDK; needs `GOOGLE_API_KEY`) and `QwenDetector._raw_detect` (load Qwen3-VL
-   once in `_ensure_ready`, run on **Hyak** — the A40 OOMs at native res). Deps:
+1. **Wire the live Qwen call.** Implement `QwenDetector._raw_detect` (load Qwen3-VL once in
+   `_ensure_ready`, run on **Hyak** — the A40 OOMs at native res). Deps:
    `pip install -r requirements-vlm.txt`. Reprojection and the parse functions already exist.
+   (Gemini is wired — see above.)
 2. **Calibrate the reprojection rig** against the first live VLM run: tune `fov_h_deg`,
    `n_yaw`, `pitch_deg` (and consider trimming the wasted nadir/hood region) so ramps land
    near-centered in some view, minimizing seam-truncation false positives. Report perspective

--- a/rampnet/detection_eval.py
+++ b/rampnet/detection_eval.py
@@ -1,0 +1,204 @@
+"""Model-agnostic detection scoring against the human-verified benchmark.
+
+`rampnet/validation.py` scores RampNet against the reviewers' *per-detection*
+verdicts, which are specific to RampNet's own detections and so can't score a
+different model. This module derives a **model-agnostic ground truth** from the
+same review and scores *any* detector's points against it identically, so
+RampNet and VLMs (Gemini, Qwen, ...) are compared on equal footing.
+
+Per pano, the ground truth is:
+  - **GT ramp points** — detections the reviewer confirmed real (`True`) plus the
+    ramps they marked as missed (non-`unsure`). This is the reviewer's complete
+    enumeration of real curb ramps in the pano.
+  - **Ignore points** — detections the reviewer marked `unsure`, and `unsure`
+    missed marks. A prediction landing here is scored as neither TP nor FP
+    (mirrors `validation.collect`'s `unsure` abstention): the reviewer couldn't
+    tell from the imagery, so no model should be rewarded or penalized there.
+  - `False`/`duplicate` detections contribute to neither set. A duplicate is a
+    second hit on a ramp already in GT, so it becomes a false positive naturally
+    when a model's own points are matched greedily 1:1.
+
+Every detector's output is reduced to center points `(x, y[, confidence])` and
+greedily matched to the GT points within a normalized radius (the pano value
+0.022, as in `rampnet/metrics.py`), using the same anisotropic x/y scaling
+(1024/512) the rest of the pipeline uses. Precision is over all panos; recall is
+over panos whose missed-ramp check is confirmed (so un-scanned panos can't bias
+it), exactly as `validation.collect` gates recall.
+
+Caveat: the GT was assembled during a RampNet review, so it is "RampNet-anchored"
+— a reviewer scanning fresh for another model might catch a few more ramps. The
+complete-scan attestation (`no_missed`) mitigates this; it is documented in
+`docs/model_comparison.md`.
+"""
+from collections import namedtuple
+
+from rampnet.validation import wilson_interval
+
+# Pano coordinate space and matching radius — identical to rampnet/metrics.py and
+# stage_two/evaluate.py so numbers stay comparable across the codebase.
+PANO_SCALE_X = 1024
+PANO_SCALE_Y = 512
+PANO_RADIUS_NORMALIZED = 0.022
+
+GroundTruth = namedtuple("GroundTruth", ["gt_points", "ignore_points", "fn_confirmed"])
+PanoScore = namedtuple("PanoScore", ["tp", "fp", "ignored", "n_gt", "fn_confirmed"])
+ScoreReport = namedtuple("ScoreReport", [
+    "precision", "recall", "f1",
+    "precision_ci", "recall_ci",
+    "tp", "fp", "fn", "ignored",
+    "n_gt_recall", "n_panos", "n_recall_panos",
+])
+
+
+def radius_sq_for(radius_normalized=PANO_RADIUS_NORMALIZED, scale_x=PANO_SCALE_X):
+    """Squared match radius in the scaled coordinate space (x-axis units)."""
+    return (radius_normalized * scale_x) ** 2
+
+
+def _xy(point):
+    """Accept a detection as a dict (x_normalized/y_normalized) or an (x, y[, ...]) tuple."""
+    if isinstance(point, dict):
+        return float(point["x_normalized"]), float(point["y_normalized"])
+    return float(point[0]), float(point[1])
+
+
+def _is_true(verdict):
+    # Raw verdicts.json carries Python bools; the parquet/encoded form uses strings.
+    return verdict is True or verdict == "true"
+
+
+def _is_unsure(verdict):
+    return verdict == "unsure"
+
+
+def build_ground_truth(detections, det_verdicts, missed, no_missed):
+    """Derive the model-agnostic ground truth for one pano.
+
+    detections: list of the reviewed RampNet detections (dicts or (x, y) tuples),
+        positionally aligned to det_verdicts.
+    det_verdicts: list of True / False / "unsure" / "duplicate" (or "true"/"false").
+    missed: list of {"x", "y", "unsure"?} marks the reviewer added.
+    no_missed: bool — the reviewer attested a complete scan with no missed ramps.
+
+    Returns a GroundTruth. ``fn_confirmed`` is True when the pano's missed-ramp
+    check is trustworthy (an explicit no-missed attestation, or at least one
+    missed mark), which is the gate for including the pano in recall.
+    """
+    if len(detections) != len(det_verdicts):
+        raise ValueError(
+            f"detections ({len(detections)}) and det_verdicts ({len(det_verdicts)}) misaligned")
+
+    gt_points, ignore_points = [], []
+    for det, verdict in zip(detections, det_verdicts):
+        if _is_true(verdict):
+            gt_points.append(_xy(det))
+        elif _is_unsure(verdict):
+            ignore_points.append(_xy(det))
+        # False / duplicate -> neither.
+
+    for mark in missed:
+        pt = (float(mark["x"]), float(mark["y"]))
+        if mark.get("unsure"):
+            ignore_points.append(pt)
+        else:
+            gt_points.append(pt)
+
+    fn_confirmed = bool(no_missed) or len(missed) > 0
+    return GroundTruth(gt_points, ignore_points, fn_confirmed)
+
+
+def _confidence(point):
+    if isinstance(point, dict):
+        return point.get("confidence")
+    return point[2] if len(point) > 2 else None
+
+
+def score_pano(pred_points, gt, radius_sq=None, scale_x=PANO_SCALE_X, scale_y=PANO_SCALE_Y):
+    """Score one pano's predictions against its GroundTruth.
+
+    Greedy one-to-one matching, highest-confidence first when confidences are
+    present (else input order): each prediction claims the nearest unclaimed GT
+    point strictly within ``radius``. A prediction with no GT in range that falls
+    within radius of an ignore point is *ignored* (neither TP nor FP); otherwise
+    it is a false positive. GT always takes priority over an ignore point.
+
+    Returns a PanoScore. False negatives are ``n_gt - tp`` (computed in aggregate,
+    and only for panos whose recall is confirmed).
+    """
+    if radius_sq is None:
+        radius_sq = radius_sq_for(scale_x=scale_x)
+
+    gt_pts = gt.gt_points
+    ignore_pts = gt.ignore_points
+
+    confs = [_confidence(p) for p in pred_points]
+    if any(c is not None for c in confs):
+        order = sorted(range(len(pred_points)),
+                       key=lambda i: confs[i] if confs[i] is not None else float("-inf"),
+                       reverse=True)
+        preds = [pred_points[i] for i in order]
+    else:
+        preds = list(pred_points)
+
+    claimed = [False] * len(gt_pts)
+    tp = fp = ignored = 0
+    for p in preds:
+        px_n, py_n = _xy(p)
+        px, py = px_n * scale_x, py_n * scale_y
+        best_k, best_dist = -1, radius_sq
+        for k, (gx, gy) in enumerate(gt_pts):
+            if claimed[k]:
+                continue
+            dist = (px - gx * scale_x) ** 2 + (py - gy * scale_y) ** 2
+            if dist < best_dist:
+                best_dist, best_k = dist, k
+        if best_k >= 0:
+            claimed[best_k] = True
+            tp += 1
+            continue
+        in_ignore = any(
+            (px - ix * scale_x) ** 2 + (py - iy * scale_y) ** 2 < radius_sq
+            for ix, iy in ignore_pts)
+        if in_ignore:
+            ignored += 1
+        else:
+            fp += 1
+
+    return PanoScore(tp=tp, fp=fp, ignored=ignored, n_gt=len(gt_pts),
+                     fn_confirmed=gt.fn_confirmed)
+
+
+def aggregate(pano_scores):
+    """Combine per-pano PanoScores into precision/recall/F1 with Wilson CIs.
+
+    Precision uses detections from every pano; recall uses only panos whose
+    missed-ramp check is confirmed (``fn_confirmed``), so panos that weren't
+    fully scanned don't deflate recall. Returns a ScoreReport.
+    """
+    tp_all = sum(s.tp for s in pano_scores)
+    fp_all = sum(s.fp for s in pano_scores)
+    ignored_all = sum(s.ignored for s in pano_scores)
+
+    recall_scores = [s for s in pano_scores if s.fn_confirmed]
+    tp_recall = sum(s.tp for s in recall_scores)
+    n_gt_recall = sum(s.n_gt for s in recall_scores)
+
+    n_preds = tp_all + fp_all
+    precision = tp_all / n_preds if n_preds else 0.0
+    recall = tp_recall / n_gt_recall if n_gt_recall else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+    return ScoreReport(
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        precision_ci=wilson_interval(tp_all, n_preds),
+        recall_ci=wilson_interval(tp_recall, n_gt_recall),
+        tp=tp_all,
+        fp=fp_all,
+        fn=n_gt_recall - tp_recall,
+        ignored=ignored_all,
+        n_gt_recall=n_gt_recall,
+        n_panos=len(pano_scores),
+        n_recall_panos=len(recall_scores),
+    )

--- a/requirements-vlm.txt
+++ b/requirements-vlm.txt
@@ -1,0 +1,13 @@
+# Optional dependencies for the VLM model-comparison harness
+# (scripts/model_comparison/). NOT needed for the core install or the test suite —
+# the detectors import these lazily and only when a live VLM run is requested.
+#
+#   pip install -r requirements-vlm.txt
+#
+# Gemini (API; needs GOOGLE_API_KEY):
+google-genai
+
+# Qwen3-VL (open weights; intended to run on Hyak, not the local box / makelab2 A40):
+#   transformers + torch are already core deps; these are the extras Qwen grounding needs.
+qwen-vl-utils
+accelerate

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -104,7 +104,7 @@ def main():
     ap.add_argument("bundle", help="Bundle dir (e.g. benchmark/richmond) with records.jsonl + verdicts.json.")
     ap.add_argument("--models", default="rampnet",
                     help="Comma-separated: rampnet,gemini,qwen (default: rampnet).")
-    ap.add_argument("--gemini-model", default="gemini-flash-latest")
+    ap.add_argument("--gemini-model", default="gemini-3.6-flash")
     ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL")
     ap.add_argument("--tiling", choices=["perspective", "none"], default="perspective",
                     help="VLM input: 'perspective' reprojects the pano into rectilinear "

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -14,6 +14,7 @@ pin a variant, so several models from the same provider compare side by side.
 See docs/model_comparison.md.
 """
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -46,6 +47,44 @@ def load_dotenv(root):
             os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
 
 
+def cache_key(label, signature, city, pano_id):
+    """Stable hash over everything that determines a detector's output for one
+    pano, so re-runs reuse cached detections and don't re-pay the API."""
+    blob = json.dumps({"label": label, "sig": signature, "city": city, "pid": pano_id},
+                      sort_keys=True, default=str)
+    return hashlib.sha1(blob.encode("utf-8")).hexdigest()
+
+
+class DetectionCache:
+    """On-disk cache of per-pano detection points (a paid VLM call is expensive;
+    scoring/radius changes are free, so we cache the detector output, not the
+    score). Sharded by key prefix. A no-op when disabled."""
+
+    def __init__(self, root, enabled=True):
+        self.root = root
+        self.enabled = enabled
+
+    def _path(self, key):
+        return os.path.join(self.root, key[:2], f"{key}.json")
+
+    def get(self, key):
+        if not self.enabled:
+            return None
+        path = self._path(key)
+        if os.path.exists(path):
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)["points"]
+        return None
+
+    def put(self, key, points):
+        if not self.enabled:
+            return
+        path = self._path(key)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"points": [list(p) for p in points]}, f)
+
+
 def load_bundle(bundle_dir):
     """Return (records_by_pid, verdicts_panos, panos_dir) for a benchmark bundle."""
     records = {}
@@ -58,23 +97,46 @@ def load_bundle(bundle_dir):
     return records, verdicts, os.path.join(bundle_dir, "panos")
 
 
-def score_model(detector, records, verdicts, panos_dir, radius_sq):
-    """Run one detector over every reviewed pano and aggregate the score."""
-    pano_scores = []
+def score_model(detector, records, verdicts, panos_dir, radius_sq, label, city, cache,
+                max_consecutive_failures=10):
+    """Run one detector over every reviewed pano and aggregate the score.
+
+    Returns ``(report, failures)``. ``detector.prepare()`` runs first (outside the
+    per-pano guard) so credential / dependency / not-wired errors propagate to the
+    caller and skip the whole model. Each pano's detections are cached, so re-runs
+    don't re-pay the API. A transient per-pano failure is recorded and skipped
+    rather than crashing the run; ``max_consecutive_failures`` aborts the model
+    early during an outage instead of burning budget."""
+    detector.prepare()
+    sig = detector.signature() if hasattr(detector, "signature") else None
+    pano_scores, failures, consecutive = [], [], 0
     for pid, entry in verdicts.items():
         rec = records[pid]
-        dets = rec["detections"]
-        gt = build_ground_truth(dets, entry["dets"], entry["missed"], entry["no_missed"])
-        sample = PanoSample(
-            pano_id=pid,
-            image_path=os.path.join(panos_dir, f"{pid}.jpg"),
-            width=rec["pano"].get("width"),
-            height=rec["pano"].get("height"),
-            meta=rec["pano"],
-        )
-        preds = detector.detect(sample)
+        gt = build_ground_truth(rec["detections"], entry["dets"], entry["missed"], entry["no_missed"])
+        key = cache_key(label, sig, city, pid) if sig is not None else None
+        preds = cache.get(key) if key else None
+        if preds is None:
+            sample = PanoSample(
+                pano_id=pid,
+                image_path=os.path.join(panos_dir, f"{pid}.jpg"),
+                width=rec["pano"].get("width"),
+                height=rec["pano"].get("height"),
+                meta=rec["pano"],
+            )
+            try:
+                preds = detector.detect(sample)
+            except Exception as e:  # transient API/network failure: isolate this pano
+                failures.append((pid, f"{type(e).__name__}: {str(e)[:120]}"))
+                consecutive += 1
+                if consecutive >= max_consecutive_failures:
+                    failures.append(("<abort>", f"{consecutive} consecutive failures; stopped early"))
+                    break
+                continue
+            consecutive = 0
+            if key:
+                cache.put(key, preds)
         pano_scores.append(score_pano(preds, gt, radius_sq=radius_sq))
-    return aggregate(pano_scores)
+    return aggregate(pano_scores), failures
 
 
 def _pct(x):
@@ -117,6 +179,10 @@ def main():
                     help=f"Normalized match radius (default {PANO_RADIUS_NORMALIZED}).")
     ap.add_argument("--limit", type=int,
                     help="Score at most N panos (smoke test / cost control for VLM runs).")
+    ap.add_argument("--cache-dir", default=str(REPO_ROOT / ".model_cache"),
+                    help="Where to cache per-pano detections (keyed by model + rig + pano). "
+                         "Re-runs reuse hits and don't re-pay the API.")
+    ap.add_argument("--no-cache", action="store_true", help="Disable the detection cache.")
     args = ap.parse_args()
 
     load_dotenv(str(REPO_ROOT))
@@ -125,9 +191,12 @@ def main():
         verdicts = dict(list(verdicts.items())[:args.limit])
     radius_sq = radius_sq_for(args.radius)
     specs = [parse_model_spec(t) for t in args.models.split(",") if t.strip()]
+    city = os.path.basename(os.path.normpath(args.bundle))
+    cache = DetectionCache(args.cache_dir, enabled=not args.no_cache)
 
     print(f"Bundle: {args.bundle}  ({len(verdicts)} reviewed panos)  "
-          f"match radius {args.radius}  ground truth: reviewer-confirmed ramps + missed marks\n")
+          f"match radius {args.radius}  ground truth: reviewer-confirmed ramps + missed marks")
+    print(f"Detection cache: {'off' if args.no_cache else args.cache_dir}\n")
 
     rows = []
     seen = {}
@@ -140,13 +209,21 @@ def main():
         else:
             seen[label] = 1
         try:
-            report = score_model(detector, records, verdicts, panos_dir, radius_sq)
+            report, failures = score_model(
+                detector, records, verdicts, panos_dir, radius_sq, label, city, cache)
         except (NotImplementedError, ImportError, RuntimeError) as e:
-            # Scaffolded VLM detectors, a missing client lib, or a missing API key:
-            # skip the model with a clear note rather than crashing the whole run.
-            print(f"[{label}] not runnable yet: {e}\n")
+            # Not-wired detector, missing client lib, or missing credentials: skip
+            # the whole model with a clear note rather than crashing the run.
+            print(f"[{label}] not runnable: {e}\n")
             continue
         rows.append((label, report))
+        if failures:
+            print(f"[{label}] {len(failures)} pano failure(s) isolated (excluded from the score):")
+            for pid, msg in failures[:5]:
+                print(f"    {pid}: {msg}")
+            if len(failures) > 5:
+                print(f"    ... and {len(failures) - 5} more")
+            print()
 
     if rows:
         print_table(rows)

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -29,6 +29,22 @@ from rampnet.validation import collect, format_report  # noqa: E402
 from detectors import PanoSample, build_detector  # noqa: E402
 
 
+def load_dotenv(root):
+    """Load KEY=VALUE lines from a repo-root .env into os.environ (without
+    overriding already-set vars), so a Gemini key can live in a git-ignored file
+    instead of the shell/transcript. Minimal parser — no python-dotenv dependency."""
+    path = os.path.join(root, ".env")
+    if not os.path.exists(path):
+        return
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            os.environ.setdefault(key.strip(), val.strip().strip('"').strip("'"))
+
+
 def load_bundle(bundle_dir):
     """Return (records_by_pid, verdicts_panos, panos_dir) for a benchmark bundle."""
     records = {}
@@ -96,9 +112,14 @@ def main():
                          "No effect on rampnet.")
     ap.add_argument("--radius", type=float, default=PANO_RADIUS_NORMALIZED,
                     help=f"Normalized match radius (default {PANO_RADIUS_NORMALIZED}).")
+    ap.add_argument("--limit", type=int,
+                    help="Score at most N panos (smoke test / cost control for VLM runs).")
     args = ap.parse_args()
 
+    load_dotenv(str(REPO_ROOT))
     records, verdicts, panos_dir = load_bundle(args.bundle)
+    if args.limit:
+        verdicts = dict(list(verdicts.items())[:args.limit])
     radius_sq = radius_sq_for(args.radius)
     model_names = [m.strip() for m in args.models.split(",") if m.strip()]
 

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -90,6 +90,10 @@ def main():
                     help="Comma-separated: rampnet,gemini,qwen (default: rampnet).")
     ap.add_argument("--gemini-model", default="gemini-flash-latest")
     ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL")
+    ap.add_argument("--tiling", choices=["perspective", "none"], default="perspective",
+                    help="VLM input: 'perspective' reprojects the pano into rectilinear "
+                         "views (fair); 'none' uses one whole-pano call (lower bound). "
+                         "No effect on rampnet.")
     ap.add_argument("--radius", type=float, default=PANO_RADIUS_NORMALIZED,
                     help=f"Normalized match radius (default {PANO_RADIUS_NORMALIZED}).")
     args = ap.parse_args()

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -1,0 +1,127 @@
+"""Compare curb-ramp detectors on a benchmark bundle.
+
+Scores each selected model against the same model-agnostic ground truth derived
+from the human review (see rampnet/detection_eval.py), so RampNet and the VLMs
+are compared on equal footing. RampNet's verdict-based numbers are re-printed as
+a cross-check.
+
+    python scripts/model_comparison/compare.py benchmark/richmond --models rampnet
+    python scripts/model_comparison/compare.py benchmark/bend --models rampnet,gemini
+
+This increment ships the harness + the RampNet baseline; the VLM detectors are
+scaffolded (a --models gemini/qwen run raises a clear NotImplementedError until
+their live calls are wired). See docs/model_comparison.md.
+"""
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))          # rampnet.* (editable install fallback)
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # local detectors.py
+
+from rampnet.detection_eval import (  # noqa: E402
+    build_ground_truth, score_pano, aggregate, radius_sq_for, PANO_RADIUS_NORMALIZED,
+)
+from rampnet.validation import collect, format_report  # noqa: E402
+from detectors import PanoSample, build_detector  # noqa: E402
+
+
+def load_bundle(bundle_dir):
+    """Return (records_by_pid, verdicts_panos, panos_dir) for a benchmark bundle."""
+    records = {}
+    with open(os.path.join(bundle_dir, "records.jsonl"), encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                r = json.loads(line)
+                records[r["pano"]["panorama_id"]] = r
+    verdicts = json.load(open(os.path.join(bundle_dir, "verdicts.json"), encoding="utf-8"))["panos"]
+    return records, verdicts, os.path.join(bundle_dir, "panos")
+
+
+def score_model(detector, records, verdicts, panos_dir, radius_sq):
+    """Run one detector over every reviewed pano and aggregate the score."""
+    pano_scores = []
+    for pid, entry in verdicts.items():
+        rec = records[pid]
+        dets = rec["detections"]
+        gt = build_ground_truth(dets, entry["dets"], entry["missed"], entry["no_missed"])
+        sample = PanoSample(
+            pano_id=pid,
+            image_path=os.path.join(panos_dir, f"{pid}.jpg"),
+            width=rec["pano"].get("width"),
+            height=rec["pano"].get("height"),
+            meta=rec["pano"],
+        )
+        preds = detector.detect(sample)
+        pano_scores.append(score_pano(preds, gt, radius_sq=radius_sq))
+    return aggregate(pano_scores)
+
+
+def _pct(x):
+    return f"{x:.3f}"
+
+
+def _ci(lo_hi):
+    return f"({lo_hi[0]:.3f}-{lo_hi[1]:.3f})"
+
+
+def print_table(rows):
+    header = f"{'model':<10} {'P':>6} {'95% CI':>15} {'R':>6} {'95% CI':>15} {'F1':>6}   {'tp/fp/fn/ign':>16}"
+    print(header)
+    print("-" * len(header))
+    for name, r in rows:
+        counts = f"{r.tp}/{r.fp}/{r.fn}/{r.ignored}"
+        print(f"{name:<10} {_pct(r.precision):>6} {_ci(r.precision_ci):>15} "
+              f"{_pct(r.recall):>6} {_ci(r.recall_ci):>15} {_pct(r.f1):>6}   {counts:>16}")
+
+
+def main():
+    # Windows consoles are cp1252; avoid UnicodeEncodeError on stray bytes.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(errors="replace")
+
+    ap = argparse.ArgumentParser(description="Compare curb-ramp detectors on a benchmark bundle.")
+    ap.add_argument("bundle", help="Bundle dir (e.g. benchmark/richmond) with records.jsonl + verdicts.json.")
+    ap.add_argument("--models", default="rampnet",
+                    help="Comma-separated: rampnet,gemini,qwen (default: rampnet).")
+    ap.add_argument("--gemini-model", default="gemini-flash-latest")
+    ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL")
+    ap.add_argument("--radius", type=float, default=PANO_RADIUS_NORMALIZED,
+                    help=f"Normalized match radius (default {PANO_RADIUS_NORMALIZED}).")
+    args = ap.parse_args()
+
+    records, verdicts, panos_dir = load_bundle(args.bundle)
+    radius_sq = radius_sq_for(args.radius)
+    model_names = [m.strip() for m in args.models.split(",") if m.strip()]
+
+    print(f"Bundle: {args.bundle}  ({len(verdicts)} reviewed panos)  "
+          f"match radius {args.radius}  ground truth: reviewer-confirmed ramps + missed marks\n")
+
+    rows = []
+    for name in model_names:
+        detector = build_detector(name, records, args)
+        try:
+            report = score_model(detector, records, verdicts, panos_dir, radius_sq)
+        except (NotImplementedError, ImportError, RuntimeError) as e:
+            # Scaffolded VLM detectors, a missing client lib, or a missing API key:
+            # skip the model with a clear note rather than crashing the whole run.
+            print(f"[{name}] not runnable yet: {e}\n")
+            continue
+        rows.append((name, report))
+
+    if rows:
+        print_table(rows)
+
+    # Cross-check: RampNet's own verdict-based P/R (the published definition).
+    confs_by_pid = {pid: [d["confidence"] for d in records[pid]["detections"]] for pid in verdicts}
+    pools = collect(verdicts, confs_by_pid)
+    print()
+    print(format_report("RampNet verdict-based cross-check", pools))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -93,8 +93,42 @@ def load_bundle(bundle_dir):
             if line.strip():
                 r = json.loads(line)
                 records[r["pano"]["panorama_id"]] = r
-    verdicts = json.load(open(os.path.join(bundle_dir, "verdicts.json"), encoding="utf-8"))["panos"]
+    with open(os.path.join(bundle_dir, "verdicts.json"), encoding="utf-8") as f:
+        verdicts = json.load(f)["panos"]
     return records, verdicts, os.path.join(bundle_dir, "panos")
+
+
+def validate_bundle(records, verdicts):
+    """Fail fast on a structurally broken bundle, *before* any (paid) detector call.
+
+    ``score_model`` builds each pano's ground truth from ``records[pid]`` + the
+    verdict entry outside its per-pano failure guard (that guard is for transient
+    detect() errors, not data integrity). Without this pre-flight a reviewed pano
+    missing from records.jsonl, a missing verdict field, or detections/verdicts
+    that don't line up would surface as a raw KeyError/ValueError partway through a
+    long VLM run — after spend, and aborting models already scored. Catch it here
+    with a clear message instead. Raises SystemExit listing every offending pano.
+
+    (Legacy verdicts.json without ``no_missed`` are intentionally rejected here
+    rather than silently defaulted — the current/planned bundles are new-schema;
+    see docs/model_comparison.md.)"""
+    problems = []
+    for pid, entry in verdicts.items():
+        rec = records.get(pid)
+        if rec is None:
+            problems.append(f"{pid}: reviewed in verdicts.json but absent from records.jsonl")
+            continue
+        missing = [k for k in ("dets", "missed", "no_missed") if k not in entry]
+        if missing:
+            problems.append(f"{pid}: verdict entry missing field(s) {missing}")
+            continue
+        n_det, n_ver = len(rec.get("detections", [])), len(entry["dets"])
+        if n_det != n_ver:
+            problems.append(f"{pid}: {n_det} detections vs {n_ver} verdicts (misaligned)")
+    if problems:
+        shown = "\n  ".join(problems[:10])
+        more = f"\n  ... and {len(problems) - 10} more" if len(problems) > 10 else ""
+        raise SystemExit(f"Bundle validation failed ({len(problems)} pano(s)):\n  {shown}{more}")
 
 
 def score_model(detector, records, verdicts, panos_dir, radius_sq, label, city, cache,
@@ -189,6 +223,7 @@ def main():
     records, verdicts, panos_dir = load_bundle(args.bundle)
     if args.limit:
         verdicts = dict(list(verdicts.items())[:args.limit])
+    validate_bundle(records, verdicts)  # fail fast before any (paid) detector call
     radius_sq = radius_sq_for(args.radius)
     specs = [parse_model_spec(t) for t in args.models.split(",") if t.strip()]
     city = os.path.basename(os.path.normpath(args.bundle))
@@ -233,6 +268,10 @@ def main():
     pools = collect(verdicts, confs_by_pid)
     print()
     print(format_report("RampNet verdict-based cross-check", pools))
+    # collect() records verdict/results mismatches as notes and leaves surfacing to
+    # the caller; print them so a silently-skipped pano is visible, not swallowed.
+    for w in pools.warnings:
+        print(f"  ! {w}")
 
 
 if __name__ == "__main__":

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -6,11 +6,12 @@ are compared on equal footing. RampNet's verdict-based numbers are re-printed as
 a cross-check.
 
     python scripts/model_comparison/compare.py benchmark/richmond --models rampnet
-    python scripts/model_comparison/compare.py benchmark/bend --models rampnet,gemini
+    python scripts/model_comparison/compare.py benchmark/richmond \
+        --models rampnet,gemini:gemini-2.5-flash,gemini:gemini-3.6-flash
 
-This increment ships the harness + the RampNet baseline; the VLM detectors are
-scaffolded (a --models gemini/qwen run raises a clear NotImplementedError until
-their live calls are wired). See docs/model_comparison.md.
+Each --models token is a provider (rampnet/gemini/qwen) or provider:model_id to
+pin a variant, so several models from the same provider compare side by side.
+See docs/model_comparison.md.
 """
 import argparse
 import json
@@ -26,7 +27,7 @@ from rampnet.detection_eval import (  # noqa: E402
     build_ground_truth, score_pano, aggregate, radius_sq_for, PANO_RADIUS_NORMALIZED,
 )
 from rampnet.validation import collect, format_report  # noqa: E402
-from detectors import PanoSample, build_detector  # noqa: E402
+from detectors import PanoSample, build_detector, parse_model_spec  # noqa: E402
 
 
 def load_dotenv(root):
@@ -85,12 +86,12 @@ def _ci(lo_hi):
 
 
 def print_table(rows):
-    header = f"{'model':<10} {'P':>6} {'95% CI':>15} {'R':>6} {'95% CI':>15} {'F1':>6}   {'tp/fp/fn/ign':>16}"
+    header = f"{'model':<22} {'P':>6} {'95% CI':>15} {'R':>6} {'95% CI':>15} {'F1':>6}   {'tp/fp/fn/ign':>16}"
     print(header)
     print("-" * len(header))
     for name, r in rows:
         counts = f"{r.tp}/{r.fp}/{r.fn}/{r.ignored}"
-        print(f"{name:<10} {_pct(r.precision):>6} {_ci(r.precision_ci):>15} "
+        print(f"{name:<22} {_pct(r.precision):>6} {_ci(r.precision_ci):>15} "
               f"{_pct(r.recall):>6} {_ci(r.recall_ci):>15} {_pct(r.f1):>6}   {counts:>16}")
 
 
@@ -103,7 +104,9 @@ def main():
     ap = argparse.ArgumentParser(description="Compare curb-ramp detectors on a benchmark bundle.")
     ap.add_argument("bundle", help="Bundle dir (e.g. benchmark/richmond) with records.jsonl + verdicts.json.")
     ap.add_argument("--models", default="rampnet",
-                    help="Comma-separated: rampnet,gemini,qwen (default: rampnet).")
+                    help="Comma-separated detectors. Each is a provider (rampnet/gemini/qwen, "
+                         "using its default model) or provider:model_id to pin a variant, e.g. "
+                         "'rampnet,gemini:gemini-2.5-flash,gemini:gemini-3.6-flash'.")
     ap.add_argument("--gemini-model", default="gemini-3.6-flash")
     ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL")
     ap.add_argument("--tiling", choices=["perspective", "none"], default="perspective",
@@ -121,22 +124,29 @@ def main():
     if args.limit:
         verdicts = dict(list(verdicts.items())[:args.limit])
     radius_sq = radius_sq_for(args.radius)
-    model_names = [m.strip() for m in args.models.split(",") if m.strip()]
+    specs = [parse_model_spec(t) for t in args.models.split(",") if t.strip()]
 
     print(f"Bundle: {args.bundle}  ({len(verdicts)} reviewed panos)  "
           f"match radius {args.radius}  ground truth: reviewer-confirmed ramps + missed marks\n")
 
     rows = []
-    for name in model_names:
-        detector = build_detector(name, records, args)
+    seen = {}
+    for provider, model_id in specs:
+        label, detector = build_detector(provider, model_id, records, args)
+        # Disambiguate if the same label appears twice (e.g. same model, two configs).
+        if label in seen:
+            seen[label] += 1
+            label = f"{label}#{seen[label]}"
+        else:
+            seen[label] = 1
         try:
             report = score_model(detector, records, verdicts, panos_dir, radius_sq)
         except (NotImplementedError, ImportError, RuntimeError) as e:
             # Scaffolded VLM detectors, a missing client lib, or a missing API key:
             # skip the model with a clear note rather than crashing the whole run.
-            print(f"[{name}] not runnable yet: {e}\n")
+            print(f"[{label}] not runnable yet: {e}\n")
             continue
-        rows.append((name, report))
+        rows.append((label, report))
 
     if rows:
         print_table(rows)

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -22,6 +22,10 @@ from collections import namedtuple
 PanoSample = namedtuple("PanoSample", ["pano_id", "image_path", "width", "height", "meta"])
 
 
+def _truthy(v):
+    return str(v).strip().lower() in ("1", "true", "yes", "on") if v is not None else False
+
+
 def load_pano_image(path, max_edge=None):
     """Open a benchmark pano as RGB, optionally downscaling so its longest edge
     is <= ``max_edge``. Lifts PIL's decompression-bomb cap (Bend GSV panos are
@@ -165,9 +169,17 @@ class GeminiDetector(_VLMDetector):
     name = "gemini"
     max_edge = 1568  # Gemini tiles internally; a modest cap keeps token cost sane
 
-    def __init__(self, model_id="gemini-flash-latest", api_key=None, max_edge=None, tile=True):
+    def __init__(self, model_id="gemini-flash-latest", api_key=None, max_edge=None, tile=True,
+                 use_vertex=None, project=None, location=None):
         super().__init__(model_id, max_edge, tile=tile)
         self.api_key = api_key or os.environ.get("GOOGLE_API_KEY")
+        # Vertex AI + Application Default Credentials is the path for orgs that
+        # disallow API keys. Driven by the standard google-genai env vars unless
+        # overridden explicitly.
+        self.use_vertex = (_truthy(os.environ.get("GOOGLE_GENAI_USE_VERTEXAI"))
+                           if use_vertex is None else use_vertex)
+        self.project = project or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        self.location = location or os.environ.get("GOOGLE_CLOUD_LOCATION") or "us-central1"
         self._client = None
 
     def _ensure_ready(self):
@@ -177,12 +189,22 @@ class GeminiDetector(_VLMDetector):
             raise ImportError(
                 "GeminiDetector needs the `google-genai` package "
                 "(pip install -r requirements-vlm.txt)") from e
-        if not self.api_key:
-            raise RuntimeError(
-                "GeminiDetector needs GOOGLE_API_KEY (set it in the environment or a "
-                "git-ignored .env at the repo root).")
-        if self._client is None:
+        if self._client is not None:
+            return
+        if self.use_vertex:
+            if not self.project:
+                raise RuntimeError(
+                    "Vertex mode needs GOOGLE_CLOUD_PROJECT (and ADC via "
+                    "`gcloud auth application-default login`).")
+            self._client = genai.Client(vertexai=True, project=self.project, location=self.location)
+        elif self.api_key:
             self._client = genai.Client(api_key=self.api_key)
+        else:
+            raise RuntimeError(
+                "No Gemini credentials. For orgs that disallow API keys, use Vertex + ADC: "
+                "set GOOGLE_GENAI_USE_VERTEXAI=true and GOOGLE_CLOUD_PROJECT (plus optional "
+                "GOOGLE_CLOUD_LOCATION) in a git-ignored .env, and run "
+                "`gcloud auth application-default login`. Otherwise set GOOGLE_API_KEY.")
 
     def _raw_detect(self, image):
         from google.genai import types

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -258,15 +258,30 @@ class QwenDetector(_VLMDetector):
         return qwen_boxes_to_points(raw, img_w, img_h)
 
 
-def build_detector(name, records, args):
-    """Instantiate a detector by name. RampNet reads from ``records``; the VLM
-    detectors take their model id and input mode (perspective tiling vs whole-pano)
-    from ``args``."""
-    if name == "rampnet":
-        return BundleRampNetDetector(records)
+def parse_model_spec(token):
+    """Parse a ``--models`` token into ``(provider, model_id_or_None)``.
+
+    A token is either a bare provider (``rampnet`` / ``gemini`` / ``qwen``, which
+    uses that provider's default model) or ``provider:model_id`` to pin a specific
+    variant — e.g. ``gemini:gemini-2.5-flash`` vs ``gemini:gemini-3.6-flash`` — so
+    several variants of the same provider can be compared in one run."""
+    provider, _, model_id = token.partition(":")
+    return provider.strip(), (model_id.strip() or None)
+
+
+def build_detector(provider, model_id, records, args):
+    """Instantiate a detector for one ``(provider, model_id)`` spec, returning
+    ``(label, detector)``. The label is the concrete model id for VLMs (so
+    variants are distinguishable in the results table) and ``rampnet`` for the
+    baseline. RampNet reads from ``records``; the VLM input mode (perspective
+    tiling vs whole-pano) comes from ``args``."""
+    if provider == "rampnet":
+        return "rampnet", BundleRampNetDetector(records)
     tile = getattr(args, "tiling", "perspective") != "none"
-    if name == "gemini":
-        return GeminiDetector(model_id=args.gemini_model, tile=tile)
-    if name == "qwen":
-        return QwenDetector(model_id=args.qwen_model, tile=tile)
-    raise ValueError(f"unknown model '{name}' (choose from: rampnet, gemini, qwen)")
+    if provider == "gemini":
+        mid = model_id or args.gemini_model
+        return mid, GeminiDetector(model_id=mid, tile=tile)
+    if provider == "qwen":
+        mid = model_id or args.qwen_model
+        return mid, QwenDetector(model_id=mid, tile=tile)
+    raise ValueError(f"unknown provider '{provider}' (choose from: rampnet, gemini, qwen)")

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -1,0 +1,186 @@
+"""Detectors for the model-comparison harness.
+
+A ``Detector`` turns one pano into a list of center-point detections
+``(x_norm, y_norm, confidence_or_None)`` that the harness scores against the
+model-agnostic ground truth (see ``rampnet/detection_eval.py``).
+
+- ``BundleRampNetDetector`` reads RampNet's detections straight from the
+  benchmark ``records.jsonl`` — free, no model load, no GPU. This is the baseline.
+- ``GeminiDetector`` / ``QwenDetector`` are **scaffolds** for this increment: the
+  image preparation (whole-pano downscale) and the box->center-point parsing are
+  real and unit-tested, but the raw model call (``_raw_detect``) raises
+  ``NotImplementedError`` with instructions. Wiring the live calls (and, later,
+  equirectangular tiling for a fair comparison) is the next increment. See
+  ``docs/model_comparison.md``.
+"""
+import os
+from collections import namedtuple
+
+# A pano to run a detector on. image_path points at the native-res JPEG in the
+# bundle's (git-ignored) panos/ dir; RampNet-from-bundle never opens it.
+PanoSample = namedtuple("PanoSample", ["pano_id", "image_path", "width", "height", "meta"])
+
+
+def load_pano_image(path, max_edge=None):
+    """Open a benchmark pano as RGB, optionally downscaling so its longest edge
+    is <= ``max_edge``. Lifts PIL's decompression-bomb cap (Bend GSV panos are
+    16384x8192, above the default limit)."""
+    from PIL import Image
+    Image.MAX_IMAGE_PIXELS = None
+    img = Image.open(path).convert("RGB")
+    if max_edge and max(img.size) > max_edge:
+        scale = max_edge / max(img.size)
+        img = img.resize((round(img.width * scale), round(img.height * scale)), Image.BILINEAR)
+    return img
+
+
+class BundleRampNetDetector:
+    """RampNet's baseline detections, read from the benchmark records.jsonl."""
+
+    name = "rampnet"
+
+    def __init__(self, records):
+        # records: {pano_id: record_dict} from the bundle's records.jsonl.
+        self.records = records
+
+    def detect(self, sample):
+        dets = self.records[sample.pano_id]["detections"]
+        return [(d["x_normalized"], d["y_normalized"], d["confidence"]) for d in dets]
+
+
+# --- VLM box parsing (pure, unit-tested) ------------------------------------
+
+def gemini_boxes_to_points(items):
+    """Gemini returns ``box_2d = [ymin, xmin, ymax, xmax]`` normalized to 0-1000.
+    Reduce each box to its normalized [0,1] center point. Confidence is None
+    (Gemini bbox detection carries no calibrated score)."""
+    points = []
+    for it in items:
+        ymin, xmin, ymax, xmax = it["box_2d"]
+        cx = (xmin + xmax) / 2.0 / 1000.0
+        cy = (ymin + ymax) / 2.0 / 1000.0
+        points.append((cx, cy, None))
+    return points
+
+
+def qwen_boxes_to_points(items, img_w, img_h):
+    """Qwen grounding returns absolute-pixel boxes ``bbox_2d = [x1, y1, x2, y2]``
+    against the image it was shown. Normalize each box center by that image's
+    width/height (the size actually sent to the model, not the native pano)."""
+    points = []
+    for it in items:
+        x1, y1, x2, y2 = it["bbox_2d"]
+        cx = (x1 + x2) / 2.0 / img_w
+        cy = (y1 + y2) / 2.0 / img_h
+        points.append((cx, cy, None))
+    return points
+
+
+# --- VLM detector scaffolds -------------------------------------------------
+
+DETECTION_PROMPT = (
+    "Detect every curb ramp (sidewalk wheelchair ramp at a street corner) visible "
+    "in this street-level image. Return one bounding box per curb ramp."
+)
+
+
+class _VLMDetector:
+    """Shared whole-pano scaffold. Subclasses implement ``_raw_detect`` (the live
+    model call) and ``_parse`` (provider box format -> center points)."""
+
+    name = "vlm"
+    max_edge = 1536  # whole-pano downscale; TODO(tiling): replace with overlapping crops
+
+    def __init__(self, model_id, max_edge=None):
+        self.model_id = model_id
+        if max_edge:
+            self.max_edge = max_edge
+
+    def detect(self, sample):
+        self._ensure_ready()
+        image = load_pano_image(sample.image_path, self.max_edge)  # whole-pano (lower bound)
+        raw = self._raw_detect(image)          # TODO(tiling) + per-provider live call
+        return self._parse(raw, image.width, image.height)
+
+    def _ensure_ready(self):
+        raise NotImplementedError
+
+    def _raw_detect(self, image):
+        raise NotImplementedError
+
+    def _parse(self, raw, img_w, img_h):
+        raise NotImplementedError
+
+
+class GeminiDetector(_VLMDetector):
+    name = "gemini"
+    max_edge = 1568  # Gemini tiles internally; a modest cap keeps token cost sane
+
+    def __init__(self, model_id="gemini-flash-latest", api_key=None, max_edge=None):
+        super().__init__(model_id, max_edge)
+        self.api_key = api_key or os.environ.get("GOOGLE_API_KEY")
+        self._client = None
+
+    def _ensure_ready(self):
+        try:
+            from google import genai  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "GeminiDetector needs the `google-genai` package "
+                "(pip install -r requirements-vlm.txt)") from e
+        if not self.api_key:
+            raise RuntimeError("GeminiDetector needs GOOGLE_API_KEY in the environment.")
+
+    def _raw_detect(self, image):
+        # TODO(increment 2): call genai.Client(api_key=...).models.generate_content(
+        #   model=self.model_id, contents=[image, DETECTION_PROMPT], config=<JSON schema
+        #   of {box_2d:[ymin,xmin,ymax,xmax], label}>) and return the parsed list.
+        raise NotImplementedError(
+            "GeminiDetector live call is scaffolded, not wired (this increment ships the "
+            "harness + RampNet baseline). Implement _raw_detect against the current genai "
+            "SDK, then feed its items to gemini_boxes_to_points via _parse. "
+            "See docs/model_comparison.md.")
+
+    def _parse(self, raw, img_w, img_h):
+        return gemini_boxes_to_points(raw)
+
+
+class QwenDetector(_VLMDetector):
+    name = "qwen"
+    max_edge = 2048  # Qwen3-VL handles large inputs; run on Hyak (A40 OOMs at native)
+
+    def __init__(self, model_id="Qwen/Qwen3-VL", max_edge=None):
+        super().__init__(model_id, max_edge)
+
+    def _ensure_ready(self):
+        try:
+            import transformers  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "QwenDetector needs `transformers` (+ qwen-vl-utils, accelerate) "
+                "(pip install -r requirements-vlm.txt)") from e
+
+    def _raw_detect(self, image):
+        # TODO(increment 2, Hyak): load Qwen3-VL once (transformers AutoModelForCausalLM /
+        #   Qwen3VL class + processor), run the grounding prompt, parse the JSON grounding
+        #   output to [{bbox_2d:[x1,y1,x2,y2]}]. Model load belongs in _ensure_ready so it
+        #   happens once per run, not per pano.
+        raise NotImplementedError(
+            "QwenDetector live call is scaffolded, not wired. Implement _raw_detect on Hyak "
+            "(load Qwen3-VL once in _ensure_ready), then feed items to qwen_boxes_to_points "
+            "via _parse. See docs/model_comparison.md.")
+
+    def _parse(self, raw, img_w, img_h):
+        return qwen_boxes_to_points(raw, img_w, img_h)
+
+
+def build_detector(name, records, args):
+    """Instantiate a detector by name. RampNet reads from ``records``; the VLM
+    detectors take their model id from ``args``."""
+    if name == "rampnet":
+        return BundleRampNetDetector(records)
+    if name == "gemini":
+        return GeminiDetector(model_id=args.gemini_model)
+    if name == "qwen":
+        return QwenDetector(model_id=args.qwen_model)
+    raise ValueError(f"unknown model '{name}' (choose from: rampnet, gemini, qwen)")

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -85,22 +85,54 @@ DETECTION_PROMPT = (
 
 
 class _VLMDetector:
-    """Shared whole-pano scaffold. Subclasses implement ``_raw_detect`` (the live
-    model call) and ``_parse`` (provider box format -> center points)."""
+    """Shared scaffold. Subclasses implement ``_raw_detect`` (the live model call)
+    and ``_parse`` (provider box format -> center points, normalized within the
+    image shown to the model).
+
+    Two input modes:
+      - ``tile=True`` (default, the fair input): reproject the pano into a ring of
+        overlapping rectilinear views, detect in each, map centers back to pano
+        coordinates, and dedup across the overlaps.
+      - ``tile=False``: one downscaled whole-pano call (a lower bound; the pano is
+        warped and ramps are tiny)."""
 
     name = "vlm"
-    max_edge = 1536  # whole-pano downscale; TODO(tiling): replace with overlapping crops
+    max_edge = 1536       # whole-pano downscale cap
+    source_max_edge = 4096  # cap on the pano fed to reprojection (native can be 16k)
 
-    def __init__(self, model_id, max_edge=None):
+    def __init__(self, model_id, max_edge=None, tile=True, views=None):
         self.model_id = model_id
         if max_edge:
             self.max_edge = max_edge
+        self.tile = tile
+        self._views = views  # None -> equirect_tiling.default_views()
 
     def detect(self, sample):
         self._ensure_ready()
+        if self.tile:
+            return self._detect_tiled(sample)
         image = load_pano_image(sample.image_path, self.max_edge)  # whole-pano (lower bound)
-        raw = self._raw_detect(image)          # TODO(tiling) + per-provider live call
+        raw = self._raw_detect(image)
         return self._parse(raw, image.width, image.height)
+
+    def _detect_tiled(self, sample):
+        from equirect_tiling import (
+            default_views, equirect_to_perspective, perspective_point_to_equirect, dedup_points)
+        from rampnet.detection_eval import radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y
+
+        pano = load_pano_image(sample.image_path, self.source_max_edge)
+        views = self._views or default_views()
+        points = []
+        for view in views:
+            view_img = equirect_to_perspective(pano, view)
+            raw = self._raw_detect(view_img)
+            # _parse returns points normalized WITHIN the view; map each back to the pano.
+            for (u, v, conf) in self._parse(raw, view.width, view.height):
+                x, y = perspective_point_to_equirect(u, v, view)
+                points.append((x, y, conf))
+        # Overlapping views see seam-straddling ramps in more than one tile; merge
+        # detections closer than the match radius (with 0/1 seam wrap).
+        return dedup_points(points, radius_sq_for(), PANO_SCALE_X, PANO_SCALE_Y)
 
     def _ensure_ready(self):
         raise NotImplementedError
@@ -116,8 +148,8 @@ class GeminiDetector(_VLMDetector):
     name = "gemini"
     max_edge = 1568  # Gemini tiles internally; a modest cap keeps token cost sane
 
-    def __init__(self, model_id="gemini-flash-latest", api_key=None, max_edge=None):
-        super().__init__(model_id, max_edge)
+    def __init__(self, model_id="gemini-flash-latest", api_key=None, max_edge=None, tile=True):
+        super().__init__(model_id, max_edge, tile=tile)
         self.api_key = api_key or os.environ.get("GOOGLE_API_KEY")
         self._client = None
 
@@ -149,8 +181,8 @@ class QwenDetector(_VLMDetector):
     name = "qwen"
     max_edge = 2048  # Qwen3-VL handles large inputs; run on Hyak (A40 OOMs at native)
 
-    def __init__(self, model_id="Qwen/Qwen3-VL", max_edge=None):
-        super().__init__(model_id, max_edge)
+    def __init__(self, model_id="Qwen/Qwen3-VL", max_edge=None, tile=True):
+        super().__init__(model_id, max_edge, tile=tile)
 
     def _ensure_ready(self):
         try:
@@ -176,11 +208,13 @@ class QwenDetector(_VLMDetector):
 
 def build_detector(name, records, args):
     """Instantiate a detector by name. RampNet reads from ``records``; the VLM
-    detectors take their model id from ``args``."""
+    detectors take their model id and input mode (perspective tiling vs whole-pano)
+    from ``args``."""
     if name == "rampnet":
         return BundleRampNetDetector(records)
+    tile = getattr(args, "tiling", "perspective") != "none"
     if name == "gemini":
-        return GeminiDetector(model_id=args.gemini_model)
+        return GeminiDetector(model_id=args.gemini_model, tile=tile)
     if name == "qwen":
-        return QwenDetector(model_id=args.qwen_model)
+        return QwenDetector(model_id=args.qwen_model, tile=tile)
     raise ValueError(f"unknown model '{name}' (choose from: rampnet, gemini, qwen)")

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -6,12 +6,12 @@ model-agnostic ground truth (see ``rampnet/detection_eval.py``).
 
 - ``BundleRampNetDetector`` reads RampNet's detections straight from the
   benchmark ``records.jsonl`` — free, no model load, no GPU. This is the baseline.
-- ``GeminiDetector`` / ``QwenDetector`` are **scaffolds** for this increment: the
-  image preparation (whole-pano downscale) and the box->center-point parsing are
-  real and unit-tested, but the raw model call (``_raw_detect``) raises
-  ``NotImplementedError`` with instructions. Wiring the live calls (and, later,
-  equirectangular tiling for a fair comparison) is the next increment. See
-  ``docs/model_comparison.md``.
+- ``GeminiDetector`` is **live** (google-genai; API key or Vertex+ADC): it
+  reprojects the pano into rectilinear views (``equirect_tiling``), runs the model
+  per view, and maps boxes back to pano coordinates.
+- ``QwenDetector`` is still a **scaffold** (Qwen3-VL on Hyak): image prep,
+  reprojection wiring, and box parsing are real, but the live ``_raw_detect``
+  raises ``NotImplementedError``. See ``docs/model_comparison.md``.
 """
 import json
 import os
@@ -169,7 +169,7 @@ class GeminiDetector(_VLMDetector):
     name = "gemini"
     max_edge = 1568  # Gemini tiles internally; a modest cap keeps token cost sane
 
-    def __init__(self, model_id="gemini-flash-latest", api_key=None, max_edge=None, tile=True,
+    def __init__(self, model_id="gemini-3.6-flash", api_key=None, max_edge=None, tile=True,
                  use_vertex=None, project=None, location=None):
         super().__init__(model_id, max_edge, tile=tile)
         self.api_key = api_key or os.environ.get("GOOGLE_API_KEY")

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -48,6 +48,9 @@ class BundleRampNetDetector:
         # records: {pano_id: record_dict} from the bundle's records.jsonl.
         self.records = records
 
+    def prepare(self):
+        pass  # nothing to load; detections come from the bundle.
+
     def detect(self, sample):
         dets = self.records[sample.pano_id]["detections"]
         return [(d["x_normalized"], d["y_normalized"], d["confidence"]) for d in dets]
@@ -136,6 +139,12 @@ class _VLMDetector:
         raw = self._raw_detect(image)
         return self._parse(raw, image.width, image.height)
 
+    def prepare(self):
+        """Build the client / load the model up front so credential, dependency,
+        or not-yet-wired errors surface once (failing the model fast) instead of
+        once per pano."""
+        self._ensure_ready()
+
     def _detect_tiled(self, sample):
         from equirect_tiling import (
             default_views, equirect_to_perspective, perspective_point_to_equirect, dedup_points)
@@ -164,6 +173,22 @@ class _VLMDetector:
     def _parse(self, raw, img_w, img_h):
         raise NotImplementedError
 
+    def signature(self):
+        """A stable description of everything that affects this detector's output,
+        used as the detection cache key. Changing the model, tiling rig, or prompt
+        invalidates cached detections."""
+        from equirect_tiling import default_views
+        views = self._views or (default_views() if self.tile else None)
+        return {
+            "provider": self.name,
+            "model_id": self.model_id,
+            "tile": self.tile,
+            "max_edge": self.max_edge,
+            "source_max_edge": self.source_max_edge,
+            "views": [list(v) for v in views] if views else None,
+            "prompt": DETECTION_PROMPT,
+        }
+
 
 class GeminiDetector(_VLMDetector):
     name = "gemini"
@@ -185,20 +210,27 @@ class GeminiDetector(_VLMDetector):
     def _ensure_ready(self):
         try:
             from google import genai
+            from google.genai import types
         except ImportError as e:
             raise ImportError(
                 "GeminiDetector needs the `google-genai` package "
                 "(pip install -r requirements-vlm.txt)") from e
         if self._client is not None:
             return
+        # Explicit retry policy for the ~hundreds of calls a full-city run makes:
+        # exponential backoff + jitter on the transient/rate-limit status codes.
+        http_options = types.HttpOptions(retry_options=types.HttpRetryOptions(
+            attempts=5, initial_delay=1.0, max_delay=30.0, exp_base=2.0, jitter=1.0,
+            http_status_codes=[408, 429, 500, 502, 503, 504]))
         if self.use_vertex:
             if not self.project:
                 raise RuntimeError(
                     "Vertex mode needs GOOGLE_CLOUD_PROJECT (and ADC via "
                     "`gcloud auth application-default login`).")
-            self._client = genai.Client(vertexai=True, project=self.project, location=self.location)
+            self._client = genai.Client(vertexai=True, project=self.project,
+                                        location=self.location, http_options=http_options)
         elif self.api_key:
-            self._client = genai.Client(api_key=self.api_key)
+            self._client = genai.Client(api_key=self.api_key, http_options=http_options)
         else:
             raise RuntimeError(
                 "No Gemini credentials. For orgs that disallow API keys, use Vertex + ADC: "
@@ -243,6 +275,11 @@ class QwenDetector(_VLMDetector):
             raise ImportError(
                 "QwenDetector needs `transformers` (+ qwen-vl-utils, accelerate) "
                 "(pip install -r requirements-vlm.txt)") from e
+        # Not yet wired: fail fast at prepare() so the model is skipped cleanly
+        # rather than failing per pano. Wiring this is the Hyak increment.
+        raise NotImplementedError(
+            "QwenDetector is scaffolded, not wired. Load Qwen3-VL in _ensure_ready and "
+            "implement _raw_detect (run on Hyak). See docs/model_comparison.md.")
 
     def _raw_detect(self, image):
         # TODO(increment 2, Hyak): load Qwen3-VL once (transformers AutoModelForCausalLM /

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -204,7 +204,11 @@ class GeminiDetector(_VLMDetector):
         self.use_vertex = (_truthy(os.environ.get("GOOGLE_GENAI_USE_VERTEXAI"))
                            if use_vertex is None else use_vertex)
         self.project = project or os.environ.get("GOOGLE_CLOUD_PROJECT")
-        self.location = location or os.environ.get("GOOGLE_CLOUD_LOCATION") or "us-central1"
+        # Default to `global`, not a region: the newest flash ids (the default
+        # gemini-3.6-flash) are served only there; regional endpoints lag and 404
+        # on them. Override with GOOGLE_CLOUD_LOCATION only for a data-residency
+        # policy (benchmark imagery is public GSV/Mapillary). See docs/model_comparison.md.
+        self.location = location or os.environ.get("GOOGLE_CLOUD_LOCATION") or "global"
         self._client = None
 
     def _ensure_ready(self):
@@ -286,6 +290,10 @@ class QwenDetector(_VLMDetector):
         #   Qwen3VL class + processor), run the grounding prompt, parse the JSON grounding
         #   output to [{bbox_2d:[x1,y1,x2,y2]}]. Model load belongs in _ensure_ready so it
         #   happens once per run, not per pano.
+        #   NOTE: Qwen's bbox pixels are relative to the image the processor *actually*
+        #   fed the model, which its smart-resize rounds to multiples of 28 — not the
+        #   (view.width, view.height) passed to _parse. Return that processed (w, h)
+        #   from _raw_detect and normalize qwen_boxes_to_points by it, else centers drift.
         raise NotImplementedError(
             "QwenDetector live call is scaffolded, not wired. Implement _raw_detect on Hyak "
             "(load Qwen3-VL once in _ensure_ready), then feed items to qwen_boxes_to_points "

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -13,6 +13,7 @@ model-agnostic ground truth (see ``rampnet/detection_eval.py``).
   equirectangular tiling for a fair comparison) is the next increment. See
   ``docs/model_comparison.md``.
 """
+import json
 import os
 from collections import namedtuple
 
@@ -50,6 +51,19 @@ class BundleRampNetDetector:
 
 # --- VLM box parsing (pure, unit-tested) ------------------------------------
 
+def boxes_from_gemini_response(resp):
+    """Pull ``[{box_2d, label}, ...]`` out of a google-genai response, whether the
+    SDK returned parsed schema objects (``resp.parsed``) or raw JSON text."""
+    parsed = getattr(resp, "parsed", None)
+    if parsed:
+        return [{"box_2d": list(b.box_2d), "label": getattr(b, "label", "")} for b in parsed]
+    text = getattr(resp, "text", None)
+    if not text:
+        return []
+    data = json.loads(text)
+    return data if isinstance(data, list) else data.get("boxes", [])
+
+
 def gemini_boxes_to_points(items):
     """Gemini returns ``box_2d = [ymin, xmin, ymax, xmax]`` normalized to 0-1000.
     Reduce each box to its normalized [0,1] center point. Confidence is None
@@ -79,8 +93,11 @@ def qwen_boxes_to_points(items, img_w, img_h):
 # --- VLM detector scaffolds -------------------------------------------------
 
 DETECTION_PROMPT = (
-    "Detect every curb ramp (sidewalk wheelchair ramp at a street corner) visible "
-    "in this street-level image. Return one bounding box per curb ramp."
+    "Detect every curb ramp in this street-level image. A curb ramp (curb cut) is the "
+    "short sloped ramp cut into a sidewalk curb at a street corner or crossing that lets "
+    "a wheelchair or stroller roll from sidewalk to street. Return one tight bounding box "
+    "per curb ramp. Do not box driveways, stairs, or crosswalk paint. If there are no curb "
+    "ramps, return an empty list."
 )
 
 
@@ -155,23 +172,36 @@ class GeminiDetector(_VLMDetector):
 
     def _ensure_ready(self):
         try:
-            from google import genai  # noqa: F401
+            from google import genai
         except ImportError as e:
             raise ImportError(
                 "GeminiDetector needs the `google-genai` package "
                 "(pip install -r requirements-vlm.txt)") from e
         if not self.api_key:
-            raise RuntimeError("GeminiDetector needs GOOGLE_API_KEY in the environment.")
+            raise RuntimeError(
+                "GeminiDetector needs GOOGLE_API_KEY (set it in the environment or a "
+                "git-ignored .env at the repo root).")
+        if self._client is None:
+            self._client = genai.Client(api_key=self.api_key)
 
     def _raw_detect(self, image):
-        # TODO(increment 2): call genai.Client(api_key=...).models.generate_content(
-        #   model=self.model_id, contents=[image, DETECTION_PROMPT], config=<JSON schema
-        #   of {box_2d:[ymin,xmin,ymax,xmax], label}>) and return the parsed list.
-        raise NotImplementedError(
-            "GeminiDetector live call is scaffolded, not wired (this increment ships the "
-            "harness + RampNet baseline). Implement _raw_detect against the current genai "
-            "SDK, then feed its items to gemini_boxes_to_points via _parse. "
-            "See docs/model_comparison.md.")
+        from google.genai import types
+        from pydantic import BaseModel
+
+        class BoundingBox(BaseModel):
+            box_2d: list[int]   # [ymin, xmin, ymax, xmax], normalized 0-1000
+            label: str
+
+        resp = self._client.models.generate_content(
+            model=self.model_id,
+            contents=[image, DETECTION_PROMPT],
+            config=types.GenerateContentConfig(
+                response_mime_type="application/json",
+                response_schema=list[BoundingBox],
+                temperature=0.0,
+            ),
+        )
+        return boxes_from_gemini_response(resp)
 
     def _parse(self, raw, img_w, img_h):
         return gemini_boxes_to_points(raw)

--- a/scripts/model_comparison/dump_views.py
+++ b/scripts/model_comparison/dump_views.py
@@ -1,0 +1,112 @@
+"""Visual QA for the perspective reprojection.
+
+Renders a pano's rectilinear views and overlays a graticule. A correct gnomonic
+projection renders every great circle (all meridians of constant longitude, and
+the equator/horizon) as a **straight line**; if the reprojection were still
+equirectangularly warped these would visibly bend. So: straight graticule lines +
+natural-looking buildings/poles = the de-distortion is working.
+
+    python scripts/model_comparison/dump_views.py benchmark/richmond --out <dir>
+    python scripts/model_comparison/dump_views.py benchmark/bend --pano <id> --no-grid
+
+Produces one PNG per view plus a contact sheet.
+"""
+import argparse
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from equirect_tiling import default_views, equirect_to_perspective, equirect_point_to_perspective  # noqa: E402
+from detectors import load_pano_image  # noqa: E402
+
+
+def _first_pano_id(bundle_dir):
+    with open(os.path.join(bundle_dir, "records.jsonl"), encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                return json.loads(line)["pano"]["panorama_id"]
+    raise SystemExit("no records in bundle")
+
+
+def _polyline(view, x, lat_range):
+    """Project a meridian (constant pano X, varying latitude) into a view; return
+    the in-view pixel points."""
+    pts = []
+    for i in range(lat_range[0], lat_range[1] + 1, 2):
+        y = 0.5 - i / 180.0
+        uv = equirect_point_to_perspective(x, y, view)
+        if uv is not None:
+            pts.append((uv[0] * view.width, uv[1] * view.height))
+    return pts
+
+
+def _equator(view):
+    pts = []
+    for lon_deg in range(-180, 181, 2):
+        uv = equirect_point_to_perspective(lon_deg / 360.0 + 0.5, 0.5, view)
+        if uv is not None:
+            pts.append((uv[0] * view.width, uv[1] * view.height))
+    return pts
+
+
+def _overlay_graticule(img, view):
+    from PIL import ImageDraw
+    draw = ImageDraw.Draw(img)
+    for lon_deg in range(0, 360, 15):                       # meridians (great circles)
+        pts = _polyline(view, lon_deg / 360.0 + 0.5, (-80, 80))
+        if len(pts) >= 2:
+            draw.line(pts, fill=(255, 90, 90), width=1)
+    eq = _equator(view)                                     # equator / horizon
+    if len(eq) >= 2:
+        draw.line(eq, fill=(90, 160, 255), width=2)
+    return img
+
+
+def _contact_sheet(images, cols=3):
+    from PIL import Image
+    rows = math.ceil(len(images) / cols)
+    w, h = images[0].size
+    sheet = Image.new("RGB", (cols * w, rows * h), (20, 20, 20))
+    for i, im in enumerate(images):
+        sheet.paste(im, ((i % cols) * w, (i // cols) * h))
+    return sheet
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render + graticule-overlay a pano's perspective views.")
+    ap.add_argument("bundle", help="Bundle dir (benchmark/<city>).")
+    ap.add_argument("--pano", help="Pano id (default: first in the bundle).")
+    ap.add_argument("--out", default="view_dump", help="Output directory.")
+    ap.add_argument("--no-grid", action="store_true", help="Skip the graticule overlay.")
+    ap.add_argument("--source-max-edge", type=int, default=4096)
+    args = ap.parse_args()
+
+    pano_id = args.pano or _first_pano_id(args.bundle)
+    pano_path = os.path.join(args.bundle, "panos", f"{pano_id}.jpg")
+    if not os.path.exists(pano_path):
+        raise SystemExit(f"pano image not found: {pano_path} (bundle panos/ are git-ignored; "
+                         "they must be present locally)")
+
+    os.makedirs(args.out, exist_ok=True)
+    pano = load_pano_image(pano_path, args.source_max_edge)
+    views = default_views()
+    rendered = []
+    for i, view in enumerate(views):
+        im = equirect_to_perspective(pano, view)
+        if not args.no_grid:
+            im = _overlay_graticule(im, view)
+        name = f"view_{i}_yaw{int(view.yaw_deg)}_pitch{int(view.pitch_deg)}.png"
+        im.save(os.path.join(args.out, name))
+        rendered.append(im)
+
+    sheet_path = os.path.join(args.out, f"contact_{pano_id}.png")
+    _contact_sheet(rendered).save(sheet_path)
+    print(f"Wrote {len(rendered)} views + contact sheet to {args.out}/ (pano {pano_id})")
+    print(f"Contact sheet: {sheet_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model_comparison/equirect_tiling.py
+++ b/scripts/model_comparison/equirect_tiling.py
@@ -1,0 +1,174 @@
+"""Perspective reprojection of equirectangular panos for VLM detection.
+
+VLMs are trained on ordinary rectilinear photos, not 360 equirectangular panos,
+and curb ramps sit on the ground near the bottom of the pano where equirectangular
+vertical stretch is worst. To give a VLM a fair input we reproject the pano into a
+ring of overlapping **rectilinear virtual-camera views** (gnomonic projection,
+pitched down toward the ground), detect in each undistorted view, then map each
+detection's center back to pano-normalized coordinates and dedup across the
+overlaps.
+
+The load-bearing, unit-tested core here is the coordinate math:
+``perspective_point_to_equirect`` (map a point in a view back to the pano) and its
+inverse ``equirect_point_to_perspective`` (round-trip check + visibility test).
+``equirect_to_perspective`` renders the actual view image for the live VLM call.
+
+Conventions: world axes are right-handed with +z forward (pano longitude 0), +x
+right/east, +y up. Equirectangular normalized coords ``(X, Y)`` in ``[0, 1]``:
+``lon = (X-0.5)*2pi``, ``lat = (0.5-Y)*pi``.
+"""
+import math
+from collections import namedtuple
+
+View = namedtuple("View", ["yaw_deg", "pitch_deg", "fov_h_deg", "fov_v_deg", "width", "height"])
+
+TWO_PI = 2.0 * math.pi
+
+
+# --- vector helpers ---------------------------------------------------------
+
+def _cross(a, b):
+    return (a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0])
+
+
+def _dot(a, b):
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _norm(a):
+    m = math.sqrt(_dot(a, a)) or 1.0
+    return (a[0] / m, a[1] / m, a[2] / m)
+
+
+# --- spherical <-> equirectangular ------------------------------------------
+
+def _dir_from_equirect(x, y):
+    lon = (x - 0.5) * TWO_PI
+    lat = (0.5 - y) * math.pi
+    cl = math.cos(lat)
+    return (cl * math.sin(lon), math.sin(lat), cl * math.cos(lon))
+
+
+def _equirect_from_dir(d):
+    lon = math.atan2(d[0], d[2])
+    lat = math.asin(max(-1.0, min(1.0, d[1])))
+    x = (lon / TWO_PI + 0.5) % 1.0
+    y = min(1.0, max(0.0, 0.5 - lat / math.pi))
+    return x, y
+
+
+def _camera_basis(yaw_deg, pitch_deg):
+    """Right-handed, roll-free camera basis (forward, right, up) for a view
+    looking at longitude=yaw, latitude=pitch."""
+    yaw, pitch = math.radians(yaw_deg), math.radians(pitch_deg)
+    cp = math.cos(pitch)
+    forward = (cp * math.sin(yaw), math.sin(pitch), cp * math.cos(yaw))
+    right = _norm(_cross((0.0, 1.0, 0.0), forward))
+    up = _cross(forward, right)
+    return forward, right, up
+
+
+# --- point mapping (the tested core) ----------------------------------------
+
+def perspective_point_to_equirect(u, v, view):
+    """Map a point ``(u, v)`` (normalized [0,1] within the view, origin top-left)
+    to pano-normalized ``(X, Y)``."""
+    f, r, up = _camera_basis(view.yaw_deg, view.pitch_deg)
+    th = math.tan(math.radians(view.fov_h_deg) / 2.0)
+    tv = math.tan(math.radians(view.fov_v_deg) / 2.0)
+    a = (u * 2.0 - 1.0) * th
+    b = (1.0 - v * 2.0) * tv
+    ray = _norm((f[0] + a * r[0] + b * up[0],
+                 f[1] + a * r[1] + b * up[1],
+                 f[2] + a * r[2] + b * up[2]))
+    return _equirect_from_dir(ray)
+
+
+def equirect_point_to_perspective(x, y, view):
+    """Inverse of ``perspective_point_to_equirect``. Returns ``(u, v)`` if the
+    pano point falls inside this view, else ``None`` (behind camera or outside FOV).
+    Used for round-trip tests and cross-view visibility checks."""
+    d = _dir_from_equirect(x, y)
+    f, r, up = _camera_basis(view.yaw_deg, view.pitch_deg)
+    zc = _dot(d, f)
+    if zc <= 1e-9:
+        return None
+    th = math.tan(math.radians(view.fov_h_deg) / 2.0)
+    tv = math.tan(math.radians(view.fov_v_deg) / 2.0)
+    u = (_dot(d, r) / zc / th + 1.0) / 2.0
+    v = (1.0 - _dot(d, up) / zc / tv) / 2.0
+    if 0.0 <= u <= 1.0 and 0.0 <= v <= 1.0:
+        return u, v
+    return None
+
+
+def default_views(fov_h_deg=90.0, fov_v_deg=90.0, pitch_deg=-30.0, n_yaw=6,
+                   width=1024, height=1024):
+    """A ring of ``n_yaw`` evenly spaced views pitched toward the ground. With the
+    default 90 deg FOV and 6 yaws (60 deg apart) neighboring views overlap by 30 deg,
+    so a ramp near a seam is seen whole in at least one view (dedup handles the
+    double-detection)."""
+    step = 360.0 / n_yaw
+    return [View(i * step, pitch_deg, fov_h_deg, fov_v_deg, width, height)
+            for i in range(n_yaw)]
+
+
+# --- rendering (for the live VLM call) --------------------------------------
+
+def equirect_to_perspective(pil_img, view):
+    """Render one rectilinear view from an equirectangular PIL image (nearest-
+    neighbor sampling — sufficient for feeding a detector). Vectorized mirror of
+    ``perspective_point_to_equirect``."""
+    import numpy as np
+    from PIL import Image
+
+    src = np.asarray(pil_img)
+    sh, sw = src.shape[:2]
+    W, H = view.width, view.height
+
+    f, r, up = _camera_basis(view.yaw_deg, view.pitch_deg)
+    th = math.tan(math.radians(view.fov_h_deg) / 2.0)
+    tv = math.tan(math.radians(view.fov_v_deg) / 2.0)
+
+    uu = ((np.arange(W) + 0.5) / W * 2.0 - 1.0) * th          # (W,)
+    vv = (1.0 - (np.arange(H) + 0.5) / H * 2.0) * tv          # (H,)
+    a = uu[None, :]                                           # (1,W)
+    b = vv[:, None]                                           # (H,1)
+
+    dx = f[0] + a * r[0] + b * up[0]
+    dy = f[1] + a * r[1] + b * up[1]
+    dz = f[2] + a * r[2] + b * up[2]
+    inv = 1.0 / np.sqrt(dx * dx + dy * dy + dz * dz)
+    dx, dy, dz = dx * inv, dy * inv, dz * inv
+
+    lon = np.arctan2(dx, dz)
+    lat = np.arcsin(np.clip(dy, -1.0, 1.0))
+    sx = np.clip(((lon / TWO_PI + 0.5) % 1.0) * sw, 0, sw - 1).astype(np.int64)
+    sy = np.clip((0.5 - lat / math.pi) * sh, 0, sh - 1).astype(np.int64)
+    return Image.fromarray(src[sy, sx])
+
+
+# --- cross-view dedup -------------------------------------------------------
+
+def dedup_points(points, radius_sq, scale_x, scale_y):
+    """Greedily merge points closer than the match radius (highest confidence
+    kept first). X distance wraps at the 0/1 seam so a ramp split across the pano
+    edge isn't double-counted."""
+    ordered = sorted(points, key=lambda p: (p[2] if len(p) > 2 and p[2] is not None else float("-inf")),
+                     reverse=True)
+    kept = []
+    for p in ordered:
+        px, py = p[0], p[1]
+        dup = False
+        for k in kept:
+            ddx = abs(px - k[0])
+            ddx = min(ddx, 1.0 - ddx) * scale_x       # wrap at the seam
+            ddy = (py - k[1]) * scale_y
+            if ddx * ddx + ddy * ddy < radius_sq:
+                dup = True
+                break
+        if not dup:
+            kept.append(p)
+    return kept

--- a/tests/test_detection_eval.py
+++ b/tests/test_detection_eval.py
@@ -1,0 +1,134 @@
+"""Guards for the model-agnostic detection scorer (rampnet/detection_eval.py).
+
+Two layers: unit tests that pin the ground-truth construction and matching
+semantics with trivial unit-scale geometry, and an integration test that scores
+RampNet's own committed detections against the derived ground truth and checks it
+reproduces the published verdict-based numbers (the harness self-validation).
+"""
+import json
+import os
+
+from rampnet.detection_eval import (
+    GroundTruth, PanoScore,
+    build_ground_truth, score_pano, aggregate,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Unit scale + radius 0.5 (radius_sq 0.25): plain Euclidean on raw coords.
+UNIT = dict(scale_x=1, scale_y=1, radius_sq=0.25)
+
+
+# --- build_ground_truth -----------------------------------------------------
+
+def test_ground_truth_partitions_verdicts():
+    dets = [(0.1, 0.1), (0.2, 0.2), (0.3, 0.3), (0.4, 0.4)]
+    verdicts = [True, False, "unsure", "duplicate"]
+    missed = [{"x": 0.5, "y": 0.5}, {"x": 0.6, "y": 0.6, "unsure": True}]
+    gt = build_ground_truth(dets, verdicts, missed, no_missed=False)
+    assert gt.gt_points == [(0.1, 0.1), (0.5, 0.5)]        # true det + confident miss
+    assert gt.ignore_points == [(0.3, 0.3), (0.6, 0.6)]    # unsure det + unsure miss
+    assert gt.fn_confirmed is True                          # a missed mark exists
+
+
+def test_ground_truth_accepts_dicts_and_string_verdicts():
+    dets = [{"x_normalized": 0.1, "y_normalized": 0.2},
+            {"x_normalized": 0.3, "y_normalized": 0.4}]
+    gt = build_ground_truth(dets, ["true", "false"], missed=[], no_missed=True)
+    assert gt.gt_points == [(0.1, 0.2)]
+    assert gt.ignore_points == []
+    assert gt.fn_confirmed is True   # explicit complete-scan attestation
+
+
+def test_ground_truth_unconfirmed_when_no_missed_false_and_no_marks():
+    gt = build_ground_truth([(0.1, 0.1)], [True], missed=[], no_missed=False)
+    assert gt.fn_confirmed is False
+
+
+def test_ground_truth_rejects_misaligned_verdicts():
+    try:
+        build_ground_truth([(0.1, 0.1)], [True, False], missed=[], no_missed=True)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError on misaligned detections/verdicts")
+
+
+# --- score_pano -------------------------------------------------------------
+
+def _gt(gt_points, ignore_points=(), fn_confirmed=True):
+    return GroundTruth(list(gt_points), list(ignore_points), fn_confirmed)
+
+
+def test_score_true_positive_and_false_positive():
+    gt = _gt([(0.0, 0.0)])
+    assert score_pano([(0.0, 0.0)], gt, **UNIT)[:3] == (1, 0, 0)   # tp
+    assert score_pano([(5.0, 5.0)], gt, **UNIT)[:3] == (0, 1, 0)   # fp
+
+
+def test_score_ignore_zone_drops_prediction():
+    gt = _gt([], ignore_points=[(0.0, 0.0)])
+    tp, fp, ignored = score_pano([(0.1, 0.0)], gt, **UNIT)[:3]
+    assert (tp, fp, ignored) == (0, 0, 1)   # neither TP nor FP
+
+
+def test_score_duplicate_is_false_positive():
+    gt = _gt([(0.0, 0.0)])
+    tp, fp, ignored = score_pano([(0.0, 0.0, 0.9), (0.1, 0.0, 0.5)], gt, **UNIT)[:3]
+    assert (tp, fp, ignored) == (1, 1, 0)   # second hit on the same ramp -> FP
+
+
+def test_score_gt_takes_priority_over_ignore():
+    gt = _gt([(0.0, 0.0)], ignore_points=[(0.1, 0.0)])
+    tp, fp, ignored = score_pano([(0.05, 0.0)], gt, **UNIT)[:3]
+    assert (tp, fp, ignored) == (1, 0, 0)   # claims the GT, not ignored
+
+
+# --- aggregate --------------------------------------------------------------
+
+def test_aggregate_gates_recall_on_confirmed_panos():
+    scores = [
+        PanoScore(tp=1, fp=0, ignored=0, n_gt=2, fn_confirmed=True),
+        PanoScore(tp=1, fp=1, ignored=0, n_gt=1, fn_confirmed=False),
+    ]
+    r = aggregate(scores)
+    assert r.precision == 2 / 3          # all detections count for precision
+    assert r.recall == 1 / 2             # only the confirmed pano's GT counts
+    assert r.fn == 1                     # 2 GT - 1 TP on the confirmed pano
+    assert r.n_recall_panos == 1 and r.n_panos == 2
+
+
+# --- integration: RampNet reproduces its published numbers ------------------
+
+def _load_bundle(city):
+    cdir = os.path.join(REPO_ROOT, "benchmark", city)
+    records = {}
+    with open(os.path.join(cdir, "records.jsonl"), encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                r = json.loads(line)
+                records[r["pano"]["panorama_id"]] = r
+    verdicts = json.load(open(os.path.join(cdir, "verdicts.json"), encoding="utf-8"))["panos"]
+    return records, verdicts
+
+
+def _score_rampnet(city):
+    records, verdicts = _load_bundle(city)
+    pano_scores = []
+    for pid, entry in verdicts.items():
+        dets = records[pid]["detections"]
+        gt = build_ground_truth(dets, entry["dets"], entry["missed"], entry["no_missed"])
+        preds = [(d["x_normalized"], d["y_normalized"], d["confidence"]) for d in dets]
+        pano_scores.append(score_pano(preds, gt))
+    return aggregate(pano_scores)
+
+
+def test_rampnet_reproduces_published_numbers():
+    # Published verdict-based numbers (benchmark/README.md). The point-matching
+    # scorer should land within a small tolerance; the only source of drift is a
+    # RampNet "false" detection occasionally falling within radius of a real GT
+    # point, which the per-detection human verdict scored differently.
+    expected = {"richmond": (0.960, 0.765), "bend": (0.954, 0.758)}
+    for city, (exp_p, exp_r) in expected.items():
+        r = _score_rampnet(city)
+        assert abs(r.precision - exp_p) <= 0.03, f"{city} precision {r.precision:.3f} vs {exp_p}"
+        assert abs(r.recall - exp_r) <= 0.03, f"{city} recall {r.recall:.3f} vs {exp_r}"

--- a/tests/test_equirect_tiling.py
+++ b/tests/test_equirect_tiling.py
@@ -1,0 +1,137 @@
+"""Correctness guards for the perspective reprojection (scripts/model_comparison/
+equirect_tiling.py).
+
+The scoring only trusts reprojection if the geometry is right, so these pin it
+three ways:
+  1. Round-trip identity: forward-projecting a pano point into a view and mapping
+     it back recovers the original point (the inverse map is exact).
+  2. De-distortion invariants: a correct gnomonic projection renders the horizon
+     as a straight horizontal line and meridians as straight vertical lines. If
+     the projection were wrong (e.g. still equirectangularly warped), these would
+     bend.
+  3. Renderer/scalar consistency: the vectorized image renderer agrees with the
+     scalar point map, and a constant image reprojects to a constant image.
+"""
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "model_comparison"))
+
+from equirect_tiling import (  # noqa: E402
+    View, default_views,
+    perspective_point_to_equirect, equirect_point_to_perspective,
+    equirect_to_perspective, dedup_points,
+)
+
+PITCHED = View(yaw_deg=0.0, pitch_deg=-30.0, fov_h_deg=90.0, fov_v_deg=90.0, width=512, height=512)
+LEVEL = View(yaw_deg=0.0, pitch_deg=0.0, fov_h_deg=90.0, fov_v_deg=90.0, width=512, height=512)
+
+
+# --- 1. round-trip identity -------------------------------------------------
+
+def test_roundtrip_view_point_to_pano_and_back():
+    for u in (0.2, 0.5, 0.8):
+        for v in (0.2, 0.5, 0.8):
+            x, y = perspective_point_to_equirect(u, v, PITCHED)
+            back = equirect_point_to_perspective(x, y, PITCHED)
+            assert back is not None
+            assert abs(back[0] - u) < 1e-6 and abs(back[1] - v) < 1e-6
+
+
+def test_view_center_looks_at_yaw_pitch():
+    x, y = perspective_point_to_equirect(0.5, 0.5, PITCHED)
+    assert abs(x - 0.5) < 1e-9              # yaw 0 -> longitude 0 -> X 0.5
+    assert abs(y - (0.5 + 30.0 / 180.0)) < 1e-9   # pitch -30 -> latitude -30 -> Y 0.6667
+
+
+def test_point_behind_camera_is_not_visible():
+    # A pano point at the opposite longitude is behind a yaw-0 view.
+    assert equirect_point_to_perspective(0.0, 0.5, LEVEL) is None   # X=0 -> lon -180
+
+
+# --- 2. de-distortion invariants (gnomonic straightness) --------------------
+
+def test_horizon_renders_as_straight_horizontal():
+    # Horizon = latitude 0 (Y=0.5). In a level view every horizon point must land
+    # on the same image row (v == 0.5).
+    for lon_deg in (-40, -20, 0, 20, 40):        # within the 45 deg half-FOV
+        x = lon_deg / 360.0 + 0.5
+        uv = equirect_point_to_perspective(x, 0.5, LEVEL)
+        assert uv is not None
+        assert abs(uv[1] - 0.5) < 1e-9
+
+
+def test_meridian_renders_as_straight_vertical():
+    # A meridian (constant longitude, a great circle) must render as a vertical
+    # line: constant u as latitude varies.
+    lon_deg = 20.0
+    x = lon_deg / 360.0 + 0.5
+    us = []
+    for lat_deg in (-30, -15, 0, 15, 30):
+        y = 0.5 - lat_deg / 180.0
+        uv = equirect_point_to_perspective(x, y, LEVEL)
+        assert uv is not None
+        us.append(uv[0])
+    assert max(us) - min(us) < 1e-9
+
+
+# --- 3. renderer / scalar consistency ---------------------------------------
+
+def _make_src(w, h):
+    import numpy as np
+    xs = (np.arange(w)[None, :] * 7) % 256
+    ys = (np.arange(h)[:, None] * 13) % 256
+    grey = ((xs + ys) % 256).astype("uint8")
+    return np.stack([grey, grey, grey], axis=-1)
+
+
+def test_renderer_size_and_scalar_agreement():
+    import numpy as np
+    from PIL import Image
+
+    sw, sh = 360, 180
+    src = Image.fromarray(_make_src(sw, sh))
+    view = View(10.0, -20.0, 90.0, 90.0, 64, 48)
+    out = np.asarray(equirect_to_perspective(src, view))
+    assert out.shape == (48, 64, 3)
+
+    src_arr = np.asarray(src)
+    for col, row in [(32, 24), (5, 40), (60, 3)]:
+        u = (col + 0.5) / view.width
+        v = (row + 0.5) / view.height
+        x, y = perspective_point_to_equirect(u, v, view)
+        # The renderer samples the same (X, Y) -> source pixel this scalar map returns.
+        sx = min(int((x % 1.0) * sw), sw - 1)
+        sy = min(int(y * sh), sh - 1)
+        assert tuple(out[row, col]) == tuple(src_arr[sy, sx])
+
+
+def test_constant_image_reprojects_constant():
+    import numpy as np
+    from PIL import Image
+    src = Image.fromarray(np.full((180, 360, 3), 123, dtype="uint8"))
+    out = np.asarray(equirect_to_perspective(src, LEVEL))
+    assert (out == 123).all()
+
+
+# --- dedup (seam handling) --------------------------------------------------
+
+def test_dedup_merges_near_and_wraps_seam():
+    from rampnet.detection_eval import radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y
+    rsq = radius_sq_for()
+    # Two near points -> one; a far point survives.
+    pts = [(0.500, 0.500, 0.9), (0.505, 0.500, 0.5), (0.800, 0.500, 0.7)]
+    kept = dedup_points(pts, rsq, PANO_SCALE_X, PANO_SCALE_Y)
+    assert len(kept) == 2
+    assert kept[0][0] == 0.500   # higher-confidence of the near pair kept first
+    # Seam wrap: X=0.002 and X=0.998 are ~0.004 apart across the 0/1 edge -> merge.
+    wrapped = dedup_points([(0.002, 0.5, None), (0.998, 0.5, None)], rsq, PANO_SCALE_X, PANO_SCALE_Y)
+    assert len(wrapped) == 1
+
+
+def test_default_views_overlap_for_seam_coverage():
+    views = default_views()          # 6 views, 90 deg FOV -> 60 deg apart
+    assert len(views) == 6
+    step = views[1].yaw_deg - views[0].yaw_deg
+    assert step < views[0].fov_h_deg   # neighboring views overlap

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -12,8 +12,20 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "model_comparison"))
 
 from detectors import (  # noqa: E402
     BundleRampNetDetector, GeminiDetector, QwenDetector, PanoSample,
-    gemini_boxes_to_points, qwen_boxes_to_points,
+    gemini_boxes_to_points, qwen_boxes_to_points, boxes_from_gemini_response,
 )
+
+
+class _FakeBox:
+    def __init__(self, box_2d, label):
+        self.box_2d = box_2d
+        self.label = label
+
+
+class _FakeResp:
+    def __init__(self, parsed=None, text=None):
+        self.parsed = parsed
+        self.text = text
 
 
 def test_gemini_boxes_to_points_center_and_normalization():
@@ -26,6 +38,21 @@ def test_qwen_boxes_to_points_normalizes_by_image_size():
     # bbox_2d = [x1, y1, x2, y2] in pixels of the image shown to the model.
     pts = qwen_boxes_to_points([{"bbox_2d": [100, 200, 300, 400]}], img_w=1000, img_h=2000)
     assert pts == [(0.2, 0.15, None)]  # cx=200/1000, cy=300/2000
+
+
+def test_boxes_from_gemini_response_parsed_objects():
+    resp = _FakeResp(parsed=[_FakeBox([400, 200, 600, 400], "curb ramp")])
+    assert boxes_from_gemini_response(resp) == [{"box_2d": [400, 200, 600, 400], "label": "curb ramp"}]
+
+
+def test_boxes_from_gemini_response_json_text_fallback():
+    resp = _FakeResp(parsed=None, text='[{"box_2d": [1, 2, 3, 4], "label": "x"}]')
+    assert boxes_from_gemini_response(resp) == [{"box_2d": [1, 2, 3, 4], "label": "x"}]
+
+
+def test_boxes_from_gemini_response_empty():
+    assert boxes_from_gemini_response(_FakeResp(parsed=None, text=None)) == []
+    assert boxes_from_gemini_response(_FakeResp(parsed=[], text="[]")) == []
 
 
 def test_bundle_rampnet_detector_reads_records():

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -17,10 +17,34 @@ from detectors import (  # noqa: E402
 )
 
 
+from compare import score_model, DetectionCache, cache_key  # noqa: E402
+from rampnet.detection_eval import radius_sq_for  # noqa: E402
+
+
 class _Args:
     gemini_model = "gemini-3.6-flash"
     qwen_model = "Qwen/Qwen3-VL"
     tiling = "perspective"
+
+
+class _FlakyDetector:
+    """Succeeds on every pano except ones whose id starts with 'bad'."""
+    name = "flaky"
+
+    def __init__(self):
+        self.calls = 0
+
+    def prepare(self):
+        pass
+
+    def signature(self):
+        return None  # disables caching so detect() is always exercised
+
+    def detect(self, sample):
+        self.calls += 1
+        if sample.pano_id.startswith("bad"):
+            raise RuntimeError("simulated transient API failure")
+        return []
 
 
 class _FakeBox:
@@ -78,6 +102,40 @@ def test_build_detector_labels_variants_by_model_id():
     # Bare provider falls back to the args default.
     label, det = build_detector("gemini", None, {}, _Args())
     assert label == "gemini-3.6-flash"
+
+
+def test_detection_cache_roundtrip(tmp_path):
+    c = DetectionCache(str(tmp_path))
+    k = cache_key("gemini-3.6-flash", {"tile": True}, "richmond", "pano1")
+    assert c.get(k) is None
+    c.put(k, [(0.1, 0.2, None), (0.3, 0.4, 0.9)])
+    assert c.get(k) == [[0.1, 0.2, None], [0.3, 0.4, 0.9]]
+
+
+def test_detection_cache_disabled_is_noop(tmp_path):
+    c = DetectionCache(str(tmp_path), enabled=False)
+    k = cache_key("m", {}, "c", "p")
+    c.put(k, [(1, 2, 3)])
+    assert c.get(k) is None
+
+
+def test_cache_key_sensitive_and_stable():
+    assert cache_key("m1", {"x": 1}, "c", "p") != cache_key("m2", {"x": 1}, "c", "p")
+    assert cache_key("m", {"x": 1}, "c", "p1") != cache_key("m", {"x": 1}, "c", "p2")
+    assert cache_key("m", {"x": 1}, "c", "p") == cache_key("m", {"x": 1}, "c", "p")
+
+
+def test_score_model_isolates_pano_failures():
+    records = {pid: {"detections": [], "pano": {"width": 1, "height": 1}}
+               for pid in ("good", "bad")}
+    verdicts = {pid: {"dets": [], "missed": [{"x": 0.5, "y": 0.5}], "no_missed": True}
+                for pid in ("good", "bad")}
+    det = _FlakyDetector()
+    report, failures = score_model(det, records, verdicts, "", radius_sq_for(),
+                                   "flaky", "city", DetectionCache("x", enabled=False))
+    assert report.n_panos == 1                       # only 'good' scored
+    assert len(failures) == 1 and failures[0][0] == "bad"
+    assert det.calls == 2                            # both panos attempted
 
 
 def test_bundle_rampnet_detector_reads_records():

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -13,7 +13,14 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "model_comparison"))
 from detectors import (  # noqa: E402
     BundleRampNetDetector, GeminiDetector, QwenDetector, PanoSample,
     gemini_boxes_to_points, qwen_boxes_to_points, boxes_from_gemini_response,
+    parse_model_spec, build_detector,
 )
+
+
+class _Args:
+    gemini_model = "gemini-3.6-flash"
+    qwen_model = "Qwen/Qwen3-VL"
+    tiling = "perspective"
 
 
 class _FakeBox:
@@ -53,6 +60,24 @@ def test_boxes_from_gemini_response_json_text_fallback():
 def test_boxes_from_gemini_response_empty():
     assert boxes_from_gemini_response(_FakeResp(parsed=None, text=None)) == []
     assert boxes_from_gemini_response(_FakeResp(parsed=[], text="[]")) == []
+
+
+def test_parse_model_spec():
+    assert parse_model_spec("rampnet") == ("rampnet", None)
+    assert parse_model_spec("gemini") == ("gemini", None)
+    assert parse_model_spec("gemini:gemini-2.5-flash") == ("gemini", "gemini-2.5-flash")
+    assert parse_model_spec(" qwen : Qwen/Qwen3-VL ") == ("qwen", "Qwen/Qwen3-VL")
+
+
+def test_build_detector_labels_variants_by_model_id():
+    label, det = build_detector("rampnet", None, {}, _Args())
+    assert label == "rampnet" and isinstance(det, BundleRampNetDetector)
+    # A pinned variant labels by its model id, so 2.5 and 3.6 are distinct rows.
+    label, det = build_detector("gemini", "gemini-2.5-flash", {}, _Args())
+    assert label == "gemini-2.5-flash" and det.model_id == "gemini-2.5-flash"
+    # Bare provider falls back to the args default.
+    label, det = build_detector("gemini", None, {}, _Args())
+    assert label == "gemini-3.6-flash"
 
 
 def test_bundle_rampnet_detector_reads_records():

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -1,0 +1,52 @@
+"""Guards for the model-comparison harness (scripts/model_comparison/).
+
+Covers the pure box->point parsing and that the VLM detectors are safe scaffolds:
+they construct without their (absent) client libraries, and only fail — with a
+clear message — when a live detection is actually requested.
+"""
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "model_comparison"))
+
+from detectors import (  # noqa: E402
+    BundleRampNetDetector, GeminiDetector, QwenDetector, PanoSample,
+    gemini_boxes_to_points, qwen_boxes_to_points,
+)
+
+
+def test_gemini_boxes_to_points_center_and_normalization():
+    # box_2d = [ymin, xmin, ymax, xmax] scaled 0-1000 -> normalized center.
+    pts = gemini_boxes_to_points([{"box_2d": [400, 200, 600, 400], "label": "curb ramp"}])
+    assert pts == [(0.3, 0.5, None)]   # cx=(200+400)/2/1000, cy=(400+600)/2/1000
+
+
+def test_qwen_boxes_to_points_normalizes_by_image_size():
+    # bbox_2d = [x1, y1, x2, y2] in pixels of the image shown to the model.
+    pts = qwen_boxes_to_points([{"bbox_2d": [100, 200, 300, 400]}], img_w=1000, img_h=2000)
+    assert pts == [(0.2, 0.15, None)]  # cx=200/1000, cy=300/2000
+
+
+def test_bundle_rampnet_detector_reads_records():
+    records = {"p1": {"detections": [
+        {"x_normalized": 0.5, "y_normalized": 0.5, "confidence": 0.9}]}}
+    det = BundleRampNetDetector(records)
+    sample = PanoSample("p1", image_path=None, width=None, height=None, meta={})
+    assert det.detect(sample) == [(0.5, 0.5, 0.9)]
+
+
+def test_vlm_detectors_construct_without_client_libs():
+    # Constructing must not import google-genai / qwen; that only happens on detect().
+    GeminiDetector(model_id="gemini-flash-latest")
+    QwenDetector(model_id="Qwen/Qwen3-VL")
+
+
+def test_gemini_detect_fails_clearly_without_key_or_lib():
+    det = GeminiDetector(model_id="gemini-flash-latest", api_key=None)
+    sample = PanoSample("p1", image_path="nope.jpg", width=100, height=100, meta={})
+    try:
+        det.detect(sample)
+    except (ImportError, RuntimeError, NotImplementedError):
+        return  # any of these is an acceptable, clear failure for a scaffold
+    raise AssertionError("expected GeminiDetector.detect to fail loudly without lib/key")

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -11,13 +11,13 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "model_comparison"))
 
 from detectors import (  # noqa: E402
-    BundleRampNetDetector, GeminiDetector, QwenDetector, PanoSample,
+    BundleRampNetDetector, GeminiDetector, QwenDetector, PanoSample, _VLMDetector,
     gemini_boxes_to_points, qwen_boxes_to_points, boxes_from_gemini_response,
     parse_model_spec, build_detector,
 )
 
 
-from compare import score_model, DetectionCache, cache_key  # noqa: E402
+from compare import score_model, validate_bundle, DetectionCache, cache_key  # noqa: E402
 from rampnet.detection_eval import radius_sq_for  # noqa: E402
 
 
@@ -160,3 +160,103 @@ def test_gemini_detect_fails_clearly_without_key_or_lib():
     except (ImportError, RuntimeError, NotImplementedError):
         return  # any of these is an acceptable, clear failure for a scaffold
     raise AssertionError("expected GeminiDetector.detect to fail loudly without lib/key")
+
+
+# --- tiled detect() end-to-end (no live model) ------------------------------
+
+class _FakeTiledVLM(_VLMDetector):
+    """A live-model-free _VLMDetector: _raw_detect echoes fixed per-view points and
+    _parse passes them through, so detect() exercises the real tiled path — the
+    view loop, per-view back-projection to pano coords, and cross-view dedup —
+    without any client library."""
+    name = "faketiled"
+
+    def __init__(self, points_per_view, **kw):
+        super().__init__("fake-model", **kw)
+        self._ppv = points_per_view
+
+    def _ensure_ready(self):
+        pass
+
+    def _raw_detect(self, image):
+        return self._ppv
+
+    def _parse(self, raw, img_w, img_h):
+        return list(raw)
+
+
+def _write_equirect(path):
+    import numpy as np
+    from PIL import Image
+    Image.fromarray(np.zeros((128, 256, 3), dtype="uint8")).save(path)
+
+
+def test_vlm_tiled_detect_maps_each_view_back_to_pano(tmp_path):
+    from equirect_tiling import default_views
+    pano = tmp_path / "p.jpg"
+    _write_equirect(pano)
+    sample = PanoSample("p", str(pano), 256, 128, {})
+
+    # One detection at each view's center -> one mapped pano point per view.
+    det = _FakeTiledVLM([(0.5, 0.5, None)], tile=True)
+    pts = det.detect(sample)
+    views = default_views()
+    assert len(pts) == len(views)                       # 6 well-separated views, none merged
+    # Every view is pitched to -30 deg, so each center maps to latitude -30 (Y=0.6667).
+    assert all(abs(y - (0.5 + 30.0 / 180.0)) < 1e-6 for (_, y, _) in pts)
+    assert any(abs(x - 0.5) < 1e-6 for (x, _, _) in pts)  # the yaw-0 view -> longitude 0
+    assert all(conf is None for (_, _, conf) in pts)      # confidence carried through
+
+
+def test_vlm_tiled_detect_dedups_overlapping_views(tmp_path):
+    from equirect_tiling import View
+    pano = tmp_path / "p.jpg"
+    _write_equirect(pano)
+    sample = PanoSample("p", str(pano), 256, 128, {})
+
+    # Two identical views + the same center detection -> both map to one pano point,
+    # which dedup must merge to a single detection (the seam-overlap contract).
+    v = View(0.0, -30.0, 90.0, 90.0, 256, 256)
+    det = _FakeTiledVLM([(0.5, 0.5, None)], tile=True, views=[v, v])
+    assert len(det.detect(sample)) == 1
+
+
+# --- pre-flight bundle validation -------------------------------------------
+
+def _aligned():
+    records = {"p1": {"detections": [{"x_normalized": 0.1, "y_normalized": 0.1,
+                                      "confidence": 0.9}], "pano": {}}}
+    verdicts = {"p1": {"dets": [True], "missed": [], "no_missed": True}}
+    return records, verdicts
+
+
+def test_validate_bundle_passes_on_aligned():
+    records, verdicts = _aligned()
+    validate_bundle(records, verdicts)  # must not raise
+
+
+def test_validate_bundle_flags_missing_record():
+    records, verdicts = _aligned()
+    verdicts["ghost"] = {"dets": [], "missed": [], "no_missed": True}
+    _assert_validation_mentions(records, verdicts, "ghost")
+
+
+def test_validate_bundle_flags_misaligned_lengths():
+    records, verdicts = _aligned()
+    verdicts["p1"]["dets"] = [True, False]  # 2 verdicts vs 1 detection
+    _assert_validation_mentions(records, verdicts, "misaligned")
+
+
+def test_validate_bundle_flags_missing_field():
+    records, verdicts = _aligned()
+    del verdicts["p1"]["no_missed"]  # legacy-style entry: rejected, not defaulted
+    _assert_validation_mentions(records, verdicts, "no_missed")
+
+
+def _assert_validation_mentions(records, verdicts, needle):
+    try:
+        validate_bundle(records, verdicts)
+    except SystemExit as e:
+        assert needle in str(e)
+        return
+    raise AssertionError(f"expected validate_bundle to reject the bundle mentioning {needle!r}")


### PR DESCRIPTION
Scaffolds a standardized comparison of RampNet against VLM detectors (Gemini, Qwen3-VL) on the curb-ramp benchmark bundles. **This increment ships the model-agnostic scoring core + the RampNet baseline + tests + methodology doc; the VLM adapters are scaffolded (no live runs yet).** Relates to #20.

## Why a new ground truth
The bundle's `verdicts.json` judges each **RampNet** detection, so it can't score a different model. Instead we derive a **model-agnostic ground truth** from the same review and score every detector against it identically:
- **GT ramp points** = reviewer-confirmed (`True`) detections + non-`unsure` missed marks.
- **Ignore zone** = `unsure` detections + `unsure` missed marks — a prediction there is neither TP nor FP (mirrors `validation.collect`'s abstention).
- **Uniform scoring**: every detector's output → center points, greedily matched to GT within the pano radius `0.022`; precision over all panos, recall gated on missed-ramp-confirmed panos; P/R/F1 each with Wilson CIs.

## What's here
- `rampnet/detection_eval.py` — pure, torch-free scorer (`build_ground_truth` / `score_pano` / `aggregate`); reuses `rampnet.validation.wilson_interval`.
- `scripts/model_comparison/{detectors,compare}.py` — `Detector` protocol, `BundleRampNetDetector` (reads `records.jsonl`, no GPU), import-guarded Gemini/Qwen scaffolds (real image-prep + box→point parsing; `_raw_detect` raises with wiring instructions), and a CLI printing a per-model P/R/F1 table + RampNet's verdict-based cross-check.
- `requirements-vlm.txt` — optional VLM deps (guarded; not needed for the suite).
- `docs/model_comparison.md` — methodology, caveats, self-validation, next steps.
- `tests/test_detection_eval.py`, `tests/test_model_comparison.py`.

## Harness self-validation
Scoring RampNet's own bundle detections against the derived GT reproduces the published numbers within tolerance — **richmond 0.964/0.768 vs 0.960/0.765; bend 0.961/0.761 vs 0.954/0.758** (~0.005 upward drift = a RampNet `False` det occasionally landing within radius of a real GT point). CLI prints both side by side. **Full suite: 51 passed.**

## Deferred (next increments)
- Wire live **Gemini** (API key) + **Qwen3-VL on Hyak**.
- **Equirectangular tiling** for a fair VLM input (whole-pano is currently a lower bound).
- Add the `clovis` split once the auto-labeler hands back its bundle (harness is city-generic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: perspective reprojection (tiling) added (commit f9b7980)

Fair VLM input is now implemented, not just deferred. Each pano is reprojected into a ring of overlapping rectilinear views (gnomonic, 90° FOV, −30° pitch, 6 yaws → 30% overlap); detections map back to pano coords and dedup across seams (`equirect_tiling.py`). `--tiling {perspective,none}` on the CLI; `none` keeps the whole-pano lower bound.

**Seams:** overlap guarantees a boundary-straddling ramp is seen whole in ≥1 view; the neighbor duplicate is merged by `dedup_points` (with 0/1 seam wrap).

**Reprojection is validated two ways:** numerically (`tests/test_equirect_tiling.py` — round-trip identity + the gnomonic invariants that horizon→straight-horizontal and meridians→straight-vertical, which a warped projection fails) and visually (`dump_views.py` renders a pano's views with a graticule overlay; great circles must render as straight lines). Full suite: 60 pass.

Still scaffolded: the live Gemini/Qwen calls (next increment: wire + calibrate the rig).
