### PR TITLE
Wire the live Qwen3-VL detector into the model-comparison harness

### DIFF
--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -2,7 +2,8 @@
 
 Uses the standardized curb-ramp benchmark (`benchmark/{bend,richmond}/`) to compare
 RampNet against general-purpose vision-language models that now do bounding-box detection —
-**Gemini Flash** (default `gemini-3.6-flash`) via API and the latest open **Qwen3-VL** (intended to run on Hyak).
+**Gemini Flash** (default `gemini-3.6-flash`) via API and the open **Qwen3-VL** (default
+`Qwen/Qwen3-VL-8B-Instruct`, run on Hyak).
 The question: does a general VLM match or beat the purpose-trained RampNet on real
 deployment imagery (GSV + Mapillary 360)? The harness is model-agnostic, so future models
 (issue #20) plug in the same way.
@@ -97,15 +98,48 @@ empirically once the live VLM runs.
   buildings/poles should look like normal photos. `python scripts/model_comparison/dump_views.py
   benchmark/richmond --out <dir>`.
 
+## Validating the box mapping
+
+Reprojection is only half the pipeline; the other half is turning a provider's boxes back into
+pano points, and that half has a silent failure mode — **box coordinate conventions differ by
+provider and even between Qwen generations**. `scripts/model_comparison/dump_detections.py`
+overlays a detector's raw boxes (red) on each view together with the pano's ground-truth ramps
+(green) and ignore points (amber), so a mapping error shows up as boxes sitting consistently
+off the ramps:
+
+```bash
+python scripts/model_comparison/dump_detections.py benchmark/richmond \
+    --model qwen:Qwen/Qwen3-VL-8B-Instruct --out view_dump/qwen
+```
+
+### Qwen box coordinates are normalized 0–1000
+
+`gemini_boxes_to_points` divides by 1000; `qwen_boxes_to_points` takes an explicit
+`coord_space` because the family changed convention:
+
+- **Qwen3-VL** (`norm1000`, the default): `bbox_2d = [x1, y1, x2, y2]` normalized to **0–1000**,
+  as in the upstream 2D-grounding cookbook (`bbox_2d[0] / 1000 * width`). Being
+  resolution-independent, the processor's smart-resize (which rounds to multiples of 28)
+  **cannot** shift them — this retires the earlier "normalize by the processed size" caveat.
+- **Qwen2/2.5-VL** (`pixels`): absolute pixels of the image the processor actually fed the model.
+
+`infer_qwen_coord_space` picks by model id; `--qwen-coord-space` overrides. The two are *not*
+auto-detected, because at a 1024px view they differ by only 2.4% — a wrong choice does not
+crash, it introduces a small systematic localization bias. Verified empirically by rendering
+one view at 512 / 1024 / 1400 px: the returned coordinates stayed in the same ~0–1000 band
+instead of scaling with the image, and the overlay put boxes squarely on tactile ramps.
+
 ## Status
 
 - **Shipped:** the model-agnostic scorer (`rampnet/detection_eval.py`), the comparison CLI
   (`scripts/model_comparison/compare.py`), the RampNet-from-bundle baseline
   (`BundleRampNetDetector`), the **perspective reprojection + dedup** (`equirect_tiling.py`),
-  and the **live `GeminiDetector`** (google-genai; API key or Vertex+ADC). Tested
+  the **live `GeminiDetector`** (google-genai; API key or Vertex+ADC), and the **live
+  `QwenDetector`** (transformers; Qwen3-VL on a cluster GPU). Tested
   (`test_detection_eval.py`, `test_model_comparison.py`, `test_equirect_tiling.py`).
-- **Scaffolded:** `QwenDetector` (Qwen3-VL on Hyak) — image prep, reprojection wiring, and
-  box→point parsing are real and tested; only the live `_raw_detect` raises `NotImplementedError`.
+- **Smoke-tested locally** on `Qwen/Qwen3-VL-2B-Instruct` (the largest that fits an 8 GB dev
+  GPU) to validate wiring, JSON parsing, and box mapping before spending cluster time. 2B is
+  far too weak to benchmark — the real runs are 8B and 32B on Hyak.
 
 ## Gemini credentials
 
@@ -145,30 +179,72 @@ python scripts/model_comparison/compare.py benchmark/richmond \
 # Cost control / smoke: cap panos; whole-pano lower bound instead of tiling:
 python scripts/model_comparison/compare.py benchmark/richmond --models rampnet,gemini --limit 20
 python scripts/model_comparison/compare.py benchmark/richmond --models gemini --tiling none
+
+# Qwen3-VL (open weights, needs a GPU — see the Hyak runbook below):
+python scripts/model_comparison/compare.py benchmark/richmond \
+    --models rampnet,qwen:Qwen/Qwen3-VL-8B-Instruct
 ```
 
-Unwired models (Qwen) are skipped with a clear note rather than crashing the run.
+A model that can't run (missing credentials, missing client lib) is skipped with a clear note
+rather than crashing the run.
+
+## Running Qwen3-VL on Hyak
+
+Qwen3-VL-8B is ~16 GB in bf16 and 32B ~64 GB, so it runs on the cluster, not the dev box.
+`scripts/model_comparison/run_qwen.slurm` is the launcher.
+
+**The results come back through the detection cache.** `cache_key` hashes only
+`(label, detector signature, city, pano id)` — nothing machine-specific — so detections computed
+on Hyak drop straight into a local `.model_cache/`. And when every pano of a model is already
+cached, `score_model` skips `detector.prepare()` entirely, so the final table can be produced on
+a laptop that cannot load Qwen at all.
+
+```bash
+# 1. On Hyak: stage the repo plus the (git-ignored) bundle imagery.
+rsync -av --exclude .venv --exclude .model_cache RampNet/ klone:~/RampNet/
+rsync -av benchmark/richmond/panos/ klone:~/RampNet/benchmark/richmond/panos/
+
+# 2. On a login node: create/activate the env and pre-download the weights, so the
+#    GPU job isn't billed for the download.
+conda env create -f environment.yml && conda activate sidewalkcv2   # CONDA_OVERRIDE_CUDA=12.6
+pip install -r requirements-vlm.txt
+export HF_HOME=/gscratch/scrubbed/$USER/hf && hf download Qwen/Qwen3-VL-8B-Instruct
+
+# 3. Submit. 8B fits one L40S; 32B needs two (device_map="auto" shards it).
+mkdir -p logs
+sbatch scripts/model_comparison/run_qwen.slurm
+BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_qwen.slurm
+QWEN_MODEL=Qwen/Qwen3-VL-32B-Instruct sbatch --gpus=2 scripts/model_comparison/run_qwen.slurm
+
+# 4. Bring the detections home and score every model side by side, no GPU needed.
+rsync -av klone:~/RampNet/.model_cache/ .model_cache/
+python scripts/model_comparison/compare.py benchmark/richmond \
+    --models rampnet,gemini:gemini-3.6-flash,qwen:Qwen/Qwen3-VL-8B-Instruct
+```
+
+Runs are resumable: a job that is preempted or times out has already cached everything it
+finished, so re-submitting picks up where it stopped.
 
 ## Next increments
 
-1. **Wire the live Qwen call.** Implement `QwenDetector._raw_detect` (load Qwen3-VL once in
-   `_ensure_ready`, run on **Hyak** — the A40 OOMs at native res). Deps:
-   `pip install -r requirements-vlm.txt`. Reprojection and the parse functions already exist.
-   (Gemini is wired — see above.)
-2. **Calibrate the reprojection rig** against the first live VLM run: tune `fov_h_deg`,
-   `n_yaw`, `pitch_deg` (and consider trimming the wasted nadir/hood region) so ramps land
-   near-centered in some view, minimizing seam-truncation false positives. Report perspective
-   vs `--tiling none` side by side.
-3. **Add the `clovis` split** once the auto-labeler hands back its bundle; the harness is
+1. **Calibrate the reprojection rig** against the live VLM runs: tune `fov_h_deg`, `n_yaw`,
+   `pitch_deg` so ramps land near-centered in some view, minimizing seam-truncation false
+   positives. The `dump_detections.py` overlays make one problem obvious — with `pitch_deg=-30`
+   the bottom ~40% of every view is the capture vehicle's hood and the black nadir cap, so
+   roughly a third of every paid call is spent on pixels that can't contain a curb ramp.
+   Report perspective vs `--tiling none` side by side.
+2. **Add the `clovis` split** once the auto-labeler hands back its bundle; the harness is
    city-generic (it just needs `records.jsonl` + `verdicts.json` + `panos/`).
 
 ## Files
 
 - `rampnet/detection_eval.py` — model-agnostic GT + scorer (pure, torch-free).
-- `scripts/model_comparison/detectors.py` — `Detector` protocol, RampNet baseline, VLM scaffolds.
+- `scripts/model_comparison/detectors.py` — `Detector` protocol, RampNet baseline, VLM detectors.
 - `scripts/model_comparison/equirect_tiling.py` — perspective reprojection + point mapping + dedup.
 - `scripts/model_comparison/compare.py` — comparison CLI.
 - `scripts/model_comparison/dump_views.py` — visual de-distortion QA (graticule overlay).
+- `scripts/model_comparison/dump_detections.py` — visual box-mapping QA (boxes vs ground truth).
+- `scripts/model_comparison/run_qwen.slurm` — Hyak launcher for the Qwen leg.
 - `requirements-vlm.txt` — optional VLM deps.
 - `tests/test_detection_eval.py`, `tests/test_model_comparison.py`,
   `tests/test_equirect_tiling.py` — guards.

--- a/requirements-vlm.txt
+++ b/requirements-vlm.txt
@@ -4,10 +4,14 @@
 #
 #   pip install -r requirements-vlm.txt
 #
-# Gemini (API; needs GOOGLE_API_KEY):
+# Gemini (API; needs GOOGLE_API_KEY, or Vertex + ADC):
 google-genai
 
-# Qwen3-VL (open weights; intended to run on Hyak, not the local box / makelab2 A40):
-#   transformers + torch are already core deps; these are the extras Qwen grounding needs.
-qwen-vl-utils
+# Qwen3-VL (open weights; run on a cluster GPU — see the Hyak runbook in
+# docs/model_comparison.md). torch comes from the conda env; these are the extras:
+#   - transformers 4.57 is the first release with Qwen3-VL.
+#   - accelerate enables device_map="auto", needed to shard Qwen3-VL-32B-Instruct
+#     (~64 GB in bf16) across two GPUs; 8B fits one 48 GB card.
+#   - qwen-vl-utils is NOT needed: Qwen3-VL's chat template takes PIL images directly.
+transformers>=4.57
 accelerate

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -135,20 +135,28 @@ def score_model(detector, records, verdicts, panos_dir, radius_sq, label, city, 
                 max_consecutive_failures=10):
     """Run one detector over every reviewed pano and aggregate the score.
 
-    Returns ``(report, failures)``. ``detector.prepare()`` runs first (outside the
-    per-pano guard) so credential / dependency / not-wired errors propagate to the
-    caller and skip the whole model. Each pano's detections are cached, so re-runs
-    don't re-pay the API. A transient per-pano failure is recorded and skipped
-    rather than crashing the run; ``max_consecutive_failures`` aborts the model
-    early during an outage instead of burning budget."""
-    detector.prepare()
+    Returns ``(report, failures)``. ``detector.prepare()`` runs before the pano loop
+    (outside the per-pano guard) so credential / dependency / not-wired errors
+    propagate to the caller and skip the whole model — but it is skipped entirely
+    when every pano is already cached, so a ``.model_cache`` copied back from a GPU
+    cluster scores on a machine that can't load the model at all. Each pano's
+    detections are cached, so re-runs don't re-pay the API. A transient per-pano
+    failure is recorded and skipped rather than crashing the run;
+    ``max_consecutive_failures`` aborts the model early during an outage instead of
+    burning budget."""
     sig = detector.signature() if hasattr(detector, "signature") else None
+    keys = {pid: (cache_key(label, sig, city, pid) if sig is not None else None)
+            for pid in verdicts}
+    cached = {pid: (cache.get(k) if k else None) for pid, k in keys.items()}
+    if not cached or any(p is None for p in cached.values()):
+        detector.prepare()
+    else:
+        print(f"[{label}] all {len(cached)} panos already cached; model load skipped")
     pano_scores, failures, consecutive = [], [], 0
     for pid, entry in verdicts.items():
         rec = records[pid]
         gt = build_ground_truth(rec["detections"], entry["dets"], entry["missed"], entry["no_missed"])
-        key = cache_key(label, sig, city, pid) if sig is not None else None
-        preds = cache.get(key) if key else None
+        key, preds = keys[pid], cached[pid]
         if preds is None:
             sample = PanoSample(
                 pano_id=pid,
@@ -204,7 +212,11 @@ def main():
                          "using its default model) or provider:model_id to pin a variant, e.g. "
                          "'rampnet,gemini:gemini-2.5-flash,gemini:gemini-3.6-flash'.")
     ap.add_argument("--gemini-model", default="gemini-3.6-flash")
-    ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL")
+    ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL-8B-Instruct")
+    ap.add_argument("--qwen-coord-space", choices=["auto", "norm1000", "pixels"], default="auto",
+                    help="Box convention the Qwen checkpoint emits: 'norm1000' (Qwen3-VL, "
+                         "0-1000) or 'pixels' (Qwen2/2.5-VL, absolute). 'auto' infers it "
+                         "from the model id.")
     ap.add_argument("--tiling", choices=["perspective", "none"], default="perspective",
                     help="VLM input: 'perspective' reprojects the pano into rectilinear "
                          "views (fair); 'none' uses one whole-pano call (lower bound). "

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -9,10 +9,11 @@ model-agnostic ground truth (see ``rampnet/detection_eval.py``).
 - ``GeminiDetector`` is **live** (google-genai; API key or Vertex+ADC): it
   reprojects the pano into rectilinear views (``equirect_tiling``), runs the model
   per view, and maps boxes back to pano coordinates.
-- ``QwenDetector`` is still a **scaffold** (Qwen3-VL on Hyak): image prep,
-  reprojection wiring, and box parsing are real, but the live ``_raw_detect``
-  raises ``NotImplementedError``. See ``docs/model_comparison.md``.
+- ``QwenDetector`` is **live** (open weights via transformers; intended for a GPU
+  cluster — see the Hyak runbook in ``docs/model_comparison.md``). Same tiled path
+  as Gemini; the model is loaded once per run in ``_ensure_ready``.
 """
+import importlib.util
 import json
 import os
 from collections import namedtuple
@@ -84,20 +85,103 @@ def gemini_boxes_to_points(items):
     return points
 
 
-def qwen_boxes_to_points(items, img_w, img_h):
-    """Qwen grounding returns absolute-pixel boxes ``bbox_2d = [x1, y1, x2, y2]``
-    against the image it was shown. Normalize each box center by that image's
-    width/height (the size actually sent to the model, not the native pano)."""
+def _first_json_blob(text):
+    """Return the first balanced JSON array/object substring in ``text``.
+
+    Qwen wraps its grounding output in a ```json fence and sometimes adds a
+    sentence around it, so scan for the first ``[``/``{`` and walk to its match
+    (brackets inside string literals don't count)."""
+    s = text.strip()
+    if "```" in s:                      # keep the body of the first fenced block
+        parts = s.split("```")
+        if len(parts) >= 3:
+            body = parts[1].lstrip()
+            s = body[4:] if body[:4].lower() == "json" else body
+    start = next((i for i, ch in enumerate(s) if ch in "[{"), None)
+    if start is None:
+        return None
+    opener = s[start]
+    closer = "]" if opener == "[" else "}"
+    depth, in_str, esc = 0, False, False
+    for i in range(start, len(s)):
+        ch = s[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == opener:
+            depth += 1
+        elif ch == closer:
+            depth -= 1
+            if depth == 0:
+                return s[start:i + 1]
+    return None
+
+
+def boxes_from_qwen_text(text):
+    """Pull ``[{bbox_2d, label}, ...]`` out of a Qwen grounding completion.
+
+    Deliberately tolerant — an open model has no response-schema equivalent, so it
+    may fence its JSON, wrap it in prose, return a bare object, or emit a
+    malformed item. Anything without a 4-number box is dropped rather than
+    crashing a 1,400-call run."""
+    if not text:
+        return []
+    blob = _first_json_blob(text)
+    if blob is None:
+        return []
+    try:
+        data = json.loads(blob)
+    except ValueError:
+        return []
+    if isinstance(data, dict):
+        data = data.get("boxes") or data.get("objects") or [data]
+    items = []
+    for it in data if isinstance(data, list) else []:
+        if not isinstance(it, dict):
+            continue
+        box = it.get("bbox_2d", it.get("bbox"))
+        if not isinstance(box, (list, tuple)) or len(box) != 4:
+            continue
+        try:
+            box = [float(v) for v in box]
+        except (TypeError, ValueError):
+            continue
+        items.append({"bbox_2d": box, "label": it.get("label", "")})
+    return items
+
+
+def qwen_boxes_to_points(items, img_w, img_h, coord_space="norm1000"):
+    """Reduce Qwen grounding boxes ``bbox_2d = [x1, y1, x2, y2]`` to normalized
+    [0,1] center points. Confidence is None (grounding carries no score).
+
+    Two conventions exist across the family, and at a ~1000px view size their
+    outputs look nearly identical, so the caller states which rather than guessing:
+
+    - ``norm1000`` (**Qwen3-VL**): coordinates are already normalized to 0-1000
+      (the cookbook rescales with ``bbox_2d[0] / 1000 * width``). Being
+      resolution-independent, the processor's smart-resize cannot shift them.
+    - ``pixels`` (Qwen2/2.5-VL): absolute pixels of the image the processor
+      actually fed the model, so normalize by that image's width/height."""
+    if coord_space not in ("norm1000", "pixels"):
+        raise ValueError(f"unknown coord_space {coord_space!r} (expected norm1000 | pixels)")
+    sx, sy = (1000.0, 1000.0) if coord_space == "norm1000" else (float(img_w), float(img_h))
     points = []
     for it in items:
         x1, y1, x2, y2 = it["bbox_2d"]
-        cx = (x1 + x2) / 2.0 / img_w
-        cy = (y1 + y2) / 2.0 / img_h
+        cx = (x1 + x2) / 2.0 / sx
+        cy = (y1 + y2) / 2.0 / sy
         points.append((cx, cy, None))
     return points
 
 
-# --- VLM detector scaffolds -------------------------------------------------
+# --- VLM detectors ----------------------------------------------------------
 
 DETECTION_PROMPT = (
     "Detect every curb ramp in this street-level image. A curb ramp (curb cut) is the "
@@ -107,9 +191,17 @@ DETECTION_PROMPT = (
     "ramps, return an empty list."
 )
 
+# Gemini gets its output shape from a response_schema; an open model has to be
+# told in the prompt. Same detection task, so the two stay word-for-word identical
+# up to this suffix.
+QWEN_JSON_INSTRUCTION = (
+    ' Respond with JSON only: a list of {"bbox_2d": [x1, y1, x2, y2], "label": "curb ramp"}.'
+)
+QWEN_PROMPT = DETECTION_PROMPT + QWEN_JSON_INSTRUCTION
+
 
 class _VLMDetector:
-    """Shared scaffold. Subclasses implement ``_raw_detect`` (the live model call)
+    """Shared base. Subclasses implement ``_raw_detect`` (the live model call)
     and ``_parse`` (provider box format -> center points, normalized within the
     image shown to the model).
 
@@ -121,6 +213,7 @@ class _VLMDetector:
         warped and ramps are tiny)."""
 
     name = "vlm"
+    prompt = DETECTION_PROMPT  # subclasses override when the provider needs more
     max_edge = 1536       # whole-pano downscale cap
     source_max_edge = 4096  # cap on the pano fed to reprojection (native can be 16k)
 
@@ -186,7 +279,7 @@ class _VLMDetector:
             "max_edge": self.max_edge,
             "source_max_edge": self.source_max_edge,
             "views": [list(v) for v in views] if views else None,
-            "prompt": DETECTION_PROMPT,
+            "prompt": self.prompt,
         }
 
 
@@ -252,7 +345,7 @@ class GeminiDetector(_VLMDetector):
 
         resp = self._client.models.generate_content(
             model=self.model_id,
-            contents=[image, DETECTION_PROMPT],
+            contents=[image, self.prompt],
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",
                 response_schema=list[BoundingBox],
@@ -265,42 +358,91 @@ class GeminiDetector(_VLMDetector):
         return gemini_boxes_to_points(raw)
 
 
-class QwenDetector(_VLMDetector):
-    name = "qwen"
-    max_edge = 2048  # Qwen3-VL handles large inputs; run on Hyak (A40 OOMs at native)
+def infer_qwen_coord_space(model_id):
+    """Which box convention a Qwen checkpoint emits (see ``qwen_boxes_to_points``).
 
-    def __init__(self, model_id="Qwen/Qwen3-VL", max_edge=None, tile=True):
+    Qwen3-VL normalizes to 0-1000; Qwen2/2.5-VL emit absolute pixels. Unknown ids
+    get the Qwen3+ convention — overridable with ``--qwen-coord-space``."""
+    mid = (model_id or "").lower()
+    if "qwen2" in mid:
+        return "pixels"
+    return "norm1000"
+
+
+class QwenDetector(_VLMDetector):
+    """Qwen3-VL grounding via transformers (open weights, local GPU).
+
+    The checkpoint is loaded once per run in ``_ensure_ready`` — 8B is ~16GB in
+    bf16 and 32B ~64GB, so this belongs on a cluster GPU (see the Hyak runbook in
+    docs/model_comparison.md), not the dev box. Detections it produces are written
+    to the same ``.model_cache`` as every other model, and that cache key contains
+    nothing machine-specific, so a cache produced on the cluster scores locally."""
+
+    name = "qwen"
+    prompt = QWEN_PROMPT
+    max_edge = 2048  # whole-pano mode only; tiled views are rendered at 1024
+
+    def __init__(self, model_id="Qwen/Qwen3-VL-8B-Instruct", max_edge=None, tile=True,
+                 coord_space=None, max_new_tokens=1024):
         super().__init__(model_id, max_edge, tile=tile)
+        self.coord_space = coord_space or infer_qwen_coord_space(model_id)
+        self.max_new_tokens = max_new_tokens
+        self._model = None
+        self._processor = None
 
     def _ensure_ready(self):
+        if self._model is not None:
+            return
         try:
-            import transformers  # noqa: F401
+            import torch
+            from transformers import AutoProcessor
         except ImportError as e:
             raise ImportError(
-                "QwenDetector needs `transformers` (+ qwen-vl-utils, accelerate) "
+                "QwenDetector needs `torch` and `transformers>=4.57` "
                 "(pip install -r requirements-vlm.txt)") from e
-        # Not yet wired: fail fast at prepare() so the model is skipped cleanly
-        # rather than failing per pano. Wiring this is the Hyak increment.
-        raise NotImplementedError(
-            "QwenDetector is scaffolded, not wired. Load Qwen3-VL in _ensure_ready and "
-            "implement _raw_detect (run on Hyak). See docs/model_comparison.md.")
+        try:
+            from transformers import AutoModelForImageTextToText as model_cls
+        except ImportError:  # older transformers: reach for the Qwen3-VL class directly
+            from transformers import Qwen3VLForConditionalGeneration as model_cls
+
+        self._processor = AutoProcessor.from_pretrained(self.model_id)
+        # device_map="auto" shards a checkpoint too big for one GPU (32B needs two),
+        # but it needs accelerate; without it fall back to a single device.
+        if importlib.util.find_spec("accelerate") is not None:
+            model = model_cls.from_pretrained(self.model_id, dtype="auto", device_map="auto")
+        else:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            model = model_cls.from_pretrained(self.model_id, dtype="auto").to(device)
+        self._model = model.eval()
 
     def _raw_detect(self, image):
-        # TODO(increment 2, Hyak): load Qwen3-VL once (transformers AutoModelForCausalLM /
-        #   Qwen3VL class + processor), run the grounding prompt, parse the JSON grounding
-        #   output to [{bbox_2d:[x1,y1,x2,y2]}]. Model load belongs in _ensure_ready so it
-        #   happens once per run, not per pano.
-        #   NOTE: Qwen's bbox pixels are relative to the image the processor *actually*
-        #   fed the model, which its smart-resize rounds to multiples of 28 — not the
-        #   (view.width, view.height) passed to _parse. Return that processed (w, h)
-        #   from _raw_detect and normalize qwen_boxes_to_points by it, else centers drift.
-        raise NotImplementedError(
-            "QwenDetector live call is scaffolded, not wired. Implement _raw_detect on Hyak "
-            "(load Qwen3-VL once in _ensure_ready), then feed items to qwen_boxes_to_points "
-            "via _parse. See docs/model_comparison.md.")
+        import torch
+        messages = [{"role": "user", "content": [
+            {"type": "image", "image": image},
+            {"type": "text", "text": self.prompt},
+        ]}]
+        # Qwen3-VL's chat template accepts PIL images directly, so qwen-vl-utils
+        # isn't needed. Greedy decoding mirrors Gemini's temperature=0.
+        inputs = self._processor.apply_chat_template(
+            messages, tokenize=True, add_generation_prompt=True,
+            return_dict=True, return_tensors="pt").to(self._model.device)
+        with torch.inference_mode():
+            out = self._model.generate(**inputs, max_new_tokens=self.max_new_tokens,
+                                       do_sample=False)
+        # generate() returns prompt + completion; keep only the completion.
+        completion = out[:, inputs["input_ids"].shape[1]:]
+        text = self._processor.batch_decode(completion, skip_special_tokens=True)[0]
+        return boxes_from_qwen_text(text)
 
     def _parse(self, raw, img_w, img_h):
-        return qwen_boxes_to_points(raw, img_w, img_h)
+        return qwen_boxes_to_points(raw, img_w, img_h, coord_space=self.coord_space)
+
+    def signature(self):
+        # Extends the base signature. Gemini's stays byte-identical, so the
+        # detections already paid for keep hitting the cache.
+        sig = super().signature()
+        sig.update({"coord_space": self.coord_space, "max_new_tokens": self.max_new_tokens})
+        return sig
 
 
 def parse_model_spec(token):
@@ -328,5 +470,7 @@ def build_detector(provider, model_id, records, args):
         return mid, GeminiDetector(model_id=mid, tile=tile)
     if provider == "qwen":
         mid = model_id or args.qwen_model
-        return mid, QwenDetector(model_id=mid, tile=tile)
+        coord_space = getattr(args, "qwen_coord_space", "auto")
+        return mid, QwenDetector(model_id=mid, tile=tile,
+                                 coord_space=None if coord_space == "auto" else coord_space)
     raise ValueError(f"unknown provider '{provider}' (choose from: rampnet, gemini, qwen)")

--- a/scripts/model_comparison/dump_detections.py
+++ b/scripts/model_comparison/dump_detections.py
@@ -1,0 +1,168 @@
+"""Visual QA for a VLM detector: overlay its boxes on the perspective views.
+
+`dump_views.py` proves the *reprojection* is right. This proves the *box mapping*
+is right — the other half of the pipeline, and the one with a silent failure mode:
+box coordinate conventions differ across providers and even across Qwen
+generations (Qwen3-VL normalizes to 0-1000, Qwen2.5-VL emits absolute pixels), and
+at a ~1000px view size a wrong choice does not crash, it just slides every
+detection toward the top-left by a constant factor. That is invisible in a P/R
+table and obvious in one overlay.
+
+For one pano it renders each rectilinear view with the model's raw boxes (red) and
+the pano's ground-truth ramps (green) / ignore points (amber) projected into the
+same view. Boxes should sit on the ramps.
+
+    python scripts/model_comparison/dump_detections.py benchmark/richmond \
+        --model qwen:Qwen/Qwen3-VL-8B-Instruct --out view_dump/qwen
+
+Needs the model's credentials/weights — it makes real calls (one per view).
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from rampnet.detection_eval import build_ground_truth  # noqa: E402
+from equirect_tiling import (  # noqa: E402
+    default_views, equirect_to_perspective, equirect_point_to_perspective)
+from detectors import build_detector, load_pano_image, parse_model_spec  # noqa: E402
+from dump_views import _contact_sheet  # noqa: E402
+from compare import load_bundle, load_dotenv  # noqa: E402
+
+GT_COLOR = (60, 220, 90)
+IGNORE_COLOR = (240, 190, 60)
+BOX_COLOR = (255, 70, 70)
+
+
+def boxes_to_view_rects(detector, raw, width, height):
+    """Provider box -> ``(x1, y1, x2, y2)`` pixel rect inside the view, for drawing.
+
+    Mirrors what ``detector._parse`` does to get centers, but keeps the full box so
+    a coordinate-space mistake is visible as a whole rectangle in the wrong place."""
+    rects = []
+    for it in raw:
+        if "box_2d" in it:                      # Gemini: [ymin, xmin, ymax, xmax], 0-1000
+            ymin, xmin, ymax, xmax = it["box_2d"]
+            rects.append((xmin / 1000.0 * width, ymin / 1000.0 * height,
+                          xmax / 1000.0 * width, ymax / 1000.0 * height))
+        elif "bbox_2d" in it:                   # Qwen: [x1, y1, x2, y2]
+            x1, y1, x2, y2 = it["bbox_2d"]
+            if getattr(detector, "coord_space", "norm1000") == "norm1000":
+                sx = sy = 1000.0
+            else:
+                sx, sy = width, height
+            rects.append((x1 / sx * width, y1 / sy * height,
+                          x2 / sx * width, y2 / sy * height))
+    return rects
+
+
+def _marker(draw, x, y, color, r=14):
+    draw.ellipse([x - r, y - r, x + r, y + r], outline=color, width=3)
+    draw.line([x - r, y, x + r, y], fill=color, width=1)
+    draw.line([x, y - r, x, y + r], fill=color, width=1)
+
+
+def overlay(image, rects, gt_uv, ignore_uv):
+    from PIL import ImageDraw
+    draw = ImageDraw.Draw(image)
+    for (x, y) in ignore_uv:
+        _marker(draw, x, y, IGNORE_COLOR)
+    for (x, y) in gt_uv:
+        _marker(draw, x, y, GT_COLOR)
+    for (x1, y1, x2, y2) in rects:
+        draw.rectangle([x1, y1, x2, y2], outline=BOX_COLOR, width=4)
+        draw.line([(x1 + x2) / 2 - 10, (y1 + y2) / 2, (x1 + x2) / 2 + 10, (y1 + y2) / 2],
+                  fill=BOX_COLOR, width=2)
+        draw.line([(x1 + x2) / 2, (y1 + y2) / 2 - 10, (x1 + x2) / 2, (y1 + y2) / 2 + 10],
+                  fill=BOX_COLOR, width=2)
+    return image
+
+
+def _project(points, view):
+    """Pano-normalized points -> in-view pixel coords, dropping those out of frame."""
+    out = []
+    for (x, y) in points:
+        uv = equirect_point_to_perspective(x, y, view)
+        if uv is not None:
+            out.append((uv[0] * view.width, uv[1] * view.height))
+    return out
+
+
+def _pick_pano(verdicts, panos_dir, requested):
+    if requested:
+        return requested
+    for pid in verdicts:
+        if os.path.exists(os.path.join(panos_dir, f"{pid}.jpg")):
+            return pid
+    raise SystemExit(f"no reviewed pano image found under {panos_dir} "
+                     "(bundle panos/ are git-ignored; they must be present locally)")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Overlay a detector's boxes on a pano's perspective views (visual QA).")
+    ap.add_argument("bundle", help="Bundle dir (benchmark/<city>).")
+    ap.add_argument("--model", default="qwen",
+                    help="One detector spec: provider or provider:model_id "
+                         "(e.g. qwen:Qwen/Qwen3-VL-8B-Instruct, gemini:gemini-3.6-flash).")
+    ap.add_argument("--pano", help="Pano id (default: first reviewed pano with an image).")
+    ap.add_argument("--out", default="view_dump/detections", help="Output directory.")
+    ap.add_argument("--source-max-edge", type=int, default=4096)
+    # Consumed by build_detector.
+    ap.add_argument("--gemini-model", default="gemini-3.6-flash")
+    ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL-8B-Instruct")
+    ap.add_argument("--qwen-coord-space", choices=["auto", "norm1000", "pixels"], default="auto")
+    ap.add_argument("--tiling", choices=["perspective"], default="perspective",
+                    help="Only the tiled path is worth eyeballing.")
+    args = ap.parse_args()
+
+    load_dotenv(str(REPO_ROOT))
+    records, verdicts, panos_dir = load_bundle(args.bundle)
+    pano_id = _pick_pano(verdicts, panos_dir, args.pano)
+    pano_path = os.path.join(panos_dir, f"{pano_id}.jpg")
+    if not os.path.exists(pano_path):
+        raise SystemExit(f"pano image not found: {pano_path}")
+
+    provider, model_id = parse_model_spec(args.model)
+    label, detector = build_detector(provider, model_id, records, args)
+    if not hasattr(detector, "_raw_detect"):
+        raise SystemExit(f"'{label}' has no boxes to draw (it reads points from the bundle)")
+    detector.prepare()
+
+    entry = verdicts[pano_id]
+    gt = build_ground_truth(records[pano_id]["detections"], entry["dets"],
+                            entry["missed"], entry["no_missed"])
+
+    os.makedirs(args.out, exist_ok=True)
+    pano = load_pano_image(pano_path, args.source_max_edge)
+    views = detector._views or default_views()
+    rendered, total_boxes = [], 0
+    for i, view in enumerate(views):
+        view_img = equirect_to_perspective(pano, view)
+        raw = detector._raw_detect(view_img)
+        rects = boxes_to_view_rects(detector, raw, view.width, view.height)
+        total_boxes += len(rects)
+        gt_uv = _project(gt.gt_points, view)
+        ignore_uv = _project(gt.ignore_points, view)
+        overlay(view_img, rects, gt_uv, ignore_uv)
+        name = f"view_{i}_yaw{int(view.yaw_deg)}_boxes{len(rects)}.png"
+        view_img.save(os.path.join(args.out, name))
+        rendered.append(view_img)
+        print(f"  view {i} (yaw {int(view.yaw_deg)}): {len(rects)} box(es), "
+              f"{len(gt_uv)} GT / {len(ignore_uv)} ignore point(s) in frame")
+
+    sheet_path = os.path.join(args.out, f"contact_{label.replace('/', '_')}_{pano_id}.png")
+    _contact_sheet(rendered).save(sheet_path)
+    print(f"\npano {pano_id}: {total_boxes} raw box(es) across {len(views)} views vs "
+          f"{len(gt.gt_points)} GT ramp(s) ({len(gt.ignore_points)} ignored)")
+    print(f"Contact sheet: {sheet_path}")
+    print("Boxes (red) should sit on ramps; a constant offset toward the top-left means "
+          "the coordinate space is wrong (see --qwen-coord-space).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model_comparison/run_qwen.slurm
+++ b/scripts/model_comparison/run_qwen.slurm
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Qwen3-VL leg of the model comparison, on Hyak (klone).
+#
+#   sbatch scripts/model_comparison/run_qwen.slurm
+#   BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_qwen.slurm
+#   QWEN_MODEL=Qwen/Qwen3-VL-32B-Instruct sbatch --gpus=2 scripts/model_comparison/run_qwen.slurm
+#
+# 32B is ~64 GB in bf16, so it needs two 48 GB cards; device_map="auto" shards it
+# across whatever the job is allocated. 8B fits one.
+#
+# Detections land in .model_cache/, whose key contains nothing machine-specific —
+# rsync that directory back and score locally with no GPU (see docs/model_comparison.md).
+#SBATCH -p gpu-l40s
+#SBATCH --job-name=qwen_curb_ramp_compare
+#SBATCH --time=12:00:00
+#SBATCH --mem=64G
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus=1
+#SBATCH --output=logs/qwen_compare_%j.out
+#SBATCH --error=logs/qwen_compare_%j.err
+
+set -euo pipefail
+
+QWEN_MODEL="${QWEN_MODEL:-Qwen/Qwen3-VL-8B-Instruct}"
+BUNDLE="${BUNDLE:-benchmark/richmond}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+# Home quota on klone is small and the checkpoints are tens of GB; keep the HF
+# cache on scratch. Pre-download on the login node so the GPU isn't billed for it:
+#   HF_HOME=... hf download "$QWEN_MODEL"
+export HF_HOME="${HF_HOME:-/gscratch/scrubbed/$USER/hf}"
+
+source activate sidewalkcv2
+
+echo "--- Qwen model comparison ---"
+echo "Model:  ${QWEN_MODEL}"
+echo "Bundle: ${BUNDLE}"
+echo "GPUs:   ${SLURM_GPUS:-1} on ${SLURMD_NODENAME:-?}"
+echo "HF_HOME: ${HF_HOME}"
+nvidia-smi --query-gpu=name,memory.total --format=csv || true
+echo "-----------------------------"
+
+python -u scripts/model_comparison/compare.py "$BUNDLE" \
+    --models "rampnet,qwen:${QWEN_MODEL}" \
+    --qwen-model "$QWEN_MODEL" \
+    $EXTRA_ARGS
+
+echo "--- done; rsync .model_cache/ back to score alongside Gemini ---"

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -1,8 +1,9 @@
 """Guards for the model-comparison harness (scripts/model_comparison/).
 
-Covers the pure box->point parsing and that the VLM detectors are safe scaffolds:
-they construct without their (absent) client libraries, and only fail — with a
-clear message — when a live detection is actually requested.
+Covers the pure box->point parsing (both providers' box conventions), that the VLM
+detectors construct without their client libraries and only fail — with a clear
+message — when a live detection is actually requested, and that the detection
+cache stays valid across changes (see ``test_gemini_cache_key_is_frozen``).
 """
 import os
 import sys
@@ -13,7 +14,8 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "model_comparison"))
 from detectors import (  # noqa: E402
     BundleRampNetDetector, GeminiDetector, QwenDetector, PanoSample, _VLMDetector,
     gemini_boxes_to_points, qwen_boxes_to_points, boxes_from_gemini_response,
-    parse_model_spec, build_detector,
+    boxes_from_qwen_text, infer_qwen_coord_space, parse_model_spec, build_detector,
+    DETECTION_PROMPT,
 )
 
 
@@ -23,7 +25,8 @@ from rampnet.detection_eval import radius_sq_for  # noqa: E402
 
 class _Args:
     gemini_model = "gemini-3.6-flash"
-    qwen_model = "Qwen/Qwen3-VL"
+    qwen_model = "Qwen/Qwen3-VL-8B-Instruct"
+    qwen_coord_space = "auto"
     tiling = "perspective"
 
 
@@ -65,10 +68,64 @@ def test_gemini_boxes_to_points_center_and_normalization():
     assert pts == [(0.3, 0.5, None)]   # cx=(200+400)/2/1000, cy=(400+600)/2/1000
 
 
-def test_qwen_boxes_to_points_normalizes_by_image_size():
-    # bbox_2d = [x1, y1, x2, y2] in pixels of the image shown to the model.
-    pts = qwen_boxes_to_points([{"bbox_2d": [100, 200, 300, 400]}], img_w=1000, img_h=2000)
+def test_qwen_boxes_to_points_pixels_normalizes_by_image_size():
+    # Qwen2/2.5-VL: bbox_2d = [x1, y1, x2, y2] in pixels of the image shown to the model.
+    pts = qwen_boxes_to_points([{"bbox_2d": [100, 200, 300, 400]}], img_w=1000, img_h=2000,
+                               coord_space="pixels")
     assert pts == [(0.2, 0.15, None)]  # cx=200/1000, cy=300/2000
+
+
+def test_qwen_boxes_to_points_norm1000_ignores_image_size():
+    # Qwen3-VL (the default): bbox_2d is already normalized 0-1000, so the center is
+    # /1000 regardless of the view size the processor was handed.
+    boxes = [{"bbox_2d": [100, 200, 300, 400]}]
+    pts = qwen_boxes_to_points(boxes, img_w=1024, img_h=1024, coord_space="norm1000")
+    assert pts == [(0.2, 0.3, None)]
+    assert qwen_boxes_to_points(boxes, 640, 480, coord_space="norm1000") == pts
+
+
+def test_qwen_boxes_to_points_rejects_unknown_coord_space():
+    try:
+        qwen_boxes_to_points([], 100, 100, coord_space="normalized")
+    except ValueError:
+        return
+    raise AssertionError("expected an unknown coord_space to raise")
+
+
+def test_infer_qwen_coord_space_by_model_id():
+    assert infer_qwen_coord_space("Qwen/Qwen3-VL-8B-Instruct") == "norm1000"
+    assert infer_qwen_coord_space("Qwen/Qwen3-VL-32B-Instruct-FP8") == "norm1000"
+    assert infer_qwen_coord_space("Qwen/Qwen2.5-VL-7B-Instruct") == "pixels"
+    assert infer_qwen_coord_space("some-future-qwen") == "norm1000"  # newest convention
+
+
+# --- Qwen completion parsing (an open model has no response_schema) ----------
+
+def test_boxes_from_qwen_text_plain_json():
+    assert boxes_from_qwen_text('[{"bbox_2d": [1, 2, 3, 4], "label": "curb ramp"}]') == [
+        {"bbox_2d": [1.0, 2.0, 3.0, 4.0], "label": "curb ramp"}]
+
+
+def test_boxes_from_qwen_text_strips_code_fence_and_prose():
+    text = 'Sure! Here are the ramps:\n```json\n[{"bbox_2d": [5, 6, 7, 8], "label": "x"}]\n```\nDone.'
+    assert boxes_from_qwen_text(text) == [{"bbox_2d": [5.0, 6.0, 7.0, 8.0], "label": "x"}]
+
+
+def test_boxes_from_qwen_text_accepts_bare_object_and_bbox_alias():
+    assert boxes_from_qwen_text('{"bbox": [1, 2, 3, 4]}') == [
+        {"bbox_2d": [1.0, 2.0, 3.0, 4.0], "label": ""}]
+
+
+def test_boxes_from_qwen_text_drops_malformed_items():
+    text = '[{"bbox_2d": [1, 2, 3]}, "junk", {"label": "no box"}, {"bbox_2d": [1, 2, 3, 4]}]'
+    assert boxes_from_qwen_text(text) == [{"bbox_2d": [1.0, 2.0, 3.0, 4.0], "label": ""}]
+
+
+def test_boxes_from_qwen_text_empty_and_unparseable():
+    assert boxes_from_qwen_text("") == []
+    assert boxes_from_qwen_text("No curb ramps are visible in this image.") == []
+    assert boxes_from_qwen_text("[{unclosed") == []
+    assert boxes_from_qwen_text("[]") == []
 
 
 def test_boxes_from_gemini_response_parsed_objects():
@@ -90,7 +147,8 @@ def test_parse_model_spec():
     assert parse_model_spec("rampnet") == ("rampnet", None)
     assert parse_model_spec("gemini") == ("gemini", None)
     assert parse_model_spec("gemini:gemini-2.5-flash") == ("gemini", "gemini-2.5-flash")
-    assert parse_model_spec(" qwen : Qwen/Qwen3-VL ") == ("qwen", "Qwen/Qwen3-VL")
+    assert parse_model_spec(" qwen : Qwen/Qwen3-VL-8B-Instruct ") == (
+        "qwen", "Qwen/Qwen3-VL-8B-Instruct")
 
 
 def test_build_detector_labels_variants_by_model_id():
@@ -125,6 +183,76 @@ def test_cache_key_sensitive_and_stable():
     assert cache_key("m", {"x": 1}, "c", "p") == cache_key("m", {"x": 1}, "c", "p")
 
 
+def test_gemini_cache_key_is_frozen():
+    """Regression guard on real spend.
+
+    The on-disk cache holds thousands of already-paid Gemini detections keyed by
+    hash(label, signature, city, pano). Any drift in GeminiDetector.signature() —
+    a reworded prompt, a new key, a changed default — silently misses every one of
+    them and re-bills the whole run. If this fails, the change was not free: either
+    revert it or accept re-paying deliberately.
+    """
+    det = GeminiDetector(model_id="gemini-3.6-flash")
+    assert det.prompt == DETECTION_PROMPT      # provider-specific suffixes must not leak in
+    assert cache_key("gemini-3.6-flash", det.signature(), "richmond", "pano1") == (
+        "b4401afce834fee6bba27f9d1fbec67e86e570dd")
+
+
+def test_qwen_signature_extends_without_disturbing_gemini():
+    qwen = QwenDetector(model_id="Qwen/Qwen3-VL-8B-Instruct")
+    gem = GeminiDetector(model_id="gemini-3.6-flash")
+    sig = qwen.signature()
+    assert sig["coord_space"] == "norm1000" and sig["max_new_tokens"] == 1024
+    assert sig["prompt"].startswith(DETECTION_PROMPT) and sig["prompt"] != DETECTION_PROMPT
+    # The extra keys live only on Qwen's signature.
+    assert set(sig) - set(gem.signature()) == {"coord_space", "max_new_tokens"}
+
+
+def test_build_detector_qwen_coord_space_override():
+    class _Pinned(_Args):
+        qwen_coord_space = "pixels"
+    _, det = build_detector("qwen", "Qwen/Qwen3-VL-8B-Instruct", {}, _Pinned())
+    assert det.coord_space == "pixels"          # explicit flag beats id inference
+    _, det = build_detector("qwen", None, {}, _Args())
+    assert det.model_id == "Qwen/Qwen3-VL-8B-Instruct" and det.coord_space == "norm1000"
+
+
+class _UnloadableDetector:
+    """Stands in for Qwen on a laptop: it can describe itself but cannot load."""
+    name = "unloadable"
+
+    def signature(self):
+        return {"provider": "unloadable"}
+
+    def prepare(self):
+        raise ImportError("no GPU / weights here")
+
+    def detect(self, sample):
+        raise AssertionError("detect() must not be reached when everything is cached")
+
+
+def test_score_model_skips_model_load_when_fully_cached(tmp_path):
+    # A .model_cache produced on the cluster must score on a machine that cannot
+    # load the model at all — otherwise the remote run is unusable locally.
+    records, verdicts = _aligned()
+    det = _UnloadableDetector()
+    cache = DetectionCache(str(tmp_path))
+    cache.put(cache_key("unloadable", det.signature(), "richmond", "p1"), [(0.1, 0.1, None)])
+    report, failures = score_model(det, records, verdicts, "", radius_sq_for(),
+                                   "unloadable", "richmond", cache)
+    assert report.n_panos == 1 and report.tp == 1 and not failures
+
+
+def test_score_model_loads_model_on_a_cache_miss(tmp_path):
+    records, verdicts = _aligned()
+    try:
+        score_model(_UnloadableDetector(), records, verdicts, "", radius_sq_for(),
+                    "unloadable", "richmond", DetectionCache(str(tmp_path)))
+    except ImportError:
+        return  # prepare() still fails fast when work actually has to be done
+    raise AssertionError("expected prepare() to run (and fail) when a pano is uncached")
+
+
 def test_score_model_isolates_pano_failures():
     records = {pid: {"detections": [], "pano": {"width": 1, "height": 1}}
                for pid in ("good", "bad")}
@@ -147,9 +275,11 @@ def test_bundle_rampnet_detector_reads_records():
 
 
 def test_vlm_detectors_construct_without_client_libs():
-    # Constructing must not import google-genai / qwen; that only happens on detect().
+    # Constructing must not import google-genai / transformers, nor download weights;
+    # that only happens on prepare()/detect().
     GeminiDetector(model_id="gemini-flash-latest")
-    QwenDetector(model_id="Qwen/Qwen3-VL")
+    det = QwenDetector(model_id="Qwen/Qwen3-VL-8B-Instruct")
+    assert det._model is None and det._processor is None
 
 
 def test_gemini_detect_fails_clearly_without_key_or_lib():
@@ -158,7 +288,7 @@ def test_gemini_detect_fails_clearly_without_key_or_lib():
     try:
         det.detect(sample)
     except (ImportError, RuntimeError, NotImplementedError):
-        return  # any of these is an acceptable, clear failure for a scaffold
+        return  # any of these is an acceptable, clear failure
     raise AssertionError("expected GeminiDetector.detect to fail loudly without lib/key")
 
 


### PR DESCRIPTION
Closes the first unchecked box on #20: `QwenDetector` was a scaffold whose `_ensure_ready`/`_raw_detect` raised `NotImplementedError`. It's now live, and runs the same tiled path as Gemini — perspective views → grounding call → boxes mapped back to pano coordinates → dedup.

## The finding that changed the work

**Qwen3-VL emits `bbox_2d` normalized 0–1000, not absolute pixels of the resized image.** That was Qwen2.5-VL's convention, and it's what the old code and its TODO assumed.

This retires the "normalize by the 28-multiple processed size" caveat — the second checkbox on #20 — as **not applicable**: a 0–1000 box is resolution-independent, so the processor's smart-resize cannot shift it. Verified rather than taken on faith, by rendering one view at three sizes:

| view render | boxes returned | max coordinate |
|---|---|---|
| 512×512 | 1 | 345 |
| 1024×1024 | 1 | 365 |
| 1400×1400 | 1 | 360 |

Absolute-pixel output would have scaled with the image (~1400 at the largest). It didn't.

`qwen_boxes_to_points` now takes an explicit `coord_space` (`norm1000` | `pixels`), inferred from the model id, with `--qwen-coord-space` to override. It is deliberately **not** auto-detected: at a 1024px view the two conventions differ by only 2.4%, so a wrong guess doesn't crash — it introduces a small systematic localization bias that a P/R table won't reveal.

## What's in the PR

- **`QwenDetector`** loads the checkpoint once per run (`AutoModelForImageTextToText`, `device_map="auto"` with a single-device fallback when accelerate is absent), greedy decoding to mirror Gemini's `temperature=0`. `qwen-vl-utils` turns out to be unnecessary — Qwen3-VL's chat template takes PIL images directly. Default id is `Qwen/Qwen3-VL-8B-Instruct`; `Qwen/Qwen3-VL` was never a real repo id.
- **`boxes_from_qwen_text`** tolerates ```` ```json ```` fences, surrounding prose, a bare object, and malformed items. An open model has no `response_schema` equivalent, and one bad completion shouldn't abort a 1,400-call run.
- **`score_model` skips `prepare()` when every pano is already cached.** `cache_key` contains nothing machine-specific, so detections computed on the cluster score locally — but only if the harness doesn't try to load 16 GB of weights before reaching the first cache hit. This is what makes the Hyak → laptop handoff work.
- **`dump_detections.py`** (new) overlays a detector's raw boxes on each view against back-projected ground truth. `dump_views.py` proves the reprojection; this proves the box mapping, which is the half with a silent failure mode. Works for both providers — it independently re-validated Gemini's mapping too.
- **`run_qwen.slurm` + a Hyak runbook** in `docs/model_comparison.md`: stage the bundle, pre-download weights on a login node (`HF_HOME` on gscratch), `sbatch`, rsync `.model_cache/` back, score every model side by side with no GPU. Runs are resumable after preemption, since anything finished is already cached.

## Testing

Suite 75 → 88, all passing. Notable addition: **`test_gemini_cache_key_is_frozen`** pins the Gemini signature hash, so a reworded prompt or changed default can't silently invalidate detections that were already paid for. I confirmed all existing richmond cache entries still resolve after this change (124/124 for each of three Gemini variants), and re-scoring reproduces the published table unchanged.

Smoke-tested locally on `Qwen3-VL-2B-Instruct` — the largest that fits an 8 GB dev GPU — to validate wiring, parsing, and box mapping before spending cluster time. Boxes land squarely on the yellow tactile ramps where the model is right; the rest are genuine false positives (a stoop, a wall, a road marking). That's 2B-model quality, not a mapping bug. **2B is far too weak to benchmark** — the real runs are 8B and then 32B (`--gpus=2`) on Hyak, and are not part of this PR.

## Incidental finding for rig calibration (#20)

The overlays make it obvious that with `pitch_deg=-30`, the bottom ~40% of every view is the capture vehicle's hood and the black nadir cap — roughly a third of every paid call is spent on pixels that cannot contain a curb ramp. Noted in the doc's next-increments section.

Refs #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JLUNv5DXC6murLjSqvkw7
