### PR TITLE
Benchmark open detectors and pointing models: OWLv2, Grounding DINO, Molmo (#39)

### DIFF
--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -86,6 +86,15 @@ radius of a real GT point, which the per-detection human verdict scored differen
   same set. Note also that `--op-threshold` truncates the curve it is computed from: the AP
   printed alongside a thresholded row is the AP *of that row's operating range*, so quote
   full-range AP from a run without `--op-threshold`.
+- **AP is not comparable across models at different floors — and RampNet's is truncated.**
+  Every model's curve stops where its detections stop. RampNet's bundle detections were
+  extracted at a **0.5** peak threshold, so its curve has no low-confidence tail at all
+  (visible in `--sweep`: every row below 0.5 is identical) and its AP — 0.763 richmond /
+  0.754 bend — is a **lower bound**, close to its recall ceiling of 0.768 / 0.761 times a
+  near-1.0 precision envelope. The open detectors are cached down to 0.05, so their curves
+  extend into a region RampNet's simply doesn't cover. Compare AP between OWLv2 and
+  Grounding DINO freely; against RampNet, compare operating points, or re-extract RampNet's
+  detections at a lower peak threshold first.
 - **A swept threshold is tuned on the test set.** The `--sweep` table's best-F1 row is
   chosen on the benchmark itself. There is no separate val split, so quote it as an
   optimistic upper bound on what threshold tuning buys, not as a held-out result.

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -15,8 +15,75 @@ Three classes of challenger, which fail differently and are worth keeping distin
 
 The chat VLMs are all doing localization as a side skill, and they lose the same way: they
 are false-positive-heavy (119–293 FP against RampNet's 9). The other two classes exist in
-this harness to test whether that is a property of *general models* or of *chat models* —
-see "What each model class buys you" below.
+this harness to test whether that is a property of *general models* or of *chat models*.
+
+**It is not.** See the results below — the purpose-built open-vocabulary detectors do far
+*worse* than the chat VLMs on this task, not better.
+
+## Results
+
+Perspective tiling, match radius 0.022, all models scored against the same derived GT.
+Open detectors are shown at their 0.05 cache floor; their tuned operating points are in the
+sweep below. Run on Hyak (L40S); RampNet and Gemini rows are cache-scored.
+
+**richmond** (124 reviewed panos, 310 GT ramps)
+
+| model | P | R | F1 | AP | tp/fp/fn |
+|---|---|---|---|---|---|
+| **rampnet** | **0.964** | 0.768 | **0.855** | 0.763 | 238/9/72 |
+| gemini-3.1-pro-preview | 0.631 | 0.700 | 0.664 | – | 217/127/93 |
+| gemini-3.6-flash | 0.626 | 0.642 | 0.634 | – | 199/119/111 |
+| Qwen3-VL-32B-Instruct | 0.760 | 0.297 | 0.427 | – | 92/29/218 |
+| Qwen3-VL-8B-Instruct | 0.323 | 0.452 | 0.377 | – | 140/293/170 |
+| owlv2-large-patch14-ensemble | 0.033 | **0.971** | 0.064 | 0.104 | 301/8799/9 |
+| grounding-dino-base | 0.028 | 0.852 | 0.053 | 0.032 | 264/9321/46 |
+
+**bend** (110 reviewed panos, 327 GT ramps)
+
+| model | P | R | F1 | AP | tp/fp/fn |
+|---|---|---|---|---|---|
+| **rampnet** | **0.961** | 0.761 | **0.850** | 0.754 | 249/10/78 |
+| gemini-3.1-pro-preview | 0.706 | 0.581 | 0.638 | – | 190/79/137 |
+| gemini-3.6-flash | 0.608 | 0.587 | 0.597 | – | 192/124/135 |
+| Qwen3-VL-32B-Instruct | 0.706 | 0.294 | 0.415 | – | 96/40/231 |
+| Qwen3-VL-8B-Instruct | 0.379 | 0.336 | 0.357 | – | 110/180/217 |
+| owlv2-large-patch14-ensemble | 0.037 | 0.951 | 0.070 | 0.093 | 311/8187/16 |
+| grounding-dino-base | 0.038 | 0.850 | 0.073 | 0.049 | 278/6969/49 |
+
+### What the numbers say
+
+1. **RampNet still wins by a wide margin**, and nothing tested comes close on F1.
+2. **Purpose-built detectors did worse than chat models, not better.** OWLv2's best F1 over
+   the whole threshold sweep is **0.184** (thr 0.25: P 0.130 / R 0.310); Grounding DINO's is
+   **0.073**. Both are far below Gemini-3.6-flash's 0.634. The issue-#39 hypothesis — that
+   the chat VLMs' weakness was a *chat* problem — is refuted. Open-vocabulary detection with
+   a text query is simply not selective enough for an object that looks like a slightly
+   different patch of concrete.
+3. **Capacity isn't the chat VLMs' problem either.** Qwen-32B moved to the *precise* end
+   (P 0.760 / R 0.297) versus 8B's FP flood (P 0.323 / R 0.452) — the operating point moved,
+   F1 barely did (0.427 vs 0.377).
+4. **But OWLv2 has an extraordinary recall ceiling.** At its floor it finds **97.1%** of
+   richmond's ramps, against RampNet's 76.8%.
+
+### The recall-first angle: OWLv2 as a candidate generator
+
+Recall matters more than precision here (a false negative is a permanently missing ramp; a
+false positive is a cheap review). So the question is not OWLv2's F1 but whether it *sees*
+what RampNet misses. It does — nearly all of it:
+
+| OWLv2 thr | RampNet FN | recovered by OWLv2 | union recall | OWLv2 FP | FP per recovered ramp |
+|---|---|---|---|---|---|
+| 0.05 | 72 | **69** | **0.990** | 8799 | 128 |
+| 0.10 | 72 | 60 | 0.961 | 5167 | 86 |
+| 0.15 | 72 | 46 | 0.916 | 2923 | 64 |
+| 0.20 | 72 | 34 | 0.877 | 1507 | 44 |
+| 0.25 | 72 | 18 | 0.826 | 640 | 36 |
+
+A RampNet ∪ OWLv2 oracle would reach **0.990** recall on richmond. The cost is the story: at
+128 false positives per recovered ramp, versus **~6** for Gemini-3.6-flash (which recovered
+20 of the 72 at 119 FP total — see issue #35), OWLv2 is a **6–20× less efficient**
+complement. It is a recall oracle, not a usable candidate generator, unless a downstream
+verifier can reject ~128 proposals per find more cheaply than Gemini can propose 6.
 
 ## Why the benchmark verdicts can't be reused directly
 
@@ -228,11 +295,31 @@ constrained-decoding logits processor). `infer_molmo_mode` picks that path by mo
 `molmo_token_points_to_items` reads only the last two values of each returned row, because
 the model card documents the leading ids two different ways.
 
-**Status: wired, not yet verified.** The Molmo path has unit tests over both syntaxes but
-has never been run against real weights — 8B is a cluster model. Before quoting any Molmo
-number, run `dump_detections.py` on one pano and confirm the red crosshairs sit on ramps,
-exactly as was done for Qwen. Note also that the Molmo model cards pin
-`transformers==4.57.1`; their remote code may not load on 5.x (see `requirements-vlm.txt`).
+**The `transformers==4.57.1` pin on the Molmo cards is real, not cautionary.** Under 5.14.1
+Molmo's own Hub code fails at import:
+
+```
+TypeError: Unexpected keyword argument image_use_col_tokens.
+  ... transformers_modules/allenai/Molmo2_hyphen_8B/.../processing_molmo2.py line 93
+```
+
+It also needs `einops` **and `requests`**, which the lean cluster env lacked. The fix is a
+**dedicated env at the pin**, not a downgrade of the env the other models use — the harness
+itself imports fine on 4.57.1, so only Molmo's interpreter differs:
+
+```bash
+conda create -p /gscratch/scrubbed/$USER/envs/molmo python=3.11 -y
+MOLMOPY=/gscratch/scrubbed/$USER/envs/molmo/bin/python
+$MOLMOPY -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126
+$MOLMOPY -m pip install "transformers==4.57.1" accelerate pillow numpy einops requests
+PYTHON=$MOLMOPY MODELS=rampnet,molmo:allenai/Molmo2-8B \
+    sbatch -A <account> scripts/model_comparison/run_open_models.slurm
+```
+
+**Status: verify the overlay before quoting any Molmo number.** The parser has unit tests
+over both syntaxes, but the coordinate scale has not been confirmed against real weights.
+Run `dump_detections.py` on one pano first and check the red crosshairs sit on ramps — as was
+done for Qwen. Nothing detected at all means the scale is wrong (try `--molmo-coord-scale`).
 
 ## Status
 
@@ -249,10 +336,12 @@ exactly as was done for Qwen. Note also that the Molmo model cards pin
   far too weak to benchmark — the real runs are 8B and 32B on Hyak.
 - **Where runs happen:** benchmark numbers come from **Hyak** (or makelab2), never the dev
   box. The desktop is for de-risking a cluster job — a 1–2 pano wiring probe and a
-  `dump_detections.py` overlay — and those results are smoke tests, not results. OWLv2 and
-  Grounding DINO were smoke-probed that way on 2 richmond panos (wiring, score
-  carry-through, box mapping, cache reuse, AP/sweep output all confirmed); their benchmark
-  rows are still pending the cluster run below.
+  `dump_detections.py` overlay — and those results are smoke tests, not results.
+- **Desktop and cluster agree exactly.** The 2-pano smoke on an RTX 3070 and on an L40S
+  produced *identical* numbers (OWLv2 18/156/1/5, AP 0.356; Grounding DINO 18/160/1/3, AP
+  0.247), and the overlay job reproduced the same 94 OWLv2 boxes across the same six views.
+  So a desktop probe is a faithful rehearsal of the cluster job — worth knowing before
+  spending an allocation on a wiring bug.
 
 ## Gemini credentials
 
@@ -388,20 +477,29 @@ finished, so re-submitting picks up where it stopped.
 
 ## Next increments
 
-1. **Calibrate the reprojection rig** against the live VLM runs: tune `fov_h_deg`, `n_yaw`,
-   `pitch_deg` so ramps land near-centered in some view, minimizing seam-truncation false
-   positives. The `dump_detections.py` overlays make one problem obvious — with `pitch_deg=-30`
-   the bottom ~40% of every view is the capture vehicle's hood and the black nadir cap, so
-   roughly a third of every paid call is spent on pixels that can't contain a curb ramp.
-   Report perspective vs `--tiling none` side by side.
+1. **Calibrate the reprojection rig — now measurable, and demonstrably costly.** With
+   `pitch_deg=-30` the bottom ~40% of every view is the capture vehicle's hood and the black
+   nadir cap, so roughly a third of every paid call is spent on pixels that cannot contain a
+   curb ramp. The open-detector overlays show this is not merely wasteful: Grounding DINO's
+   **highest-scoring box in a view (0.40) is the hood itself**, outranking its correct 0.22
+   box on a real tactile pad. Because AP ranks by score, hood detections at the top of the
+   ranking depress AP directly — which is a plausible part of why Grounding DINO's AP (0.032)
+   trails OWLv2's (0.104) despite similar operating points. Masking the nadir/hood region is
+   now a change whose benefit can be *measured* (ΔAP), not just argued. Report perspective vs
+   `--tiling none` side by side.
 2. **Add the `clovis` split** once the auto-labeler hands back its bundle; the harness is
    city-generic (it just needs `records.jsonl` + `verdicts.json` + `panos/`).
 3. **Verify Molmo against real weights** (overlay first, then the run), and decide whether
    `MolmoPoint-8B`'s special-token path or `Molmo2-8B`'s XML path is the one to report.
-4. **Tune the open detectors toward recall.** They are the only challengers with a knob;
-   `--sweep` on the full bundles will show whether a recall-first operating point exists
-   that keeps precision usable, and `--owlv2-query` / `--gdino-query` are worth a small
-   sweep of their own (the query is a free hyperparameter and these models are cheap).
+4. **Prompt-sweep the open detectors before writing them off entirely.** `--owlv2-query` /
+   `--gdino-query` are free hyperparameters and these models are cheap to run (43
+   detections/min on one L40S; a full city is ~15 min). The current queries are a single
+   untuned phrase each; "curb cut", "wheelchair ramp at a crosswalk", or a multi-query
+   ensemble might move them. Given F1 0.184 vs RampNet's 0.855 this will not change the
+   verdict, but it would tell us whether the ceiling is the *query* or the *model class*.
+5. **If a recall-first candidate generator is wanted, compare complements on FP-per-find,
+   not F1.** That metric ranks Gemini-3.6-flash (~6) far above OWLv2 (36–128) despite
+   OWLv2's much higher recall ceiling — see the table above.
 
 ## Files
 

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -33,6 +33,7 @@ sweep below. Run on Hyak (L40S); RampNet and Gemini rows are cache-scored.
 | **rampnet** | **0.964** | 0.768 | **0.855** | 0.763 | 238/9/72 |
 | gemini-3.1-pro-preview | 0.631 | 0.700 | 0.664 | – | 217/127/93 |
 | gemini-3.6-flash | 0.626 | 0.642 | 0.634 | – | 199/119/111 |
+| **molmo2-8B** (points) | 0.410 | 0.516 | **0.457** | – | 160/230/150 |
 | Qwen3-VL-32B-Instruct | 0.760 | 0.297 | 0.427 | – | 92/29/218 |
 | Qwen3-VL-8B-Instruct | 0.323 | 0.452 | 0.377 | – | 140/293/170 |
 | owlv2-large-patch14-ensemble | 0.033 | **0.971** | 0.064 | 0.104 | 301/8799/9 |
@@ -45,14 +46,23 @@ sweep below. Run on Hyak (L40S); RampNet and Gemini rows are cache-scored.
 | **rampnet** | **0.961** | 0.761 | **0.850** | 0.754 | 249/10/78 |
 | gemini-3.1-pro-preview | 0.706 | 0.581 | 0.638 | – | 190/79/137 |
 | gemini-3.6-flash | 0.608 | 0.587 | 0.597 | – | 192/124/135 |
+| **molmo2-8B** (points) | 0.510 | 0.401 | **0.449** | – | 131/126/196 |
 | Qwen3-VL-32B-Instruct | 0.706 | 0.294 | 0.415 | – | 96/40/231 |
 | Qwen3-VL-8B-Instruct | 0.379 | 0.336 | 0.357 | – | 110/180/217 |
 | owlv2-large-patch14-ensemble | 0.037 | 0.951 | 0.070 | 0.093 | 311/8187/16 |
 | grounding-dino-base | 0.038 | 0.850 | 0.073 | 0.049 | 278/6969/49 |
 
+Molmo is the strongest **open-weight** model here — best F1 of the four, and the only
+challenger with a *balanced* profile (P≈R) rather than an FP flood or extreme caution. It
+also does it natively in points, no box→center reduction. But it is still ~0.4 F1 behind
+RampNet and clearly behind both Geminis, and it is *sparse*: on the verified overlay pano it
+proposed 2 points where 4 ramps were visible, which shows up as its 150/196 false negatives.
+
 ### What the numbers say
 
-1. **RampNet still wins by a wide margin**, and nothing tested comes close on F1.
+1. **RampNet still wins by a wide margin**, and nothing tested comes close on F1. The best
+   challenger (Gemini-3.1-pro, F1 0.664) trails it by ~0.19; the best open-weight model
+   (Molmo, F1 0.457) by ~0.40.
 2. **Purpose-built detectors did worse than chat models, not better.** OWLv2's best F1 over
    the whole threshold sweep is **0.184** (thr 0.25: P 0.130 / R 0.310); Grounding DINO's is
    **0.073**. Both are far below Gemini-3.6-flash's 0.634. The issue-#39 hypothesis — that
@@ -316,10 +326,12 @@ PYTHON=$MOLMOPY MODELS=rampnet,molmo:allenai/Molmo2-8B \
     sbatch -A <account> scripts/model_comparison/run_open_models.slurm
 ```
 
-**Status: verify the overlay before quoting any Molmo number.** The parser has unit tests
-over both syntaxes, but the coordinate scale has not been confirmed against real weights.
-Run `dump_detections.py` on one pano first and check the red crosshairs sit on ramps — as was
-done for Qwen. Nothing detected at all means the scale is wrong (try `--molmo-coord-scale`).
+**Status: run and scored** (richmond/bend, above). Verifying the overlay first was not
+optional — the first run put every point on the left edge because Molmo's `coords` list
+opens with an **image index** the parser mistook for a point id (fixed; see the parser note
+below). After the fix the crosshairs sit on ramps and the numbers are the F1-0.45 rows above.
+The lesson stands for the next pointing model: `dump_detections.py` on one pano first, and if
+nothing is detected the scale is wrong (try `--molmo-coord-scale`).
 
 ## Status
 

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -1,12 +1,22 @@
-# Model comparison: RampNet vs. VLMs
+# Model comparison: RampNet vs. general-purpose models
 
 Uses the standardized curb-ramp benchmark (`benchmark/{bend,richmond}/`) to compare
-RampNet against general-purpose vision-language models that now do bounding-box detection —
-**Gemini Flash** (default `gemini-3.6-flash`) via API and the open **Qwen3-VL** (default
-`Qwen/Qwen3-VL-8B-Instruct`, run on Hyak).
-The question: does a general VLM match or beat the purpose-trained RampNet on real
-deployment imagery (GSV + Mapillary 360)? The harness is model-agnostic, so future models
-(issue #20) plug in the same way.
+RampNet against off-the-shelf models. The question: does a general model match or beat the
+purpose-trained RampNet on real deployment imagery (GSV + Mapillary 360)? The harness is
+model-agnostic, so new models (issues #20, #39) plug in the same way.
+
+Three classes of challenger, which fail differently and are worth keeping distinct:
+
+| class | models | output | tunable? |
+|---|---|---|---|
+| **chat VLMs** | `gemini-3.6-flash`, `gemini-3.1-pro-preview`, `Qwen/Qwen3-VL-*` | boxes, no score | no — one operating point |
+| **open-vocab detectors** | `google/owlv2-large-patch14-ensemble`, `IDEA-Research/grounding-dino-base` | boxes **with calibrated scores** | yes — AP, PR curve, threshold sweep |
+| **pointing models** | `allenai/Molmo2-8B`, `allenai/MolmoPoint-8B` | **points** (RampNet's native format) | no score, but no box→point reduction |
+
+The chat VLMs are all doing localization as a side skill, and they lose the same way: they
+are false-positive-heavy (119–293 FP against RampNet's 9). The other two classes exist in
+this harness to test whether that is a property of *general models* or of *chat models* —
+see "What each model class buys you" below.
 
 ## Why the benchmark verdicts can't be reused directly
 
@@ -57,16 +67,28 @@ radius of a real GT point, which the per-detection human verdict scored differen
 - **RampNet-anchored GT.** The GT was assembled during a RampNet review. A reviewer scanning
   fresh for another model might catch a few more ramps; the complete-scan attestation
   (`no_missed`) mitigates this, but it is a known asymmetry.
-- **Box → point reduction.** VLM boxes are scored by their centers, at the same radius as
-  RampNet's point detections. Localization differences finer than the radius aren't measured.
-- **Equirectangular projection disadvantages VLMs.** RampNet was trained on 2048×4096
-  equirect panos; Gemini/Qwen were not, and ramps are tiny in a warped 4k+ pano. The fair
-  input is **perspective reprojection** (default, below): the pano is reprojected into
-  overlapping rectilinear views. Whole-pano (`--tiling none`) remains available as a lower
-  bound.
-- **No AP for VLMs.** VLM box detection carries no calibrated per-box confidence, so we report
-  **operating-point** P/R for all models; AP / PR-curve (via `rampnet.metrics`) applies only
-  where confidences exist (RampNet).
+- **Box → point reduction.** Box models are scored by their box centers, at the same radius
+  as RampNet's point detections. Localization differences finer than the radius aren't
+  measured. Molmo is the exception — it emits points natively, so nothing is reduced.
+- **Equirectangular projection disadvantages the challengers.** RampNet was trained on
+  2048×4096 equirect panos; the others were not, and ramps are tiny in a warped 4k+ pano.
+  The fair input is **perspective reprojection** (default, below): the pano is reprojected
+  into overlapping rectilinear views. Whole-pano (`--tiling none`) remains available as a
+  lower bound.
+- **No AP for *chat* VLMs.** Gemini/Qwen box detection carries no calibrated per-box
+  confidence, so those rows are a single **operating point** and their AP column reads `-`.
+  AP / PR curves (via `rampnet.metrics`) are reported wherever confidences exist: RampNet,
+  OWLv2, and Grounding DINO.
+- **AP is measured on a slightly different slice than P/R.** AP needs one consistent recall
+  denominator, so it is computed over the **recall-confirmed panos** only (the `no_missed`
+  gate), while the precision column counts detections on every pano. On the current bundles
+  nearly every pano is recall-confirmed, so the two slices are close — but they are not the
+  same set. Note also that `--op-threshold` truncates the curve it is computed from: the AP
+  printed alongside a thresholded row is the AP *of that row's operating range*, so quote
+  full-range AP from a run without `--op-threshold`.
+- **A swept threshold is tuned on the test set.** The `--sweep` table's best-F1 row is
+  chosen on the benchmark itself. There is no separate val split, so quote it as an
+  optimistic upper bound on what threshold tuning buys, not as a held-out result.
 
 ## VLM input: perspective reprojection (fair) vs whole-pano (lower bound)
 
@@ -129,17 +151,99 @@ crash, it introduces a small systematic localization bias. Verified empirically 
 one view at 512 / 1024 / 1400 px: the returned coordinates stayed in the same ~0–1000 band
 instead of scaling with the image, and the overlay put boxes squarely on tactile ramps.
 
+`dump_detections.py` draws all three prediction shapes: plain boxes (Gemini, Qwen), **scored**
+boxes (OWLv2, Grounding DINO — the score is printed next to each box, since that is the
+number the threshold sweep tunes), and **points** (Molmo, drawn as a red crosshair-in-circle
+with the same visual weight as a box, so a scale error is equally obvious).
+
+## What each model class buys you
+
+### Open-vocabulary detectors: real confidences, so a real curve
+
+`OwlV2Detector` and `GroundingDinoDetector` are text-prompted *detectors*, not chat models:
+the "prompt" is a short query (`"a photo of a curb ramp"` for OWLv2, which is CLIP-based;
+`"curb ramp."` — lowercase, period-terminated — for Grounding DINO), and every box comes
+back with a **calibrated score**. The harness threads that score all the way through
+(`pixel_boxes_to_points` → `dedup_points` keeps the highest-scoring copy of a cross-view
+duplicate → `score_pano` matches greedily in score order), which unlocks three things no
+chat VLM in this harness can offer:
+
+- **AP** in the main table,
+- **PR curves** (`--pr-out DIR` → one JSON per model plus a combined PNG),
+- a **threshold sweep** (`--sweep`) — P/R/F1 at each cutoff, best-F1 row flagged.
+
+That last one matters directly for the recall-first direction: a detector you can *tune*
+toward recall is worth more than a chat model pinned at one operating point.
+
+**`--score-threshold` is a cache floor, not the operating point.** Detections are computed
+once down to a low score (default **0.05**) and cached; every higher operating point is then
+a free local re-score (`--op-threshold`, `--sweep`) with no second model run. The floor is
+part of the detector signature, so *lowering* it invalidates the cache and re-runs the model
+— raising the reported threshold never does.
+
+**OWLv2's boxes are relative to a padded square.** Its image processor pads to
+`max(h, w)` (bottom/right) before resizing, so boxes live in that square's frame with the
+image in the top-left corner; `owlv2_target_size` states that frame explicitly and
+`pixel_boxes_to_points` normalizes by the *original* width/height, dropping centers that
+land in the pad. Current transformers already scales OWLv2 boxes by `max(h, w)` internally
+(`_scale_boxes`: *"for owlv2 image is padded to max size"*), so on this version passing the
+square and passing the image's own `(h, w)` agree — verified on a 2:1 crop, where both put
+the top box at y 0.815 against a true position of 0.817. Square views (the default rig) are
+unaffected either way; whole-pano mode (`--tiling none`) is the only place the distinction
+could bite, and passing the square is also correct under the older per-axis scaling.
+
+### Molmo: points, not boxes
+
+Molmo is the one challenger whose native output is a **point**, which is RampNet's own
+output format — so it is the only apples-to-apples comparison in the table, with no
+box→center reduction. There is no per-point score, so Molmo gets an operating point but no
+PR curve.
+
+**Its coordinate convention changed between generations**, and unlike Qwen's two box
+conventions the two are distinguishable by *syntax*, so `molmo_points_from_text` infers the
+scale per tag (override with `--molmo-coord-scale`):
+
+- **Molmo 1** — `<point x="35.4" y="61.2" alt="...">` / `<points x1=… y1=… x2=… y2=…>`:
+  coordinates are **percentages (0–100)**.
+- **Molmo 2** — `<points coords="0 354 612; 1 700 480"/>`, triplets of `id x y`:
+  coordinates are **scaled by 1000**, per the model card's own regex. (Issue #39 expected
+  0–100 for all of Molmo; that holds for Molmo 1 only.)
+
+A wrong scale here fails loudly rather than silently: points outside `[0,1]` after scaling
+are dropped (as the model card's reference implementation does), so mis-scaled 0–1000
+numbers divided by 100 land out of frame and the model appears to detect nothing.
+
+`MolmoPoint-8B` is different again — it emits points as **special tokens** that only the
+model can decode (`extract_image_points`, with metadata from the processor and a
+constrained-decoding logits processor). `infer_molmo_mode` picks that path by model id;
+`molmo_token_points_to_items` reads only the last two values of each returned row, because
+the model card documents the leading ids two different ways.
+
+**Status: wired, not yet verified.** The Molmo path has unit tests over both syntaxes but
+has never been run against real weights — 8B is a cluster model. Before quoting any Molmo
+number, run `dump_detections.py` on one pano and confirm the red crosshairs sit on ramps,
+exactly as was done for Qwen. Note also that the Molmo model cards pin
+`transformers==4.57.1`; their remote code may not load on 5.x (see `requirements-vlm.txt`).
+
 ## Status
 
 - **Shipped:** the model-agnostic scorer (`rampnet/detection_eval.py`), the comparison CLI
   (`scripts/model_comparison/compare.py`), the RampNet-from-bundle baseline
   (`BundleRampNetDetector`), the **perspective reprojection + dedup** (`equirect_tiling.py`),
-  the **live `GeminiDetector`** (google-genai; API key or Vertex+ADC), and the **live
-  `QwenDetector`** (transformers; Qwen3-VL on a cluster GPU). Tested
-  (`test_detection_eval.py`, `test_model_comparison.py`, `test_equirect_tiling.py`).
+  the **live `GeminiDetector`** (google-genai; API key or Vertex+ADC), the **live
+  `QwenDetector`** (transformers; Qwen3-VL on a cluster GPU), the **live `OwlV2Detector` /
+  `GroundingDinoDetector`** (with AP, PR curves and a threshold sweep), and the
+  **`MolmoDetector`** (points; wired, unverified). Tested (`test_detection_eval.py`,
+  `test_model_comparison.py`, `test_equirect_tiling.py`).
 - **Smoke-tested locally** on `Qwen/Qwen3-VL-2B-Instruct` (the largest that fits an 8 GB dev
   GPU) to validate wiring, JSON parsing, and box mapping before spending cluster time. 2B is
   far too weak to benchmark — the real runs are 8B and 32B on Hyak.
+- **Where runs happen:** benchmark numbers come from **Hyak** (or makelab2), never the dev
+  box. The desktop is for de-risking a cluster job — a 1–2 pano wiring probe and a
+  `dump_detections.py` overlay — and those results are smoke tests, not results. OWLv2 and
+  Grounding DINO were smoke-probed that way on 2 richmond panos (wiring, score
+  carry-through, box mapping, cache reuse, AP/sweep output all confirmed); their benchmark
+  rows are still pending the cluster run below.
 
 ## Gemini credentials
 
@@ -183,15 +287,31 @@ python scripts/model_comparison/compare.py benchmark/richmond --models gemini --
 # Qwen3-VL (open weights, needs a GPU — see the Hyak runbook below):
 python scripts/model_comparison/compare.py benchmark/richmond \
     --models rampnet,qwen:Qwen/Qwen3-VL-8B-Instruct
+
+# Open-vocabulary detectors: AP in the table, plus the curve and the sweep.
+python scripts/model_comparison/compare.py benchmark/richmond \
+    --models rampnet,owlv2,gdino --sweep --pr-out evaluation_results/pr_richmond
+
+# Scoring only (no GPU, no model load) once .model_cache holds the detections.
+# Every operating point is a free re-score of that cache:
+python scripts/model_comparison/compare.py benchmark/richmond \
+    --models rampnet,owlv2,gdino --op-threshold 0.2
 ```
 
-A model that can't run (missing credentials, missing client lib) is skipped with a clear note
-rather than crashing the run.
+A model that can't run (missing credentials, missing client lib, remote code that won't load
+on this transformers version) is skipped with a clear note rather than crashing the run — so
+one broken model can't cost you the models that already ran.
 
-## Running Qwen3-VL on Hyak
+## Running the open-weight models on Hyak
 
-Qwen3-VL-8B is ~16 GB in bf16 and 32B ~64 GB, so it runs on the cluster, not the dev box.
-`scripts/model_comparison/run_qwen.slurm` is the launcher.
+Benchmark runs go on the cluster, not the dev box — Qwen3-VL-8B is ~16 GB in bf16 (32B
+~64 GB) and Molmo-8B ~16 GB, and even the small detectors should produce their reported
+numbers where every other model's came from. Two launchers:
+
+- `scripts/model_comparison/run_qwen.slurm` — the Qwen leg.
+- `scripts/model_comparison/run_open_models.slurm` — OWLv2 + Grounding DINO (default), or
+  Molmo via `MODELS=`. OWLv2-large and Grounding DINO-base are ~1–2 GB and finish in
+  minutes on one card; Molmo-8B takes hours because it generates text per view.
 
 **The results come back through the detection cache.** `cache_key` hashes only
 `(label, detector signature, city, pano id)` — nothing machine-specific — so detections computed
@@ -200,26 +320,58 @@ cached, `score_model` skips `detector.prepare()` entirely, so the final table ca
 a laptop that cannot load Qwen at all.
 
 ```bash
-# 1. On Hyak: stage the repo plus the (git-ignored) bundle imagery.
-rsync -av --exclude .venv --exclude .model_cache RampNet/ klone:~/RampNet/
+# 1. Stage the repo plus the (git-ignored) bundle imagery. Send the NATIVE panos:
+#    the harness downscales in-process, and pre-resizing re-encodes the JPEG,
+#    which is not free (a past gold-set re-eval moved P +2.2 / R -1.8 on
+#    re-encoding alone).
+rsync -av --exclude .venv --exclude .model_cache --exclude 'benchmark/*/panos' \
+      RampNet/ klone:~/RampNet/
 rsync -av benchmark/richmond/panos/ klone:~/RampNet/benchmark/richmond/panos/
 
-# 2. On a login node: create/activate the env and pre-download the weights, so the
-#    GPU job isn't billed for the download.
-conda env create -f environment.yml && conda activate sidewalkcv2   # CONDA_OVERRIDE_CUDA=12.6
-pip install -r requirements-vlm.txt
-export HF_HOME=/gscratch/scrubbed/$USER/hf && hf download Qwen/Qwen3-VL-8B-Instruct
+# 2. On a login node: build an env. The full environment.yml works (remember
+#    CONDA_OVERRIDE_CUDA=12.6, or conda-forge silently installs CPU-only torch),
+#    but this leg needs only numpy/PIL/torch/torchvision/transformers -- the
+#    RampNet baseline reads detections from the bundle, so no timm, no model load.
+#    A lean env off the CUDA wheel index is faster and has no CPU-fallback trap:
+module load conda/Miniforge3-25.9.1-0
+conda create -p /gscratch/scrubbed/$USER/envs/qwenvl python=3.11 -y
+ENVPY=/gscratch/scrubbed/$USER/envs/qwenvl/bin/python
+$ENVPY -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126
+$ENVPY -m pip install "transformers>=4.57" accelerate pillow numpy
 
-# 3. Submit. 8B fits one L40S; 32B needs two (device_map="auto" shards it).
+# 3. Pre-download the weights so the GPU job isn't billed for the transfer.
+#    (~17 GB for Qwen-8B; OWLv2-large + Grounding DINO-base are ~2 GB together.)
+export HF_HOME=/gscratch/scrubbed/$USER/hf
+$ENVPY -c 'from huggingface_hub import snapshot_download as d; [d(m) for m in [
+    "Qwen/Qwen3-VL-8B-Instruct",
+    "google/owlv2-large-patch14-ensemble",
+    "IDEA-Research/grounding-dino-base"]]'
+
+# 4. Submit. -A is required (find yours: sacctmgr -nP show assoc user=$USER
+#    format=Account,QOS). 8B fits one L40S; 32B needs two (device_map shards it).
 mkdir -p logs
-sbatch scripts/model_comparison/run_qwen.slurm
-BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_qwen.slurm
-QWEN_MODEL=Qwen/Qwen3-VL-32B-Instruct sbatch --gpus=2 scripts/model_comparison/run_qwen.slurm
+export PYTHON=$ENVPY
+sbatch -A <account> scripts/model_comparison/run_qwen.slurm
+BUNDLE=benchmark/bend sbatch -A <account> scripts/model_comparison/run_qwen.slurm
+QWEN_MODEL=Qwen/Qwen3-VL-32B-Instruct sbatch -A <account> --gpus=2 \
+    scripts/model_comparison/run_qwen.slurm
 
-# 4. Bring the detections home and score every model side by side, no GPU needed.
+# 4b. The open-vocabulary detectors: minutes, one card, both cities.
+sbatch -A <account> scripts/model_comparison/run_open_models.slurm
+BUNDLE=benchmark/bend sbatch -A <account> scripts/model_comparison/run_open_models.slurm
+
+# 4c. Molmo (hours — it generates text per view). Verify the box/point mapping on
+#     one pano FIRST; the Molmo path has never seen real weights:
+$ENVPY scripts/model_comparison/dump_detections.py benchmark/richmond \
+    --model molmo:allenai/Molmo2-8B --out view_dump/molmo
+MODELS=rampnet,molmo:allenai/Molmo2-8B \
+    sbatch -A <account> scripts/model_comparison/run_open_models.slurm
+
+# 5. Bring the detections home and score every model side by side, no GPU needed.
 rsync -av klone:~/RampNet/.model_cache/ .model_cache/
-python scripts/model_comparison/compare.py benchmark/richmond \
-    --models rampnet,gemini:gemini-3.6-flash,qwen:Qwen/Qwen3-VL-8B-Instruct
+python scripts/model_comparison/compare.py benchmark/richmond --sweep \
+    --pr-out evaluation_results/pr_richmond \
+    --models rampnet,gemini:gemini-3.6-flash,qwen:Qwen/Qwen3-VL-8B-Instruct,owlv2,gdino
 ```
 
 Runs are resumable: a job that is preempted or times out has already cached everything it
@@ -235,16 +387,24 @@ finished, so re-submitting picks up where it stopped.
    Report perspective vs `--tiling none` side by side.
 2. **Add the `clovis` split** once the auto-labeler hands back its bundle; the harness is
    city-generic (it just needs `records.jsonl` + `verdicts.json` + `panos/`).
+3. **Verify Molmo against real weights** (overlay first, then the run), and decide whether
+   `MolmoPoint-8B`'s special-token path or `Molmo2-8B`'s XML path is the one to report.
+4. **Tune the open detectors toward recall.** They are the only challengers with a knob;
+   `--sweep` on the full bundles will show whether a recall-first operating point exists
+   that keeps precision usable, and `--owlv2-query` / `--gdino-query` are worth a small
+   sweep of their own (the query is a free hyperparameter and these models are cheap).
 
 ## Files
 
-- `rampnet/detection_eval.py` — model-agnostic GT + scorer (pure, torch-free).
-- `scripts/model_comparison/detectors.py` — `Detector` protocol, RampNet baseline, VLM detectors.
+- `rampnet/detection_eval.py` — model-agnostic GT + scorer, AP/PR curve (pure, torch-free).
+- `scripts/model_comparison/detectors.py` — `Detector` protocol, RampNet baseline, VLM /
+  open-vocabulary / pointing detectors.
 - `scripts/model_comparison/equirect_tiling.py` — perspective reprojection + point mapping + dedup.
-- `scripts/model_comparison/compare.py` — comparison CLI.
+- `scripts/model_comparison/compare.py` — comparison CLI (table, sweep, PR curves).
 - `scripts/model_comparison/dump_views.py` — visual de-distortion QA (graticule overlay).
-- `scripts/model_comparison/dump_detections.py` — visual box-mapping QA (boxes vs ground truth).
+- `scripts/model_comparison/dump_detections.py` — visual mapping QA (boxes/points vs ground truth).
 - `scripts/model_comparison/run_qwen.slurm` — Hyak launcher for the Qwen leg.
+- `scripts/model_comparison/run_open_models.slurm` — Hyak launcher for OWLv2 / Grounding DINO / Molmo.
 - `requirements-vlm.txt` — optional VLM deps.
 - `tests/test_detection_eval.py`, `tests/test_model_comparison.py`,
   `tests/test_equirect_tiling.py` — guards.

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -284,7 +284,9 @@ toward recall is worth more than a chat model pinned at one operating point.
 once down to a low score (default **0.05**) and cached; every higher operating point is then
 a free local re-score (`--op-threshold`, `--sweep`) with no second model run. The floor is
 part of the detector signature, so *lowering* it invalidates the cache and re-runs the model
-— raising the reported threshold never does.
+— raising the reported threshold never does. The sweep only prints rows at or above the
+floor: below it the cache holds no detections, so those rows would just repeat the floor row
+while reading as real measurements.
 
 **OWLv2's boxes are relative to a padded square.** Its image processor pads to
 `max(h, w)` (bottom/right) before resizing, so boxes live in that square's frame with the
@@ -360,8 +362,10 @@ nothing is detected the scale is wrong (try `--molmo-coord-scale`).
   the **live `GeminiDetector`** (google-genai; API key or Vertex+ADC), the **live
   `QwenDetector`** (transformers; Qwen3-VL on a cluster GPU), the **live `OwlV2Detector` /
   `GroundingDinoDetector`** (with AP, PR curves and a threshold sweep), and the
-  **`MolmoDetector`** (points; wired, unverified). Tested (`test_detection_eval.py`,
-  `test_model_comparison.py`, `test_equirect_tiling.py`).
+  **`MolmoDetector`** (points; `Molmo2-8B` verified by overlay and run on both cities —
+  see the Molmo section; `MolmoPoint-8B`'s special-token path is wired but has not met
+  real weights). Tested (`test_detection_eval.py`, `test_model_comparison.py`,
+  `test_equirect_tiling.py`).
 - **Smoke-tested locally** on `Qwen/Qwen3-VL-2B-Instruct` (the largest that fits an 8 GB dev
   GPU) to validate wiring, JSON parsing, and box mapping before spending cluster time. 2B is
   far too weak to benchmark — the real runs are 8B and 32B on Hyak.
@@ -489,8 +493,10 @@ QWEN_MODEL=Qwen/Qwen3-VL-32B-Instruct sbatch -A <account> --gpus=2 \
 sbatch -A <account> scripts/model_comparison/run_open_models.slurm
 BUNDLE=benchmark/bend sbatch -A <account> scripts/model_comparison/run_open_models.slurm
 
-# 4c. Molmo (hours — it generates text per view). Verify the box/point mapping on
-#     one pano FIRST; the Molmo path has never seen real weights:
+# 4c. Molmo (hours — it generates text per view). Verify the point mapping on one
+#     pano FIRST — this overlay is what caught the image-index parsing bug on the
+#     first real run (see the Molmo section), and any new checkpoint can pull the
+#     same kind of trick:
 $ENVPY scripts/model_comparison/dump_detections.py benchmark/richmond \
     --model molmo:allenai/Molmo2-8B --out view_dump/molmo
 MODELS=rampnet,molmo:allenai/Molmo2-8B \
@@ -520,8 +526,9 @@ finished, so re-submitting picks up where it stopped.
    `--tiling none` side by side.
 2. **Add the `clovis` split** once the auto-labeler hands back its bundle; the harness is
    city-generic (it just needs `records.jsonl` + `verdicts.json` + `panos/`).
-3. **Verify Molmo against real weights** (overlay first, then the run), and decide whether
-   `MolmoPoint-8B`'s special-token path or `Molmo2-8B`'s XML path is the one to report.
+3. **Run `MolmoPoint-8B`** (its special-token path is wired but has never met real
+   weights — overlay first) and decide whether it or `Molmo2-8B`'s XML path, already run
+   and scored above, is the one to report.
 4. **Prompt-sweep the open detectors before writing them off entirely.** `--owlv2-query` /
    `--gdino-query` are free hyperparameters and these models are cheap to run (43
    detections/min on one L40S; a full city is ~15 min). The current queries are a single

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -17,8 +17,12 @@ The chat VLMs are all doing localization as a side skill, and they lose the same
 are false-positive-heavy (119–293 FP against RampNet's 9). The other two classes exist in
 this harness to test whether that is a property of *general models* or of *chat models*.
 
-**It is not.** See the results below — the purpose-built open-vocabulary detectors do far
-*worse* than the chat VLMs on this task, not better.
+**It looks like a general-model property, not a chat-specific one:** see the results below —
+the off-the-shelf open-vocabulary detectors do far *worse* than the chat VLMs on this task,
+not better. (Caveat up front: these are general open-vocab detectors given a short text
+query — *not* detectors trained for curb ramps. The only model here purpose-built for the
+class is RampNet itself, and every challenger is zero-shot with an untuned prompt. See
+"Scope of the claim" below.)
 
 ## Results
 
@@ -58,17 +62,32 @@ also does it natively in points, no box→center reduction. But it is still ~0.4
 RampNet and clearly behind both Geminis, and it is *sparse*: on the verified overlay pano it
 proposed 2 points where 4 ramps were visible, which shows up as its 150/196 false negatives.
 
+### Scope of the claim
+
+The headline — RampNet beats every off-the-shelf model tested — is real and wide, but it
+carries qualifiers that must travel with it: the challengers are **zero-shot**, run with a
+single **untuned prompt/query**, scored by **box-center** at a tight radius, against a
+**RampNet-anchored** ground truth (see Caveats). The honest one-liner is *"an in-domain model
+trained for curb ramps beats zero-shot general models — chat VLMs and open-vocab detectors
+alike — under a reasonable but untuned prompt,"* not *"purpose-built detection loses,"* which
+no experiment here tested (OWLv2 / Grounding DINO are general open-vocab models, not
+curb-ramp detectors). How much of the gap survives a tuned prompt (#45), a failure-artifact
+audit (#46), and a nadir/hood mask (#47) is exactly what those follow-ups measure.
+
 ### What the numbers say
 
 1. **RampNet still wins by a wide margin**, and nothing tested comes close on F1. The best
    challenger (Gemini-3.1-pro, F1 0.664) trails it by ~0.19; the best open-weight model
    (Molmo, F1 0.457) by ~0.40.
-2. **Purpose-built detectors did worse than chat models, not better.** OWLv2's best F1 over
-   the whole threshold sweep is **0.184** (thr 0.25: P 0.130 / R 0.310); Grounding DINO's is
-   **0.073**. Both are far below Gemini-3.6-flash's 0.634. The issue-#39 hypothesis — that
-   the chat VLMs' weakness was a *chat* problem — is refuted. Open-vocabulary detection with
-   a text query is simply not selective enough for an object that looks like a slightly
-   different patch of concrete.
+2. **Off-the-shelf open-vocab detectors did worse than chat models, not better.** OWLv2's
+   best F1 over the whole threshold sweep is **0.184** (thr 0.25: P 0.130 / R 0.310);
+   Grounding DINO's is **0.073**. Both are far below Gemini-3.6-flash's 0.634. So the
+   *chat-specific* version of the issue-#39 hypothesis — that the VLMs' weakness was a *chat*
+   problem an open-vocab *detector* would sidestep — does not hold: a text-queried open-vocab
+   detector is simply not selective enough for an object that looks like a slightly different
+   patch of concrete. Note the narrower scope, though: these are general open-vocab models
+   with an untuned query (#45), not detectors trained for curb ramps — the only purpose-built
+   model here is RampNet.
 3. **Capacity isn't the chat VLMs' problem either.** Qwen-32B moved to the *precise* end
    (P 0.760 / R 0.297) versus 8B's FP flood (P 0.323 / R 0.452) — the operating point moved,
    F1 barely did (0.427 vs 0.377).

--- a/rampnet/detection_eval.py
+++ b/rampnet/detection_eval.py
@@ -25,6 +25,11 @@ greedily matched to the GT points within a normalized radius (the pano value
 over panos whose missed-ramp check is confirmed (so un-scanned panos can't bias
 it), exactly as `validation.collect` gates recall.
 
+When every prediction carries a confidence — RampNet, and the open-vocabulary
+detectors (OWLv2 / Grounding DINO), but not the chat VLMs — `aggregate` also
+returns **AP and a PR curve** (via `rampnet.metrics`), so those models can be
+compared across their whole operating range instead of at one arbitrary point.
+
 Caveat: the GT was assembled during a RampNet review, so it is "RampNet-anchored"
 — a reviewer scanning fresh for another model might catch a few more ramps. The
 complete-scan attestation (`no_missed`) mitigates this; it is documented in
@@ -32,6 +37,7 @@ complete-scan attestation (`no_missed`) mitigates this; it is documented in
 """
 from collections import namedtuple
 
+from rampnet.metrics import calculate_ap_and_pr_curve
 from rampnet.validation import wilson_interval
 
 # Pano coordinate space and matching radius — identical to rampnet/metrics.py and
@@ -41,13 +47,17 @@ PANO_SCALE_Y = 512
 PANO_RADIUS_NORMALIZED = 0.022
 
 GroundTruth = namedtuple("GroundTruth", ["gt_points", "ignore_points", "fn_confirmed"])
-PanoScore = namedtuple("PanoScore", ["tp", "fp", "ignored", "n_gt", "fn_confirmed"])
+# details: one (confidence, is_true_positive) per *scored* prediction, in match
+# order (ignored predictions are excluded — they are neither). Feeds AP.
+PanoScore = namedtuple("PanoScore", ["tp", "fp", "ignored", "n_gt", "fn_confirmed", "details"],
+                       defaults=((),))
 ScoreReport = namedtuple("ScoreReport", [
     "precision", "recall", "f1",
     "precision_ci", "recall_ci",
     "tp", "fp", "fn", "ignored",
     "n_gt_recall", "n_panos", "n_recall_panos",
-])
+    "ap", "pr_curve",
+], defaults=(None, None))
 
 
 def radius_sq_for(radius_normalized=PANO_RADIUS_NORMALIZED, scale_x=PANO_SCALE_X):
@@ -142,6 +152,7 @@ def score_pano(pred_points, gt, radius_sq=None, scale_x=PANO_SCALE_X, scale_y=PA
 
     claimed = [False] * len(gt_pts)
     tp = fp = ignored = 0
+    details = []
     for p in preds:
         px_n, py_n = _xy(p)
         px, py = px_n * scale_x, py_n * scale_y
@@ -155,17 +166,19 @@ def score_pano(pred_points, gt, radius_sq=None, scale_x=PANO_SCALE_X, scale_y=PA
         if best_k >= 0:
             claimed[best_k] = True
             tp += 1
+            details.append((_confidence(p), True))
             continue
         in_ignore = any(
             (px - ix * scale_x) ** 2 + (py - iy * scale_y) ** 2 < radius_sq
             for ix, iy in ignore_pts)
         if in_ignore:
-            ignored += 1
+            ignored += 1        # neither TP nor FP, so it stays out of the PR curve too
         else:
             fp += 1
+            details.append((_confidence(p), False))
 
     return PanoScore(tp=tp, fp=fp, ignored=ignored, n_gt=len(gt_pts),
-                     fn_confirmed=gt.fn_confirmed)
+                     fn_confirmed=gt.fn_confirmed, details=details)
 
 
 def aggregate(pano_scores):
@@ -174,6 +187,15 @@ def aggregate(pano_scores):
     Precision uses detections from every pano; recall uses only panos whose
     missed-ramp check is confirmed (``fn_confirmed``), so panos that weren't
     fully scanned don't deflate recall. Returns a ScoreReport.
+
+    **AP** is filled in only when every scored prediction carries a confidence —
+    RampNet always, and the open-vocabulary detectors (OWLv2, Grounding DINO); chat
+    VLMs emit no calibrated score, so they get ``ap=None`` and an operating point
+    only. It is computed over the **recall-confirmed subset** alone, because AP
+    needs one consistent denominator for recall (``n_gt_recall``) and predictions
+    from unscanned panos have no GT to be measured against. That makes AP a
+    slightly different slice than the operating-point precision above it, which
+    counts every pano — the tradeoff is noted in docs/model_comparison.md.
     """
     tp_all = sum(s.tp for s in pano_scores)
     fp_all = sum(s.fp for s in pano_scores)
@@ -188,6 +210,12 @@ def aggregate(pano_scores):
     recall = tp_recall / n_gt_recall if n_gt_recall else 0.0
     f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
 
+    ap, pr_curve = None, None
+    details = [d for s in recall_scores for d in s.details]
+    if details and n_gt_recall and all(c is not None for c, _ in details):
+        ap, plot_recalls, plot_precisions, _, _ = calculate_ap_and_pr_curve(details, n_gt_recall)
+        pr_curve = (plot_recalls, plot_precisions)
+
     return ScoreReport(
         precision=precision,
         recall=recall,
@@ -201,4 +229,6 @@ def aggregate(pano_scores):
         n_gt_recall=n_gt_recall,
         n_panos=len(pano_scores),
         n_recall_panos=len(recall_scores),
+        ap=ap,
+        pr_curve=pr_curve,
     )

--- a/rampnet/detection_eval.py
+++ b/rampnet/detection_eval.py
@@ -117,7 +117,11 @@ def build_ground_truth(detections, det_verdicts, missed, no_missed):
     return GroundTruth(gt_points, ignore_points, fn_confirmed)
 
 
-def _confidence(point):
+def prediction_confidence(point):
+    """The confidence a prediction carries, or None (chat VLMs emit none).
+
+    Shared with the comparison CLI's re-scoring/sweep helpers so "does this
+    prediction carry a score" is decided one way everywhere."""
     if isinstance(point, dict):
         return point.get("confidence")
     return point[2] if len(point) > 2 else None
@@ -141,7 +145,7 @@ def score_pano(pred_points, gt, radius_sq=None, scale_x=PANO_SCALE_X, scale_y=PA
     gt_pts = gt.gt_points
     ignore_pts = gt.ignore_points
 
-    confs = [_confidence(p) for p in pred_points]
+    confs = [prediction_confidence(p) for p in pred_points]
     if any(c is not None for c in confs):
         order = sorted(range(len(pred_points)),
                        key=lambda i: confs[i] if confs[i] is not None else float("-inf"),
@@ -166,7 +170,7 @@ def score_pano(pred_points, gt, radius_sq=None, scale_x=PANO_SCALE_X, scale_y=PA
         if best_k >= 0:
             claimed[best_k] = True
             tp += 1
-            details.append((_confidence(p), True))
+            details.append((prediction_confidence(p), True))
             continue
         in_ignore = any(
             (px - ix * scale_x) ** 2 + (py - iy * scale_y) ** 2 < radius_sq
@@ -175,7 +179,7 @@ def score_pano(pred_points, gt, radius_sq=None, scale_x=PANO_SCALE_X, scale_y=PA
             ignored += 1        # neither TP nor FP, so it stays out of the PR curve too
         else:
             fp += 1
-            details.append((_confidence(p), False))
+            details.append((prediction_confidence(p), False))
 
     return PanoScore(tp=tp, fp=fp, ignored=ignored, n_gt=len(gt_pts),
                      fn_confirmed=gt.fn_confirmed, details=details)

--- a/requirements-vlm.txt
+++ b/requirements-vlm.txt
@@ -12,6 +12,23 @@ google-genai
 #   - transformers 4.57 is the first release with Qwen3-VL.
 #   - accelerate enables device_map="auto", needed to shard Qwen3-VL-32B-Instruct
 #     (~64 GB in bf16) across two GPUs; 8B fits one 48 GB card.
+#   - torchvision is required even though we never touch video: AutoProcessor for
+#     Qwen3-VL constructs a Qwen3VLVideoProcessor, which hard-fails without it.
+#     environment.yml already pulls it in, so this only bites a lean pip install.
 #   - qwen-vl-utils is NOT needed: Qwen3-VL's chat template takes PIL images directly.
 transformers>=4.57
 accelerate
+torchvision
+
+# OWLv2 / Grounding DINO (open-vocabulary detectors) need nothing beyond the
+# transformers + torchvision above — they are ~1-2 GB and ship in-library
+# (AutoModelForZeroShotObjectDetection), no remote code.
+#
+# Ai2 Molmo runs its own modeling/processing code from the Hub
+# (trust_remote_code=True), which imports einops:
+einops
+# NOTE for the Molmo leg only: the Molmo/Molmo2/MolmoPoint model cards pin
+# `transformers==4.57.1`, and their remote code is not guaranteed to load on the
+# 5.x that `transformers>=4.57` resolves to today. If Molmo fails to load, build it
+# a separate env at that pin rather than downgrading the env the other models use.
+# (`decord2` from the card is video-only; this harness only sends still views.)

--- a/requirements-vlm.txt
+++ b/requirements-vlm.txt
@@ -25,10 +25,14 @@ torchvision
 # (AutoModelForZeroShotObjectDetection), no remote code.
 #
 # Ai2 Molmo runs its own modeling/processing code from the Hub
-# (trust_remote_code=True), which imports einops:
+# (trust_remote_code=True), which imports einops and requests:
 einops
-# NOTE for the Molmo leg only: the Molmo/Molmo2/MolmoPoint model cards pin
-# `transformers==4.57.1`, and their remote code is not guaranteed to load on the
-# 5.x that `transformers>=4.57` resolves to today. If Molmo fails to load, build it
-# a separate env at that pin rather than downgrading the env the other models use.
+requests
+# WARNING for the Molmo leg: the `transformers==4.57.1` pin on the Molmo cards is
+# REAL, not cautionary. Confirmed 2026-07-23 on transformers 5.14.1:
+#   TypeError: Unexpected keyword argument image_use_col_tokens
+#   (processing_molmo2.py, from Molmo's own Hub code)
+# Build Molmo a SEPARATE env at that pin rather than downgrading the env the other
+# models use — the harness itself imports fine on 4.57.1, so only Molmo's
+# interpreter differs. See docs/model_comparison.md.
 # (`decord2` from the card is video-only; this harness only sends still views.)

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -9,8 +9,11 @@ a cross-check.
     python scripts/model_comparison/compare.py benchmark/richmond \
         --models rampnet,gemini:gemini-2.5-flash,gemini:gemini-3.6-flash
 
-Each --models token is a provider (rampnet/gemini/qwen) or provider:model_id to
-pin a variant, so several models from the same provider compare side by side.
+Each --models token is a provider (rampnet/gemini/qwen/owlv2/gdino/molmo) or
+provider:model_id to pin a variant, so several models from the same provider
+compare side by side. Detectors that emit calibrated scores (RampNet, OWLv2,
+Grounding DINO) additionally get AP, a PR curve (--pr-out) and a threshold sweep
+(--sweep); chat VLMs have no score to rank by, so they get one operating point.
 See docs/model_comparison.md.
 """
 import argparse
@@ -18,6 +21,7 @@ import hashlib
 import json
 import os
 import sys
+from collections import namedtuple
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -28,7 +32,9 @@ from rampnet.detection_eval import (  # noqa: E402
     build_ground_truth, score_pano, aggregate, radius_sq_for, PANO_RADIUS_NORMALIZED,
 )
 from rampnet.validation import collect, format_report  # noqa: E402
-from detectors import PanoSample, build_detector, parse_model_spec  # noqa: E402
+from detectors import (  # noqa: E402
+    GDINO_QUERY, OWLV2_QUERY, PanoSample, build_detector, parse_model_spec,
+)
 
 
 def load_dotenv(root):
@@ -131,11 +137,17 @@ def validate_bundle(records, verdicts):
         raise SystemExit(f"Bundle validation failed ({len(problems)} pano(s)):\n  {shown}{more}")
 
 
+# scored: [(pred_points, GroundTruth)] for every pano that was successfully
+# scored, kept so the threshold sweep and PR curves can re-score from memory
+# instead of re-running the detector.
+ModelRun = namedtuple("ModelRun", ["report", "failures", "scored"])
+
+
 def score_model(detector, records, verdicts, panos_dir, radius_sq, label, city, cache,
                 max_consecutive_failures=10):
     """Run one detector over every reviewed pano and aggregate the score.
 
-    Returns ``(report, failures)``. ``detector.prepare()`` runs before the pano loop
+    Returns a ``ModelRun``. ``detector.prepare()`` runs before the pano loop
     (outside the per-pano guard) so credential / dependency / not-wired errors
     propagate to the caller and skip the whole model — but it is skipped entirely
     when every pano is already cached, so a ``.model_cache`` copied back from a GPU
@@ -152,7 +164,7 @@ def score_model(detector, records, verdicts, panos_dir, radius_sq, label, city, 
         detector.prepare()
     else:
         print(f"[{label}] all {len(cached)} panos already cached; model load skipped")
-    pano_scores, failures, consecutive = [], [], 0
+    pano_scores, failures, consecutive, scored = [], [], 0, []
     for pid, entry in verdicts.items():
         rec = records[pid]
         gt = build_ground_truth(rec["detections"], entry["dets"], entry["missed"], entry["no_missed"])
@@ -177,8 +189,43 @@ def score_model(detector, records, verdicts, panos_dir, radius_sq, label, city, 
             consecutive = 0
             if key:
                 cache.put(key, preds)
+        scored.append((preds, gt))
         pano_scores.append(score_pano(preds, gt, radius_sq=radius_sq))
-    return aggregate(pano_scores), failures
+    return ModelRun(aggregate(pano_scores), failures, scored)
+
+
+def rescore(scored, radius_sq, min_confidence=0.0):
+    """Re-aggregate a finished run with predictions below ``min_confidence`` dropped.
+
+    Detections are cached with their scores, so every operating point of a
+    confidence-carrying detector is a free re-score — no second model run. A
+    prediction with no confidence (chat VLMs) is never dropped: there is nothing to
+    threshold on."""
+    return aggregate([
+        score_pano([p for p in preds if _conf_of(p) is None or _conf_of(p) >= min_confidence],
+                   gt, radius_sq=radius_sq)
+        for preds, gt in scored])
+
+
+def _conf_of(p):
+    return p[2] if len(p) > 2 else None
+
+
+def has_confidences(scored):
+    """True when every prediction in the run carries a score (so AP / a sweep mean
+    something). An empty run counts as no confidences."""
+    preds = [p for ps, _ in scored for p in ps]
+    return bool(preds) and all(_conf_of(p) is not None for p in preds)
+
+
+SWEEP_THRESHOLDS = (0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
+
+
+def sweep_rows(scored, radius_sq, thresholds=SWEEP_THRESHOLDS):
+    """(threshold, ScoreReport) for each threshold that still keeps a prediction."""
+    top = max((_conf_of(p) for ps, _ in scored for p in ps if _conf_of(p) is not None),
+              default=0.0)
+    return [(t, rescore(scored, radius_sq, t)) for t in thresholds if t <= top]
 
 
 def _pct(x):
@@ -189,14 +236,75 @@ def _ci(lo_hi):
     return f"({lo_hi[0]:.3f}-{lo_hi[1]:.3f})"
 
 
+def _ap(r):
+    # Blank for chat VLMs: no calibrated per-box score, so no curve to integrate.
+    return f"{r.ap:.3f}" if r.ap is not None else "  -  "
+
+
 def print_table(rows):
-    header = f"{'model':<22} {'P':>6} {'95% CI':>15} {'R':>6} {'95% CI':>15} {'F1':>6}   {'tp/fp/fn/ign':>16}"
+    # Wide enough for the longest HF id in play (google/owlv2-large-patch14-ensemble).
+    header = (f"{'model':<36} {'P':>6} {'95% CI':>15} {'R':>6} {'95% CI':>15} "
+              f"{'F1':>6} {'AP':>6}   {'tp/fp/fn/ign':>16}")
     print(header)
     print("-" * len(header))
     for name, r in rows:
         counts = f"{r.tp}/{r.fp}/{r.fn}/{r.ignored}"
-        print(f"{name:<22} {_pct(r.precision):>6} {_ci(r.precision_ci):>15} "
-              f"{_pct(r.recall):>6} {_ci(r.recall_ci):>15} {_pct(r.f1):>6}   {counts:>16}")
+        print(f"{name:<36} {_pct(r.precision):>6} {_ci(r.precision_ci):>15} "
+              f"{_pct(r.recall):>6} {_ci(r.recall_ci):>15} {_pct(r.f1):>6} {_ap(r):>6}   "
+              f"{counts:>16}")
+
+
+def print_sweep(label, rows):
+    """Threshold sweep for one model: what tuning the score cutoff buys.
+
+    This is the point of a real detector over a chat VLM — the recall-first
+    direction needs a knob, and a model pinned at one operating point has none.
+    The best-F1 row is flagged; it is chosen *on the benchmark itself*, so it is an
+    optimistic, tune-on-test number and must be quoted as such."""
+    if not rows:
+        return
+    best = max(range(len(rows)), key=lambda i: rows[i][1].f1)
+    print(f"\n[{label}] threshold sweep (re-scored from cached detections)")
+    print(f"  {'thr':>5} {'P':>6} {'R':>6} {'F1':>6}   {'tp/fp/fn':>14}")
+    for i, (t, r) in enumerate(rows):
+        mark = " <- best F1" if i == best else ""
+        print(f"  {t:>5.2f} {_pct(r.precision):>6} {_pct(r.recall):>6} {_pct(r.f1):>6}   "
+              f"{f'{r.tp}/{r.fp}/{r.fn}':>14}{mark}")
+
+
+def write_pr_curves(out_dir, curves):
+    """Write each model's PR curve to JSON, and a combined PNG if matplotlib is
+    around (it is not a harness dependency). ``curves``: [(label, ScoreReport)]."""
+    os.makedirs(out_dir, exist_ok=True)
+    for label, r in curves:
+        recalls, precisions = r.pr_curve
+        safe = label.replace("/", "_")
+        with open(os.path.join(out_dir, f"pr_{safe}.json"), "w", encoding="utf-8") as f:
+            json.dump({"model": label, "ap": r.ap, "n_gt": r.n_gt_recall,
+                       "recalls": recalls, "precisions": precisions}, f, indent=2)
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print(f"PR curves written to {out_dir} (JSON only; matplotlib not installed)")
+        return
+    plt.figure(figsize=(7, 6))
+    for label, r in curves:
+        recalls, precisions = r.pr_curve
+        plt.plot(recalls, precisions, marker=".", markersize=3,
+                 label=f"{label} (AP {r.ap:.3f})")
+    plt.xlabel("Recall")
+    plt.ylabel("Precision")
+    plt.title("Curb-ramp detection PR curves")
+    plt.xlim(0, 1)
+    plt.ylim(0, 1.05)
+    plt.grid(alpha=0.3)
+    plt.legend(loc="lower left", fontsize=8)
+    path = os.path.join(out_dir, "pr_curves.png")
+    plt.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"PR curves written to {out_dir} (JSON + {os.path.basename(path)})")
 
 
 def main():
@@ -208,21 +316,46 @@ def main():
     ap = argparse.ArgumentParser(description="Compare curb-ramp detectors on a benchmark bundle.")
     ap.add_argument("bundle", help="Bundle dir (e.g. benchmark/richmond) with records.jsonl + verdicts.json.")
     ap.add_argument("--models", default="rampnet",
-                    help="Comma-separated detectors. Each is a provider (rampnet/gemini/qwen, "
-                         "using its default model) or provider:model_id to pin a variant, e.g. "
-                         "'rampnet,gemini:gemini-2.5-flash,gemini:gemini-3.6-flash'.")
+                    help="Comma-separated detectors. Each is a provider (rampnet/gemini/qwen/"
+                         "owlv2/gdino/molmo, using its default model) or provider:model_id to "
+                         "pin a variant, e.g. 'rampnet,gemini:gemini-2.5-flash,owlv2'.")
     ap.add_argument("--gemini-model", default="gemini-3.6-flash")
     ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL-8B-Instruct")
     ap.add_argument("--qwen-coord-space", choices=["auto", "norm1000", "pixels"], default="auto",
                     help="Box convention the Qwen checkpoint emits: 'norm1000' (Qwen3-VL, "
                          "0-1000) or 'pixels' (Qwen2/2.5-VL, absolute). 'auto' infers it "
                          "from the model id.")
+    ap.add_argument("--owlv2-model", default="google/owlv2-large-patch14-ensemble")
+    ap.add_argument("--gdino-model", default="IDEA-Research/grounding-dino-base")
+    ap.add_argument("--molmo-model", default="allenai/Molmo2-8B")
+    ap.add_argument("--owlv2-query", help=f"OWLv2 text query (default {OWLV2_QUERY!r}).")
+    ap.add_argument("--gdino-query", help=f"Grounding DINO category text (default {GDINO_QUERY!r}); "
+                                          "lowercase, period-terminated.")
+    ap.add_argument("--gdino-text-threshold", type=float,
+                    help="Grounding DINO token-alignment threshold (default 0.2).")
+    ap.add_argument("--score-threshold", type=float,
+                    help="Score floor for the open-vocabulary detectors (owlv2/gdino), default "
+                         "0.05. This is a CACHE floor, not the operating point: it is part of "
+                         "the detector signature, so lowering it re-runs the model, while every "
+                         "higher operating point is a free re-score (--op-threshold, --sweep).")
+    ap.add_argument("--molmo-coord-scale", choices=["auto", "100", "1000"], default="auto",
+                    help="Divisor for Molmo point coordinates: Molmo 1 emits percentages "
+                         "(100), Molmo 2 emits 0-1000. 'auto' infers it from the tag syntax.")
     ap.add_argument("--tiling", choices=["perspective", "none"], default="perspective",
                     help="VLM input: 'perspective' reprojects the pano into rectilinear "
                          "views (fair); 'none' uses one whole-pano call (lower bound). "
                          "No effect on rampnet.")
     ap.add_argument("--radius", type=float, default=PANO_RADIUS_NORMALIZED,
                     help=f"Normalized match radius (default {PANO_RADIUS_NORMALIZED}).")
+    ap.add_argument("--op-threshold", type=float, default=0.0,
+                    help="Drop predictions scoring below this before the main table, so the "
+                         "reported operating point is comparable across models. Free (re-scores "
+                         "the cache); models without confidences are unaffected.")
+    ap.add_argument("--sweep", action="store_true",
+                    help="Also print a threshold sweep for every model whose detections carry "
+                         "confidences (RampNet, owlv2, gdino) — the tunable operating range.")
+    ap.add_argument("--pr-out", help="Directory to write PR curves to (JSON per model, plus a "
+                                     "combined PNG when matplotlib is installed).")
     ap.add_argument("--limit", type=int,
                     help="Score at most N panos (smoke test / cost control for VLM runs).")
     ap.add_argument("--cache-dir", default=str(REPO_ROOT / ".model_cache"),
@@ -245,7 +378,7 @@ def main():
           f"match radius {args.radius}  ground truth: reviewer-confirmed ramps + missed marks")
     print(f"Detection cache: {'off' if args.no_cache else args.cache_dir}\n")
 
-    rows = []
+    rows, runs = [], []
     seen = {}
     for provider, model_id in specs:
         label, detector = build_detector(provider, model_id, records, args)
@@ -256,24 +389,54 @@ def main():
         else:
             seen[label] = 1
         try:
-            report, failures = score_model(
+            run = score_model(
                 detector, records, verdicts, panos_dir, radius_sq, label, city, cache)
-        except (NotImplementedError, ImportError, RuntimeError) as e:
-            # Not-wired detector, missing client lib, or missing credentials: skip
-            # the whole model with a clear note rather than crashing the run.
-            print(f"[{label}] not runnable: {e}\n")
+        except Exception as e:
+            # Missing client lib, missing credentials, a checkpoint whose remote
+            # code won't load on this transformers version: skip the whole model
+            # with a clear note rather than crashing a multi-model cluster run that
+            # has already paid for the models before it. Per-pano faults are
+            # isolated inside score_model; data-integrity problems are caught by
+            # validate_bundle before any of this. The type is printed so a genuine
+            # bug here is still diagnosable rather than silently "not runnable".
+            print(f"[{label}] not runnable: {type(e).__name__}: {e}\n")
             continue
+        report = (rescore(run.scored, radius_sq, args.op_threshold)
+                  if args.op_threshold > 0 else run.report)
         rows.append((label, report))
-        if failures:
-            print(f"[{label}] {len(failures)} pano failure(s) isolated (excluded from the score):")
-            for pid, msg in failures[:5]:
+        runs.append((label, run))
+        if run.failures:
+            print(f"[{label}] {len(run.failures)} pano failure(s) isolated "
+                  "(excluded from the score):")
+            for pid, msg in run.failures[:5]:
                 print(f"    {pid}: {msg}")
-            if len(failures) > 5:
-                print(f"    ... and {len(failures) - 5} more")
+            if len(run.failures) > 5:
+                print(f"    ... and {len(run.failures) - 5} more")
             print()
 
     if rows:
+        if args.op_threshold > 0:
+            print(f"Operating point: predictions with confidence < {args.op_threshold} dropped "
+                  "(models without confidences are unaffected).")
         print_table(rows)
+        # AP is over the recall-confirmed panos only (one consistent GT denominator);
+        # the P/R columns count every pano. See rampnet/detection_eval.aggregate.
+        if any(r.ap is not None for _, r in rows):
+            print("AP: all-point interpolated, over the recall-confirmed panos; "
+                  "'-' = no calibrated per-box score.")
+
+    if args.sweep:
+        for label, run in runs:
+            if has_confidences(run.scored):
+                print_sweep(label, sweep_rows(run.scored, radius_sq))
+        print()
+
+    if args.pr_out:
+        curves = [(label, r) for label, r in rows if r.pr_curve]
+        if curves:
+            write_pr_curves(args.pr_out, curves)
+        else:
+            print("No model produced a PR curve (needs per-detection confidences).")
 
     # Cross-check: RampNet's own verdict-based P/R (the published definition).
     confs_by_pid = {pid: [d["confidence"] for d in records[pid]["detections"]] for pid in verdicts}

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -29,7 +29,8 @@ sys.path.insert(0, str(REPO_ROOT))          # rampnet.* (editable install fallba
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # local detectors.py
 
 from rampnet.detection_eval import (  # noqa: E402
-    build_ground_truth, score_pano, aggregate, radius_sq_for, PANO_RADIUS_NORMALIZED,
+    build_ground_truth, score_pano, aggregate, prediction_confidence, radius_sq_for,
+    PANO_RADIUS_NORMALIZED,
 )
 from rampnet.validation import collect, format_report  # noqa: E402
 from detectors import (  # noqa: E402
@@ -202,30 +203,35 @@ def rescore(scored, radius_sq, min_confidence=0.0):
     prediction with no confidence (chat VLMs) is never dropped: there is nothing to
     threshold on."""
     return aggregate([
-        score_pano([p for p in preds if _conf_of(p) is None or _conf_of(p) >= min_confidence],
+        score_pano([p for p in preds
+                    if prediction_confidence(p) is None
+                    or prediction_confidence(p) >= min_confidence],
                    gt, radius_sq=radius_sq)
         for preds, gt in scored])
-
-
-def _conf_of(p):
-    return p[2] if len(p) > 2 else None
 
 
 def has_confidences(scored):
     """True when every prediction in the run carries a score (so AP / a sweep mean
     something). An empty run counts as no confidences."""
     preds = [p for ps, _ in scored for p in ps]
-    return bool(preds) and all(_conf_of(p) is not None for p in preds)
+    return bool(preds) and all(prediction_confidence(p) is not None for p in preds)
 
 
 SWEEP_THRESHOLDS = (0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
 
 
-def sweep_rows(scored, radius_sq, thresholds=SWEEP_THRESHOLDS):
-    """(threshold, ScoreReport) for each threshold that still keeps a prediction."""
-    top = max((_conf_of(p) for ps, _ in scored for p in ps if _conf_of(p) is not None),
+def sweep_rows(scored, radius_sq, thresholds=SWEEP_THRESHOLDS, floor=None):
+    """(threshold, ScoreReport) for each threshold that still keeps a prediction.
+
+    ``floor`` is the detector's cache floor (--score-threshold): the cache holds
+    no detections below it, so a sweep row under the floor would silently repeat
+    the floor row while reading as a real measurement. Those rows are dropped
+    (with the default floor, 0.05, nothing is — it equals the lowest threshold)."""
+    top = max((prediction_confidence(p) for ps, _ in scored for p in ps
+               if prediction_confidence(p) is not None),
               default=0.0)
-    return [(t, rescore(scored, radius_sq, t)) for t in thresholds if t <= top]
+    return [(t, rescore(scored, radius_sq, t)) for t in thresholds
+            if t <= top and (floor is None or t >= floor)]
 
 
 def _pct(x):
@@ -262,6 +268,10 @@ def print_sweep(label, rows):
     The best-F1 row is flagged; it is chosen *on the benchmark itself*, so it is an
     optimistic, tune-on-test number and must be quoted as such."""
     if not rows:
+        # has_confidences was True, so the model did detect — every score just
+        # sits below the sweepable range. Say so instead of printing nothing.
+        print(f"\n[{label}] threshold sweep: no detections at or above the lowest "
+              "sweepable threshold; nothing to sweep")
         return
     best = max(range(len(rows)), key=lambda i: rows[i][1].f1)
     print(f"\n[{label}] threshold sweep (re-scored from cached detections)")
@@ -404,7 +414,9 @@ def main():
         report = (rescore(run.scored, radius_sq, args.op_threshold)
                   if args.op_threshold > 0 else run.report)
         rows.append((label, report))
-        runs.append((label, run))
+        # The detector's cache floor travels with the run so the sweep can drop
+        # thresholds the cache has no detections for (phantom rows otherwise).
+        runs.append((label, run, getattr(detector, "score_threshold", None)))
         if run.failures:
             print(f"[{label}] {len(run.failures)} pano failure(s) isolated "
                   "(excluded from the score):")
@@ -426,9 +438,9 @@ def main():
                   "'-' = no calibrated per-box score.")
 
     if args.sweep:
-        for label, run in runs:
+        for label, run, floor in runs:
             if has_confidences(run.scored):
-                print_sweep(label, sweep_rows(run.scored, radius_sq))
+                print_sweep(label, sweep_rows(run.scored, radius_sq, floor=floor))
         print()
 
     if args.pr_out:

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -12,10 +12,17 @@ model-agnostic ground truth (see ``rampnet/detection_eval.py``).
 - ``QwenDetector`` is **live** (open weights via transformers; intended for a GPU
   cluster — see the Hyak runbook in ``docs/model_comparison.md``). Same tiled path
   as Gemini; the model is loaded once per run in ``_ensure_ready``.
+- ``OwlV2Detector`` / ``GroundingDinoDetector`` are **live** open-vocabulary
+  *detectors* (not chat models): text query in, boxes **with calibrated scores**
+  out. That confidence is carried through the whole harness, which is what makes
+  AP / PR curves and threshold sweeps possible for a non-RampNet model.
+- ``MolmoDetector`` is **live** and emits **points**, not boxes — RampNet's native
+  output format, so it avoids the box->center reduction every other VLM needs.
 """
 import importlib.util
 import json
 import os
+import re
 from collections import namedtuple
 
 # A pano to run a detector on. image_path points at the native-res JPEG in the
@@ -181,14 +188,184 @@ def qwen_boxes_to_points(items, img_w, img_h, coord_space="norm1000"):
     return points
 
 
+# --- open-vocabulary detector parsing (pure, unit-tested) -------------------
+
+def zero_shot_results_to_boxes(result, threshold=None):
+    """Normalize a transformers ``post_process_grounded_object_detection`` result
+    (one image) into ``[{"box": [x1, y1, x2, y2], "score": float, "label": str}]``.
+
+    The result's values are torch tensors in a live run and plain lists in tests,
+    so everything goes through ``_as_list``. Boxes are absolute pixels in the frame
+    named by the ``target_sizes`` that was passed (see ``owlv2_target_size``)."""
+    boxes = _as_list(result.get("boxes"))
+    scores = _as_list(result.get("scores"))
+    labels = result.get("text_labels")
+    if labels is None:
+        labels = result.get("labels")
+    labels = _as_list(labels)
+    items = []
+    for i, box in enumerate(boxes):
+        box = [float(v) for v in _as_list(box)]
+        if len(box) != 4:
+            continue
+        score = float(scores[i]) if i < len(scores) else None
+        if threshold is not None and score is not None and score < threshold:
+            continue
+        label = labels[i] if i < len(labels) else ""
+        items.append({"box": box, "score": score, "label": str(label)})
+    return items
+
+
+def _as_list(v):
+    """Tensor / ndarray / sequence -> plain list (empty for None)."""
+    if v is None:
+        return []
+    if hasattr(v, "tolist"):
+        v = v.tolist()
+    return list(v) if isinstance(v, (list, tuple)) else [v]
+
+
+def owlv2_target_size(img_w, img_h):
+    """The frame OWLv2's boxes live in: ``(side, side)`` with ``side = max(w, h)``.
+
+    OWLv2's image processor **pads the image to a square before resizing**, adding
+    the padding at the bottom and right, so the model's boxes are relative to that
+    square and the original image sits in its top-left corner. Dividing by the
+    *original* width/height (``pixel_boxes_to_points``) is therefore what recovers
+    normalized in-image coordinates — and a box may legitimately land outside them,
+    in the pad.
+
+    Current transformers already scales OWLv2 boxes by ``max(h, w)`` on both axes
+    inside ``_scale_boxes`` ("for owlv2 image is padded to max size"), so passing
+    the square and passing the image's own ``(h, w)`` are equivalent there —
+    verified empirically on a 2:1 crop, where both put the top box at y 0.815 (true
+    position 0.817). Passing the square is still what this returns: it is also
+    correct under the older per-axis scaling the model card's workaround was
+    written for, and it states the frame the caller is normalizing against instead
+    of relying on a library internal. Square views (the default rig) are
+    unaffected either way; whole-pano mode (2:1) is the only place it could bite."""
+    side = max(int(img_w), int(img_h))
+    return (side, side)
+
+
+def pixel_boxes_to_points(items, img_w, img_h):
+    """Reduce ``{"box": [x1, y1, x2, y2] (pixels), "score": s}`` to normalized [0,1]
+    center points ``(cx, cy, score)``.
+
+    Unlike the chat VLMs, the score is a real per-box confidence and is **carried
+    through** — it is what lets ``score_pano`` rank predictions and the harness
+    report AP / PR curves. Centers outside the image are dropped: OWLv2 can place a
+    box in the padded region, which is not part of the picture."""
+    points = []
+    for it in items:
+        x1, y1, x2, y2 = it["box"]
+        cx = (x1 + x2) / 2.0 / float(img_w)
+        cy = (y1 + y2) / 2.0 / float(img_h)
+        if 0.0 <= cx <= 1.0 and 0.0 <= cy <= 1.0:
+            points.append((cx, cy, it.get("score")))
+    return points
+
+
+# --- Molmo point parsing (pure, unit-tested) --------------------------------
+
+# Molmo emits points as XML-ish tags, and the two generations disagree on both the
+# tag shape and the coordinate scale:
+#   Molmo 1:  <point x="35.4" y="61.2" alt="...">...</point>
+#             <points x1="10.5" y1="20.0" x2="30.1" y2="40.2" ...>...</points>
+#             -> coordinates are PERCENTAGES of the image (0-100).
+#   Molmo 2:  <points coords="0 354 612; 1 700 480"/>  (triplets: object_id x y)
+#             -> coordinates are scaled by 1000, per the model card's own regex.
+# The two are distinguishable by syntax (a `coords` attribute vs `x`/`y` attributes),
+# which is why the scale can be inferred here — unlike Qwen's two box conventions,
+# which were syntactically identical and had to be chosen by model id.
+_MOLMO_TAG_RE = re.compile(r"<(point|points)\b([^>]*)>", re.IGNORECASE)
+_MOLMO_ATTR_RE = re.compile(r'([A-Za-z_]\w*)\s*=\s*"([^"]*)"')
+_MOLMO_XY_RE = re.compile(r"^([xy])(\d*)$")
+_MOLMO_TRIPLE_RE = re.compile(r"([0-9]+) ([0-9.]+) ([0-9.]+)")
+
+MOLMO_ATTR_SCALE = 100.0    # Molmo 1: percent of the image
+MOLMO_COORDS_SCALE = 1000.0  # Molmo 2: the card's "coordinates are scaled by 1000"
+
+
+def molmo_points_from_text(text, coord_scale=None):
+    """Parse a Molmo completion into ``[{"point": [x, y], "label": str}]`` with
+    **normalized [0,1]** coordinates.
+
+    ``coord_scale=None`` (default) infers the divisor from the tag syntax, as
+    documented above; pass 100.0 / 1000.0 to force one. Points outside [0,1] after
+    scaling are dropped — the reference implementation on the model card does the
+    same, and it makes a wrong scale show up as "almost nothing detected" instead
+    of a silent systematic offset."""
+    if not text:
+        return []
+    items = []
+    for tag, attr_text in _MOLMO_TAG_RE.findall(text):
+        attrs = dict(_MOLMO_ATTR_RE.findall(attr_text))
+        label = attrs.get("alt", "")
+        if "coords" in attrs:                       # Molmo 2: "<id> <x> <y>" triplets
+            scale = coord_scale or MOLMO_COORDS_SCALE
+            pairs = [(m.group(2), m.group(3)) for m in _MOLMO_TRIPLE_RE.finditer(attrs["coords"])]
+        else:                                       # Molmo 1: x/y (or x1/y1, x2/y2 ...)
+            scale = coord_scale or MOLMO_ATTR_SCALE
+            xs, ys = {}, {}
+            for key, val in attrs.items():
+                m = _MOLMO_XY_RE.match(key)
+                if m:
+                    (xs if m.group(1) == "x" else ys)[m.group(2)] = val
+            # Suffixes are "", "1", "2", ...; sort numerically so a 10+-point tag
+            # doesn't come back as 1, 10, 2 (order is cosmetic — pairing is by key).
+            order = sorted(xs, key=lambda k: (len(k), k))
+            pairs = [(xs[k], ys[k]) for k in order if k in ys]
+        for xs_, ys_ in pairs:
+            try:
+                x, y = float(xs_) / scale, float(ys_) / scale
+            except ValueError:
+                continue
+            if 0.0 <= x <= 1.0 and 0.0 <= y <= 1.0:
+                items.append({"point": [x, y], "label": label})
+    return items
+
+
+def molmo_token_points_to_items(points, img_w, img_h):
+    """MolmoPoint's decoded points -> the same ``{"point": [x, y]}`` items.
+
+    ``model.extract_image_points`` returns rows whose **last two** values are pixel
+    coordinates in the input image; the leading ids are documented inconsistently
+    on the model card (``[object_id, image_num, x, y]`` in the code comment,
+    ``(image_id, object_id, x, y)`` in the prose), so only the tail is read."""
+    items = []
+    for row in points or []:
+        row = _as_list(row)
+        if len(row) < 2:
+            continue
+        try:
+            x, y = float(row[-2]) / float(img_w), float(row[-1]) / float(img_h)
+        except (TypeError, ValueError):
+            continue
+        if 0.0 <= x <= 1.0 and 0.0 <= y <= 1.0:
+            items.append({"point": [x, y], "label": ""})
+    return items
+
+
+def points_to_center_points(items):
+    """Molmo point items -> ``(x, y, None)`` triples. Molmo carries no per-point
+    score, so these models get an operating point but no PR curve."""
+    return [(it["point"][0], it["point"][1], None) for it in items]
+
+
 # --- VLM detectors ----------------------------------------------------------
 
+# The one definition of the target class, shared verbatim by every prompted model so
+# they are asked for the same thing. Changing it re-bills every cached detection.
+CURB_RAMP_DEFINITION = (
+    "A curb ramp (curb cut) is the short sloped ramp cut into a sidewalk curb at a street "
+    "corner or crossing that lets a wheelchair or stroller roll from sidewalk to street."
+)
+
 DETECTION_PROMPT = (
-    "Detect every curb ramp in this street-level image. A curb ramp (curb cut) is the "
-    "short sloped ramp cut into a sidewalk curb at a street corner or crossing that lets "
-    "a wheelchair or stroller roll from sidewalk to street. Return one tight bounding box "
-    "per curb ramp. Do not box driveways, stairs, or crosswalk paint. If there are no curb "
-    "ramps, return an empty list."
+    "Detect every curb ramp in this street-level image. " + CURB_RAMP_DEFINITION +
+    " Return one tight bounding box per curb ramp. Do not box driveways, stairs, or "
+    "crosswalk paint. If there are no curb ramps, return an empty list."
 )
 
 # Gemini gets its output shape from a response_schema; an open model has to be
@@ -198,6 +375,20 @@ QWEN_JSON_INSTRUCTION = (
     ' Respond with JSON only: a list of {"bbox_2d": [x1, y1, x2, y2], "label": "curb ramp"}.'
 )
 QWEN_PROMPT = DETECTION_PROMPT + QWEN_JSON_INSTRUCTION
+
+# Open-vocabulary detectors take a text *query*, not an instruction. They are not
+# chat models: OWLv2 is CLIP-based and responds to a "a photo of a ..." template,
+# Grounding DINO expects lowercase, period-terminated category text. The paragraph
+# above would be truncated by their text encoders, so the class name is the prompt.
+OWLV2_QUERY = "a photo of a curb ramp"
+GDINO_QUERY = "curb ramp."
+
+# Molmo points instead of boxing, so the same definition gets a pointing verb.
+MOLMO_PROMPT = (
+    "Point to every curb ramp in this street-level image. " + CURB_RAMP_DEFINITION +
+    " Put one point at the center of each curb ramp. Do not point at driveways, stairs, "
+    "or crosswalk paint. If there are no curb ramps, say so."
+)
 
 
 class _VLMDetector:
@@ -445,13 +636,243 @@ class QwenDetector(_VLMDetector):
         return sig
 
 
+class _ZeroShotDetector(_VLMDetector):
+    """Open-vocabulary *detector* (OWLv2, Grounding DINO) via transformers.
+
+    The important difference from the chat VLMs: these are trained to detect, and
+    every box carries a **calibrated score**. The harness threads that score all the
+    way through (``pixel_boxes_to_points`` -> ``dedup_points`` -> ``score_pano``),
+    so these models get AP, a PR curve, and a threshold sweep — the tunable
+    operating range that a chat VLM pinned at one point cannot offer.
+
+    ``score_threshold`` is a **cache floor**, not the operating point: detections are
+    computed once down to a low score and every higher threshold is then a free
+    re-score of the cache. Lowering it invalidates the cache (it is in the
+    signature); raising the *reported* threshold does not (``--op-threshold``)."""
+
+    name = "zeroshot"
+    query = "object"
+    score_threshold = 0.05
+    max_edge = 1536       # whole-pano mode only; tiled views render at 1024
+
+    def __init__(self, model_id, query=None, score_threshold=None, max_edge=None,
+                 tile=True, views=None):
+        super().__init__(model_id, max_edge, tile=tile, views=views)
+        self.query = query or self.query
+        # The text query *is* the prompt for these models, so the base signature's
+        # "prompt" key keys the cache on it.
+        self.prompt = self.query
+        if score_threshold is not None:
+            self.score_threshold = float(score_threshold)
+        self._model = None
+        self._processor = None
+        self._device = "cpu"
+
+    def _ensure_ready(self):
+        if self._model is not None:
+            return
+        try:
+            import torch
+            from transformers import AutoModelForZeroShotObjectDetection, AutoProcessor
+        except ImportError as e:
+            raise ImportError(
+                f"{type(self).__name__} needs `torch` and `transformers` "
+                "(pip install -r requirements-vlm.txt)") from e
+        self._processor = AutoProcessor.from_pretrained(self.model_id)
+        model = AutoModelForZeroShotObjectDetection.from_pretrained(self.model_id)
+        self._device = "cuda" if torch.cuda.is_available() else "cpu"
+        self._model = model.to(self._device).eval()
+
+    def _raw_detect(self, image):
+        import torch
+        inputs = self._processor(images=image, text=self._text_input(),
+                                 return_tensors="pt").to(self._device)
+        with torch.inference_mode():
+            outputs = self._model(**inputs)
+        results = self._post_process(outputs, inputs, image)
+        return zero_shot_results_to_boxes(results[0])
+
+    def _parse(self, raw, img_w, img_h):
+        return pixel_boxes_to_points(raw, img_w, img_h)
+
+    def _text_input(self):
+        raise NotImplementedError
+
+    def _post_process(self, outputs, inputs, image):
+        raise NotImplementedError
+
+    def _post_process_fn(self):
+        """``post_process_grounded_object_detection`` is the current name; older
+        transformers only had ``post_process_object_detection`` for OWLv2."""
+        fn = getattr(self._processor, "post_process_grounded_object_detection", None)
+        return fn or self._processor.post_process_object_detection
+
+    def signature(self):
+        sig = super().signature()
+        sig.update({"query": self.query, "score_threshold": self.score_threshold})
+        return sig
+
+
+class OwlV2Detector(_ZeroShotDetector):
+    """OWLv2 (``google/owlv2-large-patch14-ensemble``) — text-prompted detection."""
+
+    name = "owlv2"
+    query = OWLV2_QUERY
+
+    def __init__(self, model_id="google/owlv2-large-patch14-ensemble", **kw):
+        super().__init__(model_id, **kw)
+
+    def _text_input(self):
+        return [[self.query]]           # batch of 1 image, 1 query
+
+    def _post_process(self, outputs, inputs, image):
+        # target_sizes must be the PADDED SQUARE, not the image — see owlv2_target_size.
+        return self._post_process_fn()(
+            outputs=outputs, threshold=self.score_threshold,
+            target_sizes=[owlv2_target_size(image.width, image.height)])
+
+
+class GroundingDinoDetector(_ZeroShotDetector):
+    """Grounding DINO (``IDEA-Research/grounding-dino-base``).
+
+    ``text_threshold`` gates how strongly a box must align with the query tokens;
+    ``score_threshold`` gates box confidence. Both are in the signature."""
+
+    name = "gdino"
+    query = GDINO_QUERY
+    text_threshold = 0.2
+
+    def __init__(self, model_id="IDEA-Research/grounding-dino-base", text_threshold=None, **kw):
+        super().__init__(model_id, **kw)
+        if text_threshold is not None:
+            self.text_threshold = float(text_threshold)
+
+    def _text_input(self):
+        return self.query               # "a. b." category text, lowercase
+
+    def _post_process(self, outputs, inputs, image):
+        # Grounding DINO does not pad to square, so the image's own (h, w) is right.
+        return self._post_process_fn()(
+            outputs=outputs, input_ids=inputs["input_ids"],
+            threshold=self.score_threshold, text_threshold=self.text_threshold,
+            target_sizes=[(image.height, image.width)])
+
+    def signature(self):
+        sig = super().signature()
+        sig["text_threshold"] = self.text_threshold
+        return sig
+
+
+def infer_molmo_mode(model_id):
+    """Which decoding path a Molmo checkpoint needs.
+
+    ``MolmoPoint`` emits points as **special tokens** that only the model can decode
+    (``extract_image_points``, with metadata from the processor); every other Molmo
+    writes them as XML in plain text. Unknown ids get the text path."""
+    return "point_tokens" if "molmopoint" in (model_id or "").lower() else "xml"
+
+
+class MolmoDetector(_VLMDetector):
+    """Ai2 Molmo — the one model here whose native output is **points**, not boxes.
+
+    Every other VLM in this harness is scored by the center of a box it drew, a
+    documented reduction (``docs/model_comparison.md``). Molmo removes it: it points
+    where RampNet points, so the comparison is like-for-like. There is no per-point
+    score, so Molmo gets an operating point but no PR curve.
+
+    8B in bf16 is ~16 GB — a cluster model, like Qwen (see the Hyak runbook)."""
+
+    name = "molmo"
+    prompt = MOLMO_PROMPT
+    max_edge = 2048       # whole-pano mode only; tiled views render at 1024
+
+    def __init__(self, model_id="allenai/Molmo2-8B", max_edge=None, tile=True,
+                 coord_scale=None, mode=None, max_new_tokens=512):
+        super().__init__(model_id, max_edge, tile=tile)
+        self.coord_scale = float(coord_scale) if coord_scale else None
+        self.mode = mode or infer_molmo_mode(model_id)
+        self.max_new_tokens = max_new_tokens
+        self._model = None
+        self._processor = None
+
+    def _ensure_ready(self):
+        if self._model is not None:
+            return
+        try:
+            import torch  # noqa: F401  (imported for the same clear error as Qwen)
+            from transformers import AutoModelForImageTextToText, AutoProcessor
+        except ImportError as e:
+            raise ImportError(
+                "MolmoDetector needs `torch` and `transformers` "
+                "(pip install -r requirements-vlm.txt)") from e
+        # Molmo ships custom modeling/processing code on the Hub; both classes need
+        # trust_remote_code. padding_side="left" is what the MolmoPoint card uses.
+        self._processor = AutoProcessor.from_pretrained(
+            self.model_id, trust_remote_code=True, padding_side="left")
+        kw = dict(trust_remote_code=True, dtype="auto")
+        if importlib.util.find_spec("accelerate") is not None:
+            kw["device_map"] = "auto"
+        model = AutoModelForImageTextToText.from_pretrained(self.model_id, **kw)
+        if "device_map" not in kw:
+            import torch
+            model = model.to("cuda" if torch.cuda.is_available() else "cpu")
+        self._model = model.eval()
+
+    def _messages(self, image):
+        return [{"role": "user", "content": [
+            {"type": "text", "text": self.prompt},
+            {"type": "image", "image": image},
+        ]}]
+
+    def _raw_detect(self, image):
+        import torch
+        want_meta = self.mode == "point_tokens"
+        template_kw = {"return_pointing_metadata": True} if want_meta else {}
+        inputs = self._processor.apply_chat_template(
+            self._messages(image), tokenize=True, add_generation_prompt=True,
+            return_dict=True, return_tensors="pt", **template_kw)
+        metadata = inputs.pop("metadata", None) if want_meta else None
+        device = getattr(self._model, "device", "cpu")
+        inputs = {k: (v.to(device) if hasattr(v, "to") else v) for k, v in inputs.items()}
+
+        gen_kw = dict(max_new_tokens=self.max_new_tokens, do_sample=False)
+        if want_meta:
+            # Constrains decoding so point tokens can only be emitted validly.
+            gen_kw["logits_processor"] = self._model.build_logit_processor_from_inputs(inputs)
+        with torch.inference_mode():
+            out = self._model.generate(**inputs, **gen_kw)
+        completion = out[:, inputs["input_ids"].shape[1]:]
+
+        if not want_meta:
+            text = self._processor.tokenizer.decode(completion[0], skip_special_tokens=True)
+            return molmo_points_from_text(text, coord_scale=self.coord_scale)
+        # Point tokens survive only with skip_special_tokens=False.
+        text = self._processor.post_process_image_text_to_text(
+            completion, skip_special_tokens=False, clean_up_tokenization_spaces=False)[0]
+        points = self._model.extract_image_points(
+            text, metadata["token_pooling"], metadata["subpatch_mapping"],
+            metadata["image_sizes"])
+        return molmo_token_points_to_items(points, image.width, image.height)
+
+    def _parse(self, raw, img_w, img_h):
+        # Both modes already produce normalized in-view points.
+        return points_to_center_points(raw)
+
+    def signature(self):
+        sig = super().signature()
+        sig.update({"coord_scale": self.coord_scale, "mode": self.mode,
+                    "max_new_tokens": self.max_new_tokens})
+        return sig
+
+
 def parse_model_spec(token):
     """Parse a ``--models`` token into ``(provider, model_id_or_None)``.
 
-    A token is either a bare provider (``rampnet`` / ``gemini`` / ``qwen``, which
-    uses that provider's default model) or ``provider:model_id`` to pin a specific
-    variant — e.g. ``gemini:gemini-2.5-flash`` vs ``gemini:gemini-3.6-flash`` — so
-    several variants of the same provider can be compared in one run."""
+    A token is either a bare provider (``rampnet`` / ``gemini`` / ``qwen`` /
+    ``owlv2`` / ``gdino`` / ``molmo``, which uses that provider's default model) or
+    ``provider:model_id`` to pin a specific variant — e.g. ``gemini:gemini-2.5-flash``
+    vs ``gemini:gemini-3.6-flash`` — so several variants of the same provider can be
+    compared in one run."""
     provider, _, model_id = token.partition(":")
     return provider.strip(), (model_id.strip() or None)
 
@@ -473,4 +894,21 @@ def build_detector(provider, model_id, records, args):
         coord_space = getattr(args, "qwen_coord_space", "auto")
         return mid, QwenDetector(model_id=mid, tile=tile,
                                  coord_space=None if coord_space == "auto" else coord_space)
-    raise ValueError(f"unknown provider '{provider}' (choose from: rampnet, gemini, qwen)")
+    if provider == "owlv2":
+        mid = model_id or getattr(args, "owlv2_model", None) or "google/owlv2-large-patch14-ensemble"
+        return mid, OwlV2Detector(model_id=mid, tile=tile,
+                                  query=getattr(args, "owlv2_query", None),
+                                  score_threshold=getattr(args, "score_threshold", None))
+    if provider == "gdino":
+        mid = model_id or getattr(args, "gdino_model", None) or "IDEA-Research/grounding-dino-base"
+        return mid, GroundingDinoDetector(model_id=mid, tile=tile,
+                                          query=getattr(args, "gdino_query", None),
+                                          score_threshold=getattr(args, "score_threshold", None),
+                                          text_threshold=getattr(args, "gdino_text_threshold", None))
+    if provider == "molmo":
+        mid = model_id or getattr(args, "molmo_model", None) or "allenai/Molmo2-8B"
+        scale = getattr(args, "molmo_coord_scale", "auto")
+        return mid, MolmoDetector(model_id=mid, tile=tile,
+                                  coord_scale=None if scale in (None, "auto") else float(scale))
+    raise ValueError(f"unknown provider '{provider}' (choose from: rampnet, gemini, qwen, "
+                     "owlv2, gdino, molmo)")

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -273,15 +273,39 @@ def pixel_boxes_to_points(items, img_w, img_h):
 #   Molmo 1:  <point x="35.4" y="61.2" alt="...">...</point>
 #             <points x1="10.5" y1="20.0" x2="30.1" y2="40.2" ...>...</points>
 #             -> coordinates are PERCENTAGES of the image (0-100).
-#   Molmo 2:  <points coords="0 354 612; 1 700 480"/>  (triplets: object_id x y)
-#             -> coordinates are scaled by 1000, per the model card's own regex.
+#   Molmo 2:  <points coords="1 1 308 305 2 752 377">curb ramp</points>
+#             -> a leading IMAGE INDEX, then (point_id, x, y) triplets, scaled by 1000.
+#             The leading index is easy to miss and costly: consuming it as a point
+#             id shifts every coordinate one slot left, which pins every point to
+#             x~0. That is what the first real Molmo run did until the
+#             dump_detections overlay showed a column of crosshairs on the left
+#             edge. Verified against Molmo2-8B on 2026-07-23; the token count is
+#             1 mod 3 (7 tokens for 2 points, 13 for 4) and the ids run 1,2,3,...
 # The two are distinguishable by syntax (a `coords` attribute vs `x`/`y` attributes),
 # which is why the scale can be inferred here — unlike Qwen's two box conventions,
 # which were syntactically identical and had to be chosen by model id.
 _MOLMO_TAG_RE = re.compile(r"<(point|points)\b([^>]*)>", re.IGNORECASE)
 _MOLMO_ATTR_RE = re.compile(r'([A-Za-z_]\w*)\s*=\s*"([^"]*)"')
 _MOLMO_XY_RE = re.compile(r"^([xy])(\d*)$")
-_MOLMO_TRIPLE_RE = re.compile(r"([0-9]+) ([0-9.]+) ([0-9.]+)")
+
+
+def _molmo_coord_pairs(coords):
+    """``"1 1 308 305 2 752 377"`` -> ``[("308", "305"), ("752", "377")]``.
+
+    Chunk into ``(id, x, y)`` triplets after dropping the leading image index.
+    Positional chunking rather than the model card's
+    ``([0-9]+) ([0-9]{3,4}) ([0-9]{3,4})`` regex: that pattern happens to
+    resynchronize past the leading index only because it demands 3-4 digits, so it
+    silently drops any point in the leftmost/topmost 10% of a view (x or y < 100).
+    Counting tokens gets both right.
+
+    Single images only — a multi-frame video response interleaves several frame
+    ids, which this harness never requests."""
+    nums = re.split(r"[\s;,:\t]+", coords.strip())
+    nums = [n for n in nums if n]
+    if len(nums) % 3 == 1:      # leading image/frame index
+        nums = nums[1:]
+    return [(nums[i + 1], nums[i + 2]) for i in range(0, len(nums) - 2, 3)]
 
 MOLMO_ATTR_SCALE = 100.0    # Molmo 1: percent of the image
 MOLMO_COORDS_SCALE = 1000.0  # Molmo 2: the card's "coordinates are scaled by 1000"
@@ -302,9 +326,9 @@ def molmo_points_from_text(text, coord_scale=None):
     for tag, attr_text in _MOLMO_TAG_RE.findall(text):
         attrs = dict(_MOLMO_ATTR_RE.findall(attr_text))
         label = attrs.get("alt", "")
-        if "coords" in attrs:                       # Molmo 2: "<id> <x> <y>" triplets
+        if "coords" in attrs:                       # Molmo 2: index + (id, x, y) triplets
             scale = coord_scale or MOLMO_COORDS_SCALE
-            pairs = [(m.group(2), m.group(3)) for m in _MOLMO_TRIPLE_RE.finditer(attrs["coords"])]
+            pairs = _molmo_coord_pairs(attrs["coords"])
         else:                                       # Molmo 1: x/y (or x1/y1, x2/y2 ...)
             scale = coord_scale or MOLMO_ATTR_SCALE
             xs, ys = {}, {}

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -292,17 +292,32 @@ _MOLMO_XY_RE = re.compile(r"^([xy])(\d*)$")
 def _molmo_coord_pairs(coords):
     """``"1 1 308 305 2 752 377"`` -> ``[("308", "305"), ("752", "377")]``.
 
-    Chunk into ``(id, x, y)`` triplets after dropping the leading image index.
-    Positional chunking rather than the model card's
+    Chunk into ``(id, x, y)`` triplets, dropping the leading image index when one
+    is present. Positional chunking rather than the model card's
     ``([0-9]+) ([0-9]{3,4}) ([0-9]{3,4})`` regex: that pattern happens to
     resynchronize past the leading index only because it demands 3-4 digits, so it
     silently drops any point in the leftmost/topmost 10% of a view (x or y < 100).
-    Counting tokens gets both right.
+
+    Whether the leading index is there is decided by the point-id column (the ids
+    run 1, 2, 3, ... — model card, confirmed on real output), not by token count
+    alone: a generation truncated mid-triplet by max_new_tokens shifts the count
+    by one or two, and misaligned pairs would divide small point ids by 1000 into
+    in-frame garbage pinned near x~0 — a quiet failure, exactly what this parser
+    must never produce. Trying the with-index alignment first is safe: for the
+    without-index alignment to be mistaken for it, a real x coordinate would have
+    to equal the next expected id (x of 0.001-0.009 of a view), which does not
+    occur. The token-count heuristic remains as the fallback for id sequences
+    that don't read 1..k.
 
     Single images only — a multi-frame video response interleaves several frame
     ids, which this harness never requests."""
     nums = re.split(r"[\s;,:\t]+", coords.strip())
     nums = [n for n in nums if n]
+    for lead in (1, 0):         # with the image index, then without
+        tail = nums[lead:]
+        n_full = len(tail) // 3
+        if n_full and tail[0::3][:n_full] == [str(i + 1) for i in range(n_full)]:
+            return [(tail[i + 1], tail[i + 2]) for i in range(0, 3 * n_full, 3)]
     if len(nums) % 3 == 1:      # leading image/frame index
         nums = nums[1:]
     return [(nums[i + 1], nums[i + 2]) for i in range(0, len(nums) - 2, 3)]

--- a/scripts/model_comparison/dump_detections.py
+++ b/scripts/model_comparison/dump_detections.py
@@ -8,12 +8,20 @@ at a ~1000px view size a wrong choice does not crash, it just slides every
 detection toward the top-left by a constant factor. That is invisible in a P/R
 table and obvious in one overlay.
 
-For one pano it renders each rectilinear view with the model's raw boxes (red) and
-the pano's ground-truth ramps (green) / ignore points (amber) projected into the
-same view. Boxes should sit on the ramps.
+For one pano it renders each rectilinear view with the model's raw predictions
+(red) and the pano's ground-truth ramps (green) / ignore points (amber) projected
+into the same view. Predictions should sit on the ramps.
+
+Three prediction shapes are drawn, because the models disagree on what they emit:
+**boxes** (Gemini, Qwen), **scored boxes** (OWLv2, Grounding DINO — the score is
+printed, since these are the models whose threshold we tune), and **points**
+(Molmo, whose scale convention is exactly the kind of thing this script exists to
+catch: Molmo 1 emits percentages, Molmo 2 emits 0-1000).
 
     python scripts/model_comparison/dump_detections.py benchmark/richmond \
         --model qwen:Qwen/Qwen3-VL-8B-Instruct --out view_dump/qwen
+    python scripts/model_comparison/dump_detections.py benchmark/richmond \
+        --model owlv2 --out view_dump/owlv2
 
 Needs the model's credentials/weights — it makes real calls (one per view).
 """
@@ -38,26 +46,34 @@ IGNORE_COLOR = (240, 190, 60)
 BOX_COLOR = (255, 70, 70)
 
 
-def boxes_to_view_rects(detector, raw, width, height):
-    """Provider box -> ``(x1, y1, x2, y2)`` pixel rect inside the view, for drawing.
+def detections_to_view_shapes(detector, raw, width, height):
+    """Provider raw item -> a drawable shape in view pixels.
 
-    Mirrors what ``detector._parse`` does to get centers, but keeps the full box so
-    a coordinate-space mistake is visible as a whole rectangle in the wrong place."""
-    rects = []
+    ``("rect", x1, y1, x2, y2, score_or_None)`` or ``("point", x, y, score_or_None)``.
+    Mirrors what ``detector._parse`` does to get centers, but keeps the full box (or
+    the bare point) so a coordinate-space mistake is visible as a whole shape in the
+    wrong place rather than as a slightly-off center."""
+    shapes = []
     for it in raw:
         if "box_2d" in it:                      # Gemini: [ymin, xmin, ymax, xmax], 0-1000
             ymin, xmin, ymax, xmax = it["box_2d"]
-            rects.append((xmin / 1000.0 * width, ymin / 1000.0 * height,
-                          xmax / 1000.0 * width, ymax / 1000.0 * height))
+            shapes.append(("rect", xmin / 1000.0 * width, ymin / 1000.0 * height,
+                           xmax / 1000.0 * width, ymax / 1000.0 * height, None))
         elif "bbox_2d" in it:                   # Qwen: [x1, y1, x2, y2]
             x1, y1, x2, y2 = it["bbox_2d"]
             if getattr(detector, "coord_space", "norm1000") == "norm1000":
                 sx = sy = 1000.0
             else:
                 sx, sy = width, height
-            rects.append((x1 / sx * width, y1 / sy * height,
-                          x2 / sx * width, y2 / sy * height))
-    return rects
+            shapes.append(("rect", x1 / sx * width, y1 / sy * height,
+                           x2 / sx * width, y2 / sy * height, None))
+        elif "box" in it:                       # OWLv2 / Grounding DINO: pixels + score
+            x1, y1, x2, y2 = it["box"]
+            shapes.append(("rect", x1, y1, x2, y2, it.get("score")))
+        elif "point" in it:                     # Molmo: already normalized to the view
+            x, y = it["point"]
+            shapes.append(("point", x * width, y * height, it.get("score")))
+    return shapes
 
 
 def _marker(draw, x, y, color, r=14):
@@ -66,19 +82,33 @@ def _marker(draw, x, y, color, r=14):
     draw.line([x, y - r, x, y + r], fill=color, width=1)
 
 
-def overlay(image, rects, gt_uv, ignore_uv):
+def _crosshair(draw, cx, cy, color, arm=10, width=2):
+    draw.line([cx - arm, cy, cx + arm, cy], fill=color, width=width)
+    draw.line([cx, cy - arm, cx, cy + arm], fill=color, width=width)
+
+
+def overlay(image, shapes, gt_uv, ignore_uv):
     from PIL import ImageDraw
     draw = ImageDraw.Draw(image)
     for (x, y) in ignore_uv:
         _marker(draw, x, y, IGNORE_COLOR)
     for (x, y) in gt_uv:
         _marker(draw, x, y, GT_COLOR)
-    for (x1, y1, x2, y2) in rects:
-        draw.rectangle([x1, y1, x2, y2], outline=BOX_COLOR, width=4)
-        draw.line([(x1 + x2) / 2 - 10, (y1 + y2) / 2, (x1 + x2) / 2 + 10, (y1 + y2) / 2],
-                  fill=BOX_COLOR, width=2)
-        draw.line([(x1 + x2) / 2, (y1 + y2) / 2 - 10, (x1 + x2) / 2, (y1 + y2) / 2 + 10],
-                  fill=BOX_COLOR, width=2)
+    for shape in shapes:
+        if shape[0] == "rect":
+            _, x1, y1, x2, y2, score = shape
+            draw.rectangle([x1, y1, x2, y2], outline=BOX_COLOR, width=4)
+            _crosshair(draw, (x1 + x2) / 2, (y1 + y2) / 2, BOX_COLOR)
+            if score is not None:
+                draw.text((x1 + 3, max(0, y1 - 12)), f"{score:.2f}", fill=BOX_COLOR)
+        else:
+            _, x, y, score = shape
+            # A point prediction has no extent, so draw the marker style used for GT
+            # (in red) — same visual weight, so a scale error is as obvious as a box's.
+            _marker(draw, x, y, BOX_COLOR, r=10)
+            _crosshair(draw, x, y, BOX_COLOR, arm=16, width=1)
+            if score is not None:
+                draw.text((x + 12, y + 12), f"{score:.2f}", fill=BOX_COLOR)
     return image
 
 
@@ -108,7 +138,8 @@ def main():
     ap.add_argument("bundle", help="Bundle dir (benchmark/<city>).")
     ap.add_argument("--model", default="qwen",
                     help="One detector spec: provider or provider:model_id "
-                         "(e.g. qwen:Qwen/Qwen3-VL-8B-Instruct, gemini:gemini-3.6-flash).")
+                         "(e.g. qwen:Qwen/Qwen3-VL-8B-Instruct, gemini:gemini-3.6-flash, "
+                         "owlv2, gdino, molmo:allenai/Molmo2-8B).")
     ap.add_argument("--pano", help="Pano id (default: first reviewed pano with an image).")
     ap.add_argument("--out", default="view_dump/detections", help="Output directory.")
     ap.add_argument("--source-max-edge", type=int, default=4096)
@@ -116,6 +147,16 @@ def main():
     ap.add_argument("--gemini-model", default="gemini-3.6-flash")
     ap.add_argument("--qwen-model", default="Qwen/Qwen3-VL-8B-Instruct")
     ap.add_argument("--qwen-coord-space", choices=["auto", "norm1000", "pixels"], default="auto")
+    ap.add_argument("--owlv2-model", default="google/owlv2-large-patch14-ensemble")
+    ap.add_argument("--gdino-model", default="IDEA-Research/grounding-dino-base")
+    ap.add_argument("--molmo-model", default="allenai/Molmo2-8B")
+    ap.add_argument("--owlv2-query")
+    ap.add_argument("--gdino-query")
+    ap.add_argument("--gdino-text-threshold", type=float)
+    ap.add_argument("--score-threshold", type=float,
+                    help="Score floor for owlv2/gdino (default 0.05). Raise it to declutter "
+                         "the overlay; the harness's own floor is unaffected.")
+    ap.add_argument("--molmo-coord-scale", choices=["auto", "100", "1000"], default="auto")
     ap.add_argument("--tiling", choices=["perspective"], default="perspective",
                     help="Only the tiled path is worth eyeballing.")
     args = ap.parse_args()
@@ -140,28 +181,28 @@ def main():
     os.makedirs(args.out, exist_ok=True)
     pano = load_pano_image(pano_path, args.source_max_edge)
     views = detector._views or default_views()
-    rendered, total_boxes = [], 0
+    rendered, total_preds = [], 0
     for i, view in enumerate(views):
         view_img = equirect_to_perspective(pano, view)
         raw = detector._raw_detect(view_img)
-        rects = boxes_to_view_rects(detector, raw, view.width, view.height)
-        total_boxes += len(rects)
+        shapes = detections_to_view_shapes(detector, raw, view.width, view.height)
+        total_preds += len(shapes)
         gt_uv = _project(gt.gt_points, view)
         ignore_uv = _project(gt.ignore_points, view)
-        overlay(view_img, rects, gt_uv, ignore_uv)
-        name = f"view_{i}_yaw{int(view.yaw_deg)}_boxes{len(rects)}.png"
+        overlay(view_img, shapes, gt_uv, ignore_uv)
+        name = f"view_{i}_yaw{int(view.yaw_deg)}_preds{len(shapes)}.png"
         view_img.save(os.path.join(args.out, name))
         rendered.append(view_img)
-        print(f"  view {i} (yaw {int(view.yaw_deg)}): {len(rects)} box(es), "
+        print(f"  view {i} (yaw {int(view.yaw_deg)}): {len(shapes)} prediction(s), "
               f"{len(gt_uv)} GT / {len(ignore_uv)} ignore point(s) in frame")
 
     sheet_path = os.path.join(args.out, f"contact_{label.replace('/', '_')}_{pano_id}.png")
     _contact_sheet(rendered).save(sheet_path)
-    print(f"\npano {pano_id}: {total_boxes} raw box(es) across {len(views)} views vs "
+    print(f"\npano {pano_id}: {total_preds} raw prediction(s) across {len(views)} views vs "
           f"{len(gt.gt_points)} GT ramp(s) ({len(gt.ignore_points)} ignored)")
     print(f"Contact sheet: {sheet_path}")
-    print("Boxes (red) should sit on ramps; a constant offset toward the top-left means "
-          "the coordinate space is wrong (see --qwen-coord-space).")
+    print("Predictions (red) should sit on ramps; a constant offset toward the top-left means "
+          "the coordinate space is wrong (see --qwen-coord-space / --molmo-coord-scale).")
 
 
 if __name__ == "__main__":

--- a/scripts/model_comparison/run_open_models.slurm
+++ b/scripts/model_comparison/run_open_models.slurm
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Open-weight leg of the model comparison, on Hyak (klone): the open-vocabulary
+# detectors (OWLv2, Grounding DINO) and Ai2 Molmo. Sibling of run_qwen.slurm.
+#
+# Pass your Slurm account with -A; there is no usable default, and a submission
+# without one is rejected. Find yours with:
+#   sacctmgr -nP show assoc user=$USER format=Account,QOS
+#
+#   sbatch -A <account> scripts/model_comparison/run_open_models.slurm
+#   BUNDLE=benchmark/bend sbatch -A <account> scripts/model_comparison/run_open_models.slurm
+#   MODELS=rampnet,molmo:allenai/Molmo2-8B \
+#       sbatch -A <account> scripts/model_comparison/run_open_models.slurm
+#
+# Sizes: OWLv2-large and Grounding DINO-base are ~1-2 GB and run in minutes, so
+# both fit one card with room to spare. Molmo-8B is ~16 GB in bf16 — still one
+# L40S, but hours rather than minutes (it generates text per view).
+#
+# The open-vocabulary detectors emit calibrated per-box scores, so the harness
+# caches detections down to a low score FLOOR (--score-threshold, default 0.05)
+# and every higher operating point is then a free local re-score (--op-threshold /
+# --sweep). Lowering the floor later re-runs the model: it is in the cache key.
+#
+# PYTHON is the interpreter to run with; default is whatever `python` resolves to
+# after the env is activated (see the runbook in docs/model_comparison.md).
+#
+# Detections land in .model_cache/, whose key contains nothing machine-specific —
+# rsync that directory back and score locally with no GPU.
+#SBATCH -p gpu-l40s
+#SBATCH --job-name=open_curb_ramp_compare
+#SBATCH --time=8:00:00
+#SBATCH --mem=64G
+#SBATCH --cpus-per-task=8
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gpus-per-node=1
+#SBATCH --output=logs/open_compare_%j.out
+#SBATCH --error=logs/open_compare_%j.err
+
+set -euo pipefail
+
+MODELS="${MODELS:-rampnet,owlv2,gdino}"
+BUNDLE="${BUNDLE:-benchmark/richmond}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+# Home quota on klone is small; keep the HF cache on scratch and pre-download the
+# weights on the login node so the GPU isn't billed for the transfer.
+export HF_HOME="${HF_HOME:-/gscratch/scrubbed/$USER/hf}"
+
+PYTHON="${PYTHON:-}"
+if [ -z "$PYTHON" ]; then
+    source activate sidewalkcv2
+    PYTHON=python
+fi
+
+echo "--- open-model comparison ---"
+echo "Models: ${MODELS}"
+echo "Bundle: ${BUNDLE}"
+echo "GPUs:   ${SLURM_GPUS_PER_NODE:-${SLURM_GPUS:-1}} on ${SLURMD_NODENAME:-?}"
+echo "HF_HOME: ${HF_HOME}"
+echo "Python:  $($PYTHON -c 'import sys,torch;print(sys.version.split()[0],"torch",torch.__version__)')"
+nvidia-smi --query-gpu=name,memory.total --format=csv || true
+echo "-----------------------------"
+
+"$PYTHON" -u scripts/model_comparison/compare.py "$BUNDLE" \
+    --models "$MODELS" \
+    --sweep \
+    $EXTRA_ARGS
+
+echo "--- done; rsync .model_cache/ back to score alongside the other models ---"

--- a/scripts/model_comparison/run_qwen.slurm
+++ b/scripts/model_comparison/run_qwen.slurm
@@ -1,12 +1,30 @@
 #!/bin/bash
 # Qwen3-VL leg of the model comparison, on Hyak (klone).
 #
-#   sbatch scripts/model_comparison/run_qwen.slurm
-#   BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_qwen.slurm
-#   QWEN_MODEL=Qwen/Qwen3-VL-32B-Instruct sbatch --gpus=2 scripts/model_comparison/run_qwen.slurm
+# Pass your Slurm account with -A; there is no usable default, and a submission
+# without one is rejected. Find yours with:
+#   sacctmgr -nP show assoc user=$USER format=Account,QOS
+#
+#   sbatch -A <account> scripts/model_comparison/run_qwen.slurm
+#   BUNDLE=benchmark/bend sbatch -A <account> scripts/model_comparison/run_qwen.slurm
+#   QWEN_MODEL=Qwen/Qwen3-VL-32B-Instruct sbatch -A <account> --gpus=2 \
+#       scripts/model_comparison/run_qwen.slurm
 #
 # 32B is ~64 GB in bf16, so it needs two 48 GB cards; device_map="auto" shards it
 # across whatever the job is allocated. 8B fits one.
+#
+# --nodes=1 below is load-bearing for the multi-GPU case. `--gpus=2` alone lets
+# Slurm satisfy the request with one GPU on each of two nodes; the process then
+# sees a single card, and accelerate silently CPU-offloads the rest ("Some
+# parameters are on the meta device...") instead of failing. The run does not
+# crash, it just becomes unusably slow. Ask for GPUs per node, on one node:
+#   sbatch -A <account> --nodes=1 --gpus-per-node=2 ...
+# (--mem is per node, so it is not multiplied by the node count either.)
+#
+# PYTHON is the interpreter to run with; default is whatever `python` resolves to
+# after the env is activated. On klone the comparison leg needs only
+# numpy/PIL/torch/transformers (the RampNet baseline reads detections from the
+# bundle, so no timm and no model load), so a lean venv works — see the runbook.
 #
 # Detections land in .model_cache/, whose key contains nothing machine-specific —
 # rsync that directory back and score locally with no GPU (see docs/model_comparison.md).
@@ -15,7 +33,9 @@
 #SBATCH --time=12:00:00
 #SBATCH --mem=64G
 #SBATCH --cpus-per-task=8
-#SBATCH --gpus=1
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gpus-per-node=1
 #SBATCH --output=logs/qwen_compare_%j.out
 #SBATCH --error=logs/qwen_compare_%j.err
 
@@ -30,17 +50,24 @@ EXTRA_ARGS="${EXTRA_ARGS:-}"
 #   HF_HOME=... hf download "$QWEN_MODEL"
 export HF_HOME="${HF_HOME:-/gscratch/scrubbed/$USER/hf}"
 
-source activate sidewalkcv2
+# PYTHON points at a ready interpreter (e.g. a venv on gscratch). Falls back to
+# activating the full conda env when unset.
+PYTHON="${PYTHON:-}"
+if [ -z "$PYTHON" ]; then
+    source activate sidewalkcv2
+    PYTHON=python
+fi
 
 echo "--- Qwen model comparison ---"
 echo "Model:  ${QWEN_MODEL}"
 echo "Bundle: ${BUNDLE}"
-echo "GPUs:   ${SLURM_GPUS:-1} on ${SLURMD_NODENAME:-?}"
+echo "GPUs:   ${SLURM_GPUS_PER_NODE:-${SLURM_GPUS:-1}} on ${SLURMD_NODENAME:-?}"
 echo "HF_HOME: ${HF_HOME}"
+echo "Python:  $($PYTHON -c 'import sys,torch;print(sys.version.split()[0],"torch",torch.__version__)')"
 nvidia-smi --query-gpu=name,memory.total --format=csv || true
 echo "-----------------------------"
 
-python -u scripts/model_comparison/compare.py "$BUNDLE" \
+"$PYTHON" -u scripts/model_comparison/compare.py "$BUNDLE" \
     --models "rampnet,qwen:${QWEN_MODEL}" \
     --qwen-model "$QWEN_MODEL" \
     $EXTRA_ARGS

--- a/tests/test_detection_eval.py
+++ b/tests/test_detection_eval.py
@@ -97,6 +97,58 @@ def test_aggregate_gates_recall_on_confirmed_panos():
     assert r.n_recall_panos == 1 and r.n_panos == 2
 
 
+# --- per-prediction details -> AP / PR curve --------------------------------
+
+def test_score_pano_records_details_for_ap():
+    gt = _gt([(0.0, 0.0)])
+    s = score_pano([(0.0, 0.0, 0.9), (5.0, 5.0, 0.4)], gt, **UNIT)
+    assert s.details == [(0.9, True), (0.4, False)]   # one TP, one FP, in match order
+
+
+def test_score_pano_keeps_ignored_predictions_out_of_the_curve():
+    # An ignored prediction is neither TP nor FP, so it must not appear in the PR
+    # curve either — otherwise the reviewer's abstention would cost the model.
+    gt = _gt([], ignore_points=[(0.0, 0.0)])
+    s = score_pano([(0.1, 0.0, 0.8)], gt, **UNIT)
+    assert s.ignored == 1 and s.details == []
+
+
+def test_aggregate_reports_ap_when_every_prediction_is_scored():
+    # Perfect ranking on 2 GT points: both TPs above the FP -> AP 1.0.
+    scores = [PanoScore(tp=2, fp=1, ignored=0, n_gt=2, fn_confirmed=True,
+                        details=[(0.9, True), (0.8, True), (0.3, False)])]
+    r = aggregate(scores)
+    assert r.ap == 1.0
+    recalls, precisions = r.pr_curve
+    assert recalls[-1] == 1.0 and len(recalls) == len(precisions)
+
+
+def test_aggregate_ranking_matters_for_ap():
+    # Same counts as above, but the false positive outranks both hits.
+    worse = aggregate([PanoScore(tp=2, fp=1, ignored=0, n_gt=2, fn_confirmed=True,
+                                 details=[(0.9, False), (0.8, True), (0.3, True)])])
+    assert 0.0 < worse.ap < 1.0
+
+
+def test_aggregate_has_no_ap_without_confidences():
+    # Chat VLMs emit no calibrated score, so there is nothing to rank by.
+    r = aggregate([PanoScore(tp=1, fp=1, ignored=0, n_gt=1, fn_confirmed=True,
+                             details=[(None, True), (None, False)])])
+    assert r.ap is None and r.pr_curve is None
+
+
+def test_aggregate_ap_uses_only_recall_confirmed_panos():
+    # An unconfirmed pano has no trustworthy GT count, so its predictions can't be
+    # placed on a recall axis; including them would distort the curve.
+    confirmed = PanoScore(tp=1, fp=0, ignored=0, n_gt=1, fn_confirmed=True,
+                          details=[(0.9, True)])
+    unconfirmed = PanoScore(tp=0, fp=1, ignored=0, n_gt=0, fn_confirmed=False,
+                            details=[(0.99, False)])
+    r = aggregate([confirmed, unconfirmed])
+    assert r.ap == 1.0                    # the unconfirmed pano's FP is excluded
+    assert r.precision == 1 / 2           # but it still counts against precision
+
+
 # --- integration: RampNet reproduces its published numbers ------------------
 
 def _load_bundle(city):

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -252,12 +252,38 @@ def test_molmo_v1_multi_point_tag():
         {"point": [0.3, 0.4], "label": "curb ramps"}]
 
 
-def test_molmo_v2_coords_triplets_are_scaled_by_1000():
-    # Molmo 2's own model card: "<id> <x> <y>", coordinates scaled by 1000.
-    text = '<points coords="0 354 612; 1 700 480"/>'
+def test_molmo_v2_coords_are_image_index_then_id_x_y_triplets():
+    # VERBATIM output from allenai/Molmo2-8B on a richmond view (2026-07-23).
+    # The leading "1" is the IMAGE index, not a point id; consuming it as one
+    # shifts every coordinate a slot left and pins all points to x~0, which is the
+    # bug the dump_detections overlay caught on the first real run.
+    text = '<points coords="1 1 308 305 2 752 377">curb ramp</points>'
     assert molmo_points_from_text(text) == [
-        {"point": [0.354, 0.612], "label": ""},
-        {"point": [0.7, 0.48], "label": ""}]
+        {"point": [0.308, 0.305], "label": ""},
+        {"point": [0.752, 0.377], "label": ""}]
+
+
+def test_molmo_v2_four_points_from_a_real_response():
+    text = ('<points coords="1 1 299 338 2 532 381 3 662 446 4 932 429">'
+            'curb ramp</points>')
+    assert [p["point"] for p in molmo_points_from_text(text)] == [
+        [0.299, 0.338], [0.532, 0.381], [0.662, 0.446], [0.932, 0.429]]
+
+
+def test_molmo_v2_keeps_points_near_the_left_and_top_edges():
+    # The model card's own regex demands 3-4 digits for x/y, which silently drops
+    # anything in the leftmost/topmost 10% of a view. Positional chunking doesn't.
+    text = '<points coords="1 1 42 7 2 500 500">curb ramp</points>'
+    assert [p["point"] for p in molmo_points_from_text(text)] == [
+        [0.042, 0.007], [0.5, 0.5]]
+
+
+def test_molmo_v2_accepts_separators_and_a_bare_triplet_list():
+    assert [p["point"] for p in molmo_points_from_text(
+        '<points coords="1 1 354 612; 2 700 480"/>')] == [[0.354, 0.612], [0.7, 0.48]]
+    # No leading index (token count already a multiple of 3).
+    assert [p["point"] for p in molmo_points_from_text(
+        '<points coords="1 354 612"/>')] == [[0.354, 0.612]]
 
 
 def test_molmo_explicit_scale_overrides_the_syntax_inference():

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -12,21 +12,36 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "model_comparison"))
 
 from detectors import (  # noqa: E402
-    BundleRampNetDetector, GeminiDetector, QwenDetector, PanoSample, _VLMDetector,
+    BundleRampNetDetector, GeminiDetector, GroundingDinoDetector, MolmoDetector,
+    OwlV2Detector, QwenDetector, PanoSample, _VLMDetector,
     gemini_boxes_to_points, qwen_boxes_to_points, boxes_from_gemini_response,
     boxes_from_qwen_text, infer_qwen_coord_space, parse_model_spec, build_detector,
-    DETECTION_PROMPT,
+    molmo_points_from_text, molmo_token_points_to_items, infer_molmo_mode,
+    owlv2_target_size, pixel_boxes_to_points, zero_shot_results_to_boxes,
+    CURB_RAMP_DEFINITION, DETECTION_PROMPT, GDINO_QUERY, MOLMO_PROMPT, OWLV2_QUERY,
 )
+from dump_detections import detections_to_view_shapes  # noqa: E402
 
 
-from compare import score_model, validate_bundle, DetectionCache, cache_key  # noqa: E402
-from rampnet.detection_eval import radius_sq_for  # noqa: E402
+from compare import (  # noqa: E402
+    score_model, validate_bundle, DetectionCache, cache_key, has_confidences, rescore,
+    sweep_rows,
+)
+from rampnet.detection_eval import GroundTruth, radius_sq_for  # noqa: E402
 
 
 class _Args:
     gemini_model = "gemini-3.6-flash"
     qwen_model = "Qwen/Qwen3-VL-8B-Instruct"
     qwen_coord_space = "auto"
+    owlv2_model = "google/owlv2-large-patch14-ensemble"
+    gdino_model = "IDEA-Research/grounding-dino-base"
+    molmo_model = "allenai/Molmo2-8B"
+    owlv2_query = None
+    gdino_query = None
+    gdino_text_threshold = None
+    score_threshold = None
+    molmo_coord_scale = "auto"
     tiling = "perspective"
 
 
@@ -143,6 +158,154 @@ def test_boxes_from_gemini_response_empty():
     assert boxes_from_gemini_response(_FakeResp(parsed=[], text="[]")) == []
 
 
+# --- open-vocabulary detectors (OWLv2 / Grounding DINO) ---------------------
+
+class _FakeTensor:
+    """Stands in for the torch tensors a live post_process returns."""
+    def __init__(self, data):
+        self._data = data
+
+    def tolist(self):
+        return self._data
+
+
+def test_zero_shot_results_to_boxes_unwraps_tensors_and_scores():
+    result = {"boxes": _FakeTensor([[10, 20, 30, 40], [1, 2, 3, 4]]),
+              "scores": _FakeTensor([0.9, 0.11]),
+              "text_labels": ["curb ramp", "curb ramp"]}
+    assert zero_shot_results_to_boxes(result) == [
+        {"box": [10.0, 20.0, 30.0, 40.0], "score": 0.9, "label": "curb ramp"},
+        {"box": [1.0, 2.0, 3.0, 4.0], "score": 0.11, "label": "curb ramp"}]
+
+
+def test_zero_shot_results_to_boxes_filters_and_survives_missing_fields():
+    result = {"boxes": [[0, 0, 2, 2], [0, 0, 4, 4]], "scores": [0.5, 0.05], "labels": [0, 0]}
+    kept = zero_shot_results_to_boxes(result, threshold=0.2)
+    assert [it["box"] for it in kept] == [[0.0, 0.0, 2.0, 2.0]]
+    assert zero_shot_results_to_boxes({}) == []                      # nothing detected
+    assert zero_shot_results_to_boxes({"boxes": [[1, 2, 3]]}) == []   # malformed box dropped
+
+
+def test_owlv2_target_size_is_the_padded_square():
+    # OWLv2's processor pads to a square (bottom/right) before resizing, so boxes are
+    # relative to that square, not to the image — which is the frame
+    # pixel_boxes_to_points normalizes against.
+    assert owlv2_target_size(1024, 1024) == (1024, 1024)   # square view: a no-op
+    assert owlv2_target_size(2048, 1024) == (2048, 2048)   # whole-pano 2:1
+    assert owlv2_target_size(600, 900) == (900, 900)
+
+
+def test_pixel_boxes_to_points_carries_confidence_through():
+    # The whole point of these models: the score survives to the scorer, which is
+    # what makes AP / PR curves / a threshold sweep possible.
+    pts = pixel_boxes_to_points([{"box": [100, 200, 300, 400], "score": 0.42}], 1000, 2000)
+    assert pts == [(0.2, 0.15, 0.42)]
+
+
+def test_pixel_boxes_to_points_drops_boxes_in_the_pad_region():
+    # With the padded-square target size, a box OWLv2 places below a wide image has a
+    # center outside the picture; it is not a detection.
+    items = [{"box": [0, 0, 100, 100], "score": 0.5},        # in frame
+             {"box": [0, 1200, 100, 1400], "score": 0.5}]    # below a 1000x600 image
+    assert pixel_boxes_to_points(items, 1000, 600) == [(0.05, 1 / 12, 0.5)]
+
+
+def test_open_vocab_queries_are_short_and_key_the_cache():
+    # These are not chat models: the query is the prompt, and it must be in the
+    # signature so changing it doesn't silently reuse detections from the old one.
+    owl, dino = OwlV2Detector(), GroundingDinoDetector()
+    assert owl.prompt == OWLV2_QUERY and dino.prompt == GDINO_QUERY
+    assert owl.signature()["query"] == OWLV2_QUERY
+    assert owl.signature()["prompt"] == OWLV2_QUERY
+    assert dino.signature()["text_threshold"] == dino.text_threshold
+    assert OwlV2Detector(query="curb cut").signature()["query"] == "curb cut"
+
+
+def test_score_threshold_is_in_the_signature():
+    # It is a cache FLOOR: lowering it must invalidate cached detections (there are
+    # boxes missing from them), while raising the reported operating point is free.
+    low = OwlV2Detector(score_threshold=0.01).signature()
+    high = OwlV2Detector(score_threshold=0.3).signature()
+    assert low["score_threshold"] == 0.01 and high["score_threshold"] == 0.3
+    assert cache_key("owlv2", low, "richmond", "p") != cache_key("owlv2", high, "richmond", "p")
+
+
+# --- Molmo (points, not boxes) ----------------------------------------------
+
+def test_molmo_prompt_shares_the_definition_but_asks_for_points():
+    assert CURB_RAMP_DEFINITION in DETECTION_PROMPT      # one definition, every model
+    assert CURB_RAMP_DEFINITION in MOLMO_PROMPT
+    assert MOLMO_PROMPT.startswith("Point to every curb ramp")
+    assert "bounding box" not in MOLMO_PROMPT
+
+
+def test_molmo_v1_attribute_points_are_percentages():
+    text = '<point x="35.4" y="61.2" alt="curb ramp">curb ramp</point>'
+    assert molmo_points_from_text(text) == [{"point": [0.354, 0.612], "label": "curb ramp"}]
+
+
+def test_molmo_v1_multi_point_tag():
+    text = ('<points x1="10.0" y1="20.0" x2="30.0" y2="40.0" alt="curb ramps">'
+            'curb ramps</points>')
+    assert molmo_points_from_text(text) == [
+        {"point": [0.1, 0.2], "label": "curb ramps"},
+        {"point": [0.3, 0.4], "label": "curb ramps"}]
+
+
+def test_molmo_v2_coords_triplets_are_scaled_by_1000():
+    # Molmo 2's own model card: "<id> <x> <y>", coordinates scaled by 1000.
+    text = '<points coords="0 354 612; 1 700 480"/>'
+    assert molmo_points_from_text(text) == [
+        {"point": [0.354, 0.612], "label": ""},
+        {"point": [0.7, 0.48], "label": ""}]
+
+
+def test_molmo_explicit_scale_overrides_the_syntax_inference():
+    text = '<point x="354" y="612">x</point>'          # 0-1000 numbers in v1 syntax
+    assert molmo_points_from_text(text) == []          # /100 -> out of frame, dropped
+    assert molmo_points_from_text(text, coord_scale=1000.0) == [
+        {"point": [0.354, 0.612], "label": ""}]
+
+
+def test_molmo_points_from_text_ignores_prose_and_empty():
+    assert molmo_points_from_text("There are no curb ramps in this image.") == []
+    assert molmo_points_from_text("") == []
+    assert molmo_points_from_text(None) == []
+
+
+def test_molmo_token_points_read_the_tail_of_each_row():
+    # The card documents the leading ids two different ways, so only (x, y) is read.
+    rows = [[0, 0, 512.0, 256.0], [1, 0, 2048.0, 10.0]]   # second is out of frame
+    assert molmo_token_points_to_items(rows, 1024, 512) == [{"point": [0.5, 0.5], "label": ""}]
+
+
+def test_infer_molmo_mode():
+    assert infer_molmo_mode("allenai/MolmoPoint-8B") == "point_tokens"
+    assert infer_molmo_mode("allenai/Molmo2-8B") == "xml"
+    assert infer_molmo_mode("allenai/Molmo-7B-D-0924") == "xml"
+
+
+def test_molmo_signature_extends_without_disturbing_gemini():
+    sig = MolmoDetector(model_id="allenai/MolmoPoint-8B").signature()
+    assert sig["mode"] == "point_tokens" and sig["coord_scale"] is None
+    assert set(sig) - set(GeminiDetector().signature()) == {
+        "coord_scale", "mode", "max_new_tokens"}
+
+
+# --- visual QA shapes (dump_detections) -------------------------------------
+
+def test_detections_to_view_shapes_covers_every_provider_format():
+    qwen = QwenDetector(model_id="Qwen/Qwen3-VL-8B-Instruct")
+    assert detections_to_view_shapes(None, [{"box_2d": [100, 200, 300, 400]}], 1000, 1000) == [
+        ("rect", 200.0, 100.0, 400.0, 300.0, None)]           # Gemini: ymin,xmin,ymax,xmax
+    assert detections_to_view_shapes(qwen, [{"bbox_2d": [100, 200, 300, 400]}], 1000, 1000) == [
+        ("rect", 100.0, 200.0, 300.0, 400.0, None)]           # Qwen norm1000 at a 1000px view
+    assert detections_to_view_shapes(None, [{"box": [1, 2, 3, 4], "score": 0.7}], 100, 100) == [
+        ("rect", 1, 2, 3, 4, 0.7)]                            # OWLv2/GDINO: pixels + score
+    assert detections_to_view_shapes(None, [{"point": [0.25, 0.5]}], 800, 600) == [
+        ("point", 200.0, 300.0, None)]                        # Molmo
+
+
 def test_parse_model_spec():
     assert parse_model_spec("rampnet") == ("rampnet", None)
     assert parse_model_spec("gemini") == ("gemini", None)
@@ -217,6 +380,80 @@ def test_build_detector_qwen_coord_space_override():
     assert det.model_id == "Qwen/Qwen3-VL-8B-Instruct" and det.coord_space == "norm1000"
 
 
+def test_build_detector_wires_the_open_models():
+    for token, cls, default_id in (
+            ("owlv2", OwlV2Detector, "google/owlv2-large-patch14-ensemble"),
+            ("gdino", GroundingDinoDetector, "IDEA-Research/grounding-dino-base"),
+            ("molmo", MolmoDetector, "allenai/Molmo2-8B")):
+        label, det = build_detector(token, None, {}, _Args())
+        assert label == default_id and isinstance(det, cls) and det.model_id == default_id
+    # A pinned variant labels by its model id, like the other providers.
+    label, det = build_detector("molmo", "allenai/MolmoPoint-8B", {}, _Args())
+    assert label == "allenai/MolmoPoint-8B" and det.mode == "point_tokens"
+
+
+def test_build_detector_applies_query_and_threshold_overrides():
+    class _Pinned(_Args):
+        owlv2_query = "curb cut"
+        gdino_query = "wheelchair ramp."
+        gdino_text_threshold = 0.35
+        score_threshold = 0.2
+        molmo_coord_scale = "1000"
+    _, owl = build_detector("owlv2", None, {}, _Pinned())
+    assert owl.query == "curb cut" and owl.score_threshold == 0.2
+    _, dino = build_detector("gdino", None, {}, _Pinned())
+    assert dino.query == "wheelchair ramp." and dino.text_threshold == 0.35
+    _, molmo = build_detector("molmo", None, {}, _Pinned())
+    assert molmo.coord_scale == 1000.0
+
+
+def test_build_detector_rejects_unknown_provider():
+    try:
+        build_detector("clip", None, {}, _Args())
+    except ValueError as e:
+        assert "owlv2" in str(e)      # the message lists what is available
+        return
+    raise AssertionError("expected an unknown provider to raise")
+
+
+def test_open_model_detectors_construct_without_weights():
+    for det in (OwlV2Detector(), GroundingDinoDetector(), MolmoDetector()):
+        assert det._model is None and det._processor is None
+
+
+# --- threshold sweep / re-scoring from the cache ----------------------------
+
+def _one_pano(preds):
+    """One pano with a single GT ramp at the origin, in unit coordinates."""
+    return [(preds, GroundTruth([(0.0, 0.0)], [], True))]
+
+
+def test_rescore_drops_predictions_below_the_threshold():
+    scored = _one_pano([(0.0, 0.0, 0.9), (0.5, 0.5, 0.1)])   # one TP, one FP
+    lo = rescore(scored, radius_sq_for(), 0.0)
+    assert (lo.tp, lo.fp, lo.precision, lo.recall) == (1, 1, 0.5, 1.0)
+    hi = rescore(scored, radius_sq_for(), 0.5)                        # the FP is gone
+    assert (hi.tp, hi.fp, hi.precision, hi.recall) == (1, 0, 1.0, 1.0)
+
+
+def test_rescore_never_drops_unscored_predictions():
+    # A chat VLM has nothing to threshold on; filtering it would silently empty it.
+    scored = _one_pano([(0.0, 0.0, None)])
+    assert rescore(scored, radius_sq_for(), 0.9).tp == 1
+
+
+def test_has_confidences_requires_every_prediction_to_carry_one():
+    assert has_confidences(_one_pano([(0.0, 0.0, 0.9)]))
+    assert not has_confidences(_one_pano([(0.0, 0.0, 0.9), (0.5, 0.5, None)]))
+    assert not has_confidences(_one_pano([]))     # nothing detected: no curve to draw
+
+
+def test_sweep_rows_stop_at_the_highest_score_present():
+    rows = sweep_rows(_one_pano([(0.0, 0.0, 0.22)]), radius_sq_for())
+    assert [t for t, _ in rows] == [0.05, 0.1, 0.15, 0.2]   # 0.25+ would be all-empty
+    assert all(r.tp == 1 for _, r in rows)
+
+
 class _UnloadableDetector:
     """Stands in for Qwen on a laptop: it can describe itself but cannot load."""
     name = "unloadable"
@@ -238,9 +475,9 @@ def test_score_model_skips_model_load_when_fully_cached(tmp_path):
     det = _UnloadableDetector()
     cache = DetectionCache(str(tmp_path))
     cache.put(cache_key("unloadable", det.signature(), "richmond", "p1"), [(0.1, 0.1, None)])
-    report, failures = score_model(det, records, verdicts, "", radius_sq_for(),
-                                   "unloadable", "richmond", cache)
-    assert report.n_panos == 1 and report.tp == 1 and not failures
+    run = score_model(det, records, verdicts, "", radius_sq_for(),
+                      "unloadable", "richmond", cache)
+    assert run.report.n_panos == 1 and run.report.tp == 1 and not run.failures
 
 
 def test_score_model_loads_model_on_a_cache_miss(tmp_path):
@@ -259,11 +496,12 @@ def test_score_model_isolates_pano_failures():
     verdicts = {pid: {"dets": [], "missed": [{"x": 0.5, "y": 0.5}], "no_missed": True}
                 for pid in ("good", "bad")}
     det = _FlakyDetector()
-    report, failures = score_model(det, records, verdicts, "", radius_sq_for(),
-                                   "flaky", "city", DetectionCache("x", enabled=False))
-    assert report.n_panos == 1                       # only 'good' scored
-    assert len(failures) == 1 and failures[0][0] == "bad"
+    run = score_model(det, records, verdicts, "", radius_sq_for(),
+                      "flaky", "city", DetectionCache("x", enabled=False))
+    assert run.report.n_panos == 1                   # only 'good' scored
+    assert len(run.failures) == 1 and run.failures[0][0] == "bad"
     assert det.calls == 2                            # both panos attempted
+    assert len(run.scored) == 1                      # the failed pano isn't re-scorable
 
 
 def test_bundle_rampnet_detector_reads_records():
@@ -349,6 +587,26 @@ def test_vlm_tiled_detect_dedups_overlapping_views(tmp_path):
     v = View(0.0, -30.0, 90.0, 90.0, 256, 256)
     det = _FakeTiledVLM([(0.5, 0.5, None)], tile=True, views=[v, v])
     assert len(det.detect(sample)) == 1
+
+
+def test_vlm_tiled_detect_preserves_scores_and_keeps_the_best_duplicate(tmp_path):
+    # A scored detector (OWLv2/GDINO) must come out of the tiled path with its
+    # confidences intact — everything downstream (AP, PR curve, sweep) needs them —
+    # and a cross-view duplicate must resolve to the higher-scoring copy.
+    from equirect_tiling import View
+    pano = tmp_path / "p.jpg"
+    _write_equirect(pano)
+    sample = PanoSample("p", str(pano), 256, 128, {})
+    v = View(0.0, -30.0, 90.0, 90.0, 256, 256)
+    det = _FakeTiledVLM([(0.5, 0.5, 0.42)], tile=True, views=[v])
+    assert [p[2] for p in det.detect(sample)] == [0.42]
+
+    class _Varying(_FakeTiledVLM):
+        def _raw_detect(self, image):
+            self._n = getattr(self, "_n", 0) + 1
+            return [(0.5, 0.5, 0.3 * self._n)]      # same spot, rising score
+    dets = _Varying([], tile=True, views=[v, v]).detect(sample)
+    assert len(dets) == 1 and dets[0][2] == 0.6
 
 
 # --- pre-flight bundle validation -------------------------------------------

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -278,6 +278,18 @@ def test_molmo_v2_keeps_points_near_the_left_and_top_edges():
         [0.042, 0.007], [0.5, 0.5]]
 
 
+def test_molmo_v2_survives_a_generation_truncated_mid_triplet():
+    # A completion cut off by max_new_tokens can end mid-triplet, shifting the
+    # token count so it mimics the other index convention. The id column
+    # (1, 2, 3, ...) decides the alignment, so the complete points still parse
+    # instead of every pair sliding into in-frame garbage pinned near x~0 —
+    # the same quiet failure the image-index fix was about.
+    with_index = '<points coords="1 1 308 305 2 752"/>'       # lost y2
+    assert [p["point"] for p in molmo_points_from_text(with_index)] == [[0.308, 0.305]]
+    without_index = '<points coords="1 354 612 2"/>'          # lost x2 y2
+    assert [p["point"] for p in molmo_points_from_text(without_index)] == [[0.354, 0.612]]
+
+
 def test_molmo_v2_accepts_separators_and_a_bare_triplet_list():
     assert [p["point"] for p in molmo_points_from_text(
         '<points coords="1 1 354 612; 2 700 480"/>')] == [[0.354, 0.612], [0.7, 0.48]]
@@ -478,6 +490,17 @@ def test_sweep_rows_stop_at_the_highest_score_present():
     rows = sweep_rows(_one_pano([(0.0, 0.0, 0.22)]), radius_sq_for())
     assert [t for t, _ in rows] == [0.05, 0.1, 0.15, 0.2]   # 0.25+ would be all-empty
     assert all(r.tp == 1 for _, r in rows)
+
+
+def test_sweep_rows_drop_thresholds_below_the_cache_floor():
+    # With a raised --score-threshold the cache holds nothing below the floor, so
+    # sweep rows down there would silently repeat the floor row while reading as
+    # real measurements. They must be dropped, not printed.
+    scored = _one_pano([(0.0, 0.0, 0.9)])
+    assert [t for t, _ in sweep_rows(scored, radius_sq_for(), floor=0.2)] == [
+        0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+    # No floor (RampNet's bundle detections): the full range, as before.
+    assert sweep_rows(scored, radius_sq_for())[0][0] == 0.05
 
 
 class _UnloadableDetector:


### PR DESCRIPTION
Closes part of #39 — the wiring **and the runs**: OWLv2, Grounding DINO, and Molmo2-8B are scored on both cities (Hyak, L40S), and the results tables live in `docs/model_comparison.md`. Still open from #39: `MolmoPoint-8B` (wired, never met real weights), `Molmo2-O-7B`, and the 32B-FP8 nice-to-have.

Every model scored before this PR was a chat VLM doing localization as a side skill, and they lose the same way: 119–293 false positives against RampNet's 9. This adds the two model classes built to *detect* (open-vocab) or *point* (Molmo) rather than chat, so "the weakness is specifically a *chat* problem" gets tested rather than assumed. **The runs say it isn't:** the open-vocab detectors do far *worse* than the chat VLMs (OWLv2's best sweep F1 0.184, Grounding DINO 0.073, vs Gemini-3.6-flash 0.634), while Molmo2-8B lands as the best open-weight challenger (F1 0.457 richmond / 0.449 bend) — balanced P≈R, no FP flood — yet still ~0.4 F1 behind RampNet. OWLv2's consolation prize is a 0.971 recall ceiling that recovers 69 of RampNet's 72 richmond misses, but at ~128 FP per recovered ramp it is a recall oracle, not a usable candidate generator. (These stay general, off-the-shelf models given a short untuned query — not detectors trained for curb ramps; the only purpose-built model here is RampNet. See "Scope of the claim" in the doc.)

## Open-vocabulary detectors — the substantive part

`OwlV2Detector` (`google/owlv2-large-patch14-ensemble`) and `GroundingDinoDetector` (`IDEA-Research/grounding-dino-base`) emit a **calibrated per-box score**, and that score is now carried end to end — `pixel_boxes_to_points` → `dedup_points` (keeps the higher-scoring copy of a cross-view duplicate) → `score_pano`'s confidence-ordered greedy match. That gives the harness, for the first time on a non-RampNet model:

- **AP** — new table column; `aggregate()` computes it via `rampnet.metrics` when every prediction carries a score. Chat VLMs read `-`.
- **PR curves** — `--pr-out DIR` writes JSON per model plus a combined PNG.
- **A threshold sweep** (`--sweep`) and a re-scored operating point (`--op-threshold`).

Both are free: detections cache down to a score **floor** (`--score-threshold`, default 0.05, part of the cache key), and every higher operating point re-scores that cache with no second model run. This is what the recall-first direction needs — a detector you can tune beats a chat model pinned at one point.

## Molmo — points, not boxes

`MolmoDetector` removes the box→center reduction every other challenger needs. `MolmoPoint`'s special-token path (`extract_image_points` + constrained decoding) is wired separately, selected by model id.

## Three findings

1. **Molmo's coordinate scale is not uniformly 0–100**, as the issue assumed. Molmo 1 emits percentages in `<point x= y=>`; **Molmo 2 emits 0–1000** triplets in `<points coords="…"/>`, per its own model card. The two differ *syntactically*, so the scale is inferred per tag (unlike Qwen's case, where both conventions looked identical) — `--molmo-coord-scale` overrides. Out-of-frame points are dropped, so a wrong scale fails loudly ("detected nothing") instead of biasing quietly.
2. **OWLv2's padded-square box frame is already handled by transformers.** Its processor pads to `max(h, w)` before resize, but current `_scale_boxes` scales by `max(h, w)` internally — verified on a 2:1 crop, where both target-size conventions put the top box at y 0.815 against a true 0.817. `owlv2_target_size` keeps the square anyway: it is also correct under the older per-axis scaling, and it states the frame the caller normalizes against rather than relying on a library internal.
3. **RampNet's AP is truncated and not comparable to the detectors'.** Its bundle detections were extracted at a 0.5 peak threshold, so its curve has no low-confidence tail (every sweep row below 0.5 is identical) and AP 0.763 richmond / 0.754 bend is a **lower bound**. Documented as a caveat: compare operating points against RampNet, or re-extract at a lower peak threshold.

## Also

- `dump_detections.py` draws all three prediction shapes: boxes, **scored** boxes (score printed — it's the number the sweep tunes), and points.
- The curb-ramp definition is factored into `CURB_RAMP_DEFINITION`, shared by the box and point prompts. `DETECTION_PROMPT` is **byte-identical**, so `test_gemini_cache_key_is_frozen` still pins `b4401afc…` and the thousands of already-paid Gemini detections still hit the cache.
- `compare.py` now skips a model that fails to load for *any* reason (printing the exception type) rather than only `ImportError`/`RuntimeError` — a checkpoint whose remote code won't load must not cost a multi-model cluster run the models that already ran.
- `run_open_models.slurm`: Hyak launcher for the new leg.

## Verification status

- **OWLv2 / Grounding DINO:** 2-pano desktop wiring probe first (scores carried through, boxes on ramps, cache reuse and model-load skip confirmed), then the full Hyak runs. Desktop (RTX 3070) and cluster (L40S) produced *identical* numbers on the probe, so a desktop rehearsal is faithful.
- **Molmo2-8B: verified, then run.** The overlay-first discipline paid for itself — the first real run put every point on the left edge, because Molmo 2's `coords` list opens with an **image index** the parser mistook for a point id. Fixed (a verbatim-output regression test pins it), overlay re-confirmed crosshairs on ramps, then both cities run and scored. It needs a **dedicated env** at the model cards' `transformers==4.57.1` pin — the pin is real, not cautionary; 5.x fails at import inside Molmo's own Hub code (runbook has the recipe).
- **MolmoPoint-8B remains wired but unverified** — it has never met real weights.

RampNet's own rows reproduce exactly: 0.964/0.768 richmond, 0.961/0.761 bend.

## Review follow-ups

A post-run review pass (`f1e437d`) tightened three things: the `--sweep` table drops thresholds below the detector's cache floor (rows down there silently repeated the floor row while reading as real measurements); the Molmo triplet parser decides its alignment by the point-id column (1, 2, 3, …) rather than token count alone, so a generation truncated mid-triplet can no longer misalign every pair into in-frame garbage near x≈0; and the scorer's `prediction_confidence` helper is shared with the CLI instead of duplicated. Deliberately *not* done: pinning HF revisions into detector signatures — it would invalidate every already-paid cached detection, so it needs its own design pass (follow-up issue material).

## Tests

37 new tests; full suite **137 pass** (rebased onto #33's matcher refactor, numbers unchanged).

The first commit is unrelated pending work from the in-flight Qwen run (`sbatch -A`, `PYTHON` override, one-node GPU request), committed separately so it isn't tangled in this.

Refs #20, #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
