### PR TITLE
Add the Hyak operator runbook for the model-comparison runs

### DIFF
--- a/hyak_qwen_runbook.sh
+++ b/hyak_qwen_runbook.sh
@@ -1,0 +1,312 @@
+#!/bin/bash
+# ============================================================================
+#  Qwen3-VL benchmark run on Hyak (klone) — self-contained runbook.
+#
+#  UNTRACKED: this file is a scratch operator script, like the earlier
+#  hyak_runbook.sh. Do not commit it.
+#
+#  Claude cannot drive klone (gssapi/keyboard-interactive only — UW password +
+#  Duo on every connection), so you run these stages. Each is idempotent and
+#  safe to re-run.
+#
+#  Usage on klone:   bash hyak_qwen_runbook.sh <stage>
+#  Stages:           env | weights | smoke | run | run32b | status | collect
+#  Open models (#39): weightsopen | smokeopen | runopen | runmolmo
+#  Windows-side:     bash hyak_qwen_runbook.sh push   (prints the rsync commands)
+#
+#  CRITICAL PATH — start the two slow things first, they overlap:
+#    1. (Windows/WSL) start the richmond pano upload   ~364 MB
+#    2. (klone login) `env` then `weights`             ~16 GB checkpoint
+#    3. (klone login) `smoke`, then `run`
+#  Bend (~1.7 GB) can upload while richmond is already running.
+# ============================================================================
+set -euo pipefail
+
+REPO="${REPO:-$HOME/RampNet}"
+USER="${USER:-$(whoami)}"          # set -u would trip on this off-cluster
+export HF_HOME="${HF_HOME:-/gscratch/scrubbed/$USER/hf}"
+QWEN_8B="Qwen/Qwen3-VL-8B-Instruct"
+QWEN_32B="Qwen/Qwen3-VL-32B-Instruct"
+OWLV2="google/owlv2-large-patch14-ensemble"
+GDINO="IDEA-Research/grounding-dino-base"
+MOLMO="${MOLMO:-allenai/Molmo2-8B}"
+STAGE="${1:-help}"
+
+banner() { echo; echo "=== $* ==="; echo; }
+
+case "$STAGE" in
+
+# ---------------------------------------------------------------------------
+help|push)
+  cat <<'TXT'
+Run these from a shell that has rsync (on Windows: WSL). Define a `klone` host in
+~/.ssh/config pointing at klone.hyak.uw.edu with your UW netid, or substitute
+<netid>@klone.hyak.uw.edu below. Each connection wants your UW password + Duo,
+so add ControlMaster/ControlPath/ControlPersist to that host block and every
+later connection reuses the first one. Start step 1 now and let it run in the
+background.
+
+  cd <parent directory of your RampNet checkout>
+
+  # 1. Repo (fast). Excludes the venv, the local Gemini cache, and the imagery.
+  rsync -av --exclude .venv --exclude .model_cache --exclude 'benchmark/*/panos' \
+        --exclude 'benchmark/*/gallery' --exclude view_dump \
+        RampNet/ klone:~/RampNet/
+
+  # 2. Richmond imagery — 364 MB, the fast path to a first number.
+  rsync -av --partial --progress \
+        RampNet/benchmark/richmond/panos/ klone:~/RampNet/benchmark/richmond/panos/
+
+  # 3. Bend imagery — 1.7 GB. Start it after richmond is running on the cluster.
+  rsync -av --partial --progress \
+        RampNet/benchmark/bend/panos/ klone:~/RampNet/benchmark/bend/panos/
+
+Send the NATIVE panos, not downscaled copies. The harness downscales in-process
+to 4096 px; pre-resizing would re-encode the JPEG, and a past gold-set re-eval
+showed JPEG re-encoding alone moved P by +2.2 and R by -1.8 pts. Not worth
+saving upload time on a benchmark number.
+
+  # 4. When the run finishes, pull the detections back (they score with no GPU):
+  rsync -av klone:~/RampNet/.model_cache/ RampNet/.model_cache/
+TXT
+  ;;
+
+# ---------------------------------------------------------------------------
+env)
+  banner "Conda env + VLM deps (login node)"
+  cd "$REPO"
+  if ! conda env list | grep -q '^sidewalkcv2 '; then
+    # CONDA_OVERRIDE_CUDA is load-bearing: solving on a GPU-less login node makes
+    # conda-forge silently pick CPU-only pytorch, and Qwen then crawls on CPU
+    # while the allocated GPU idles.
+    CONDA_OVERRIDE_CUDA=12.6 conda env create -f environment.yml
+  else
+    echo "sidewalkcv2 already exists; skipping create"
+  fi
+  # shellcheck disable=SC1091
+  source activate sidewalkcv2
+
+  # environment.yml pins an unpinned conda `transformers`, usually older than the
+  # 4.57 that first shipped Qwen3-VL. Upgrade via pip; transformers has no torch
+  # dependency, so this cannot clobber the CUDA build.
+  pip install -r requirements-vlm.txt
+
+  banner "Verify — CUDA build survived, and Qwen3-VL is importable"
+  python - <<'PY'
+import torch, transformers
+print("torch       ", torch.__version__, "cuda_available:", torch.cuda.is_available())
+print("transformers", transformers.__version__)
+ok = hasattr(transformers, "Qwen3VLForConditionalGeneration")
+print("Qwen3VLForConditionalGeneration present:", ok)
+if "cpu" in torch.__version__ or not ok:
+    raise SystemExit("STOP: CPU-only torch or missing Qwen3-VL. Recreate the env "
+                     "with CONDA_OVERRIDE_CUDA=12.6 / upgrade transformers.")
+PY
+  echo "(torch.cuda.is_available() is False on a login node — that's expected; "
+  echo " the check above is that the build is not the '+cpu' one.)"
+  echo "OK. Next: bash hyak_qwen_runbook.sh weights"
+  ;;
+
+# ---------------------------------------------------------------------------
+weights)
+  banner "Pre-download checkpoints to $HF_HOME (login node, not GPU time)"
+  cd "$REPO"
+  # shellcheck disable=SC1091
+  source activate sidewalkcv2
+  mkdir -p "$HF_HOME"
+  for M in "$QWEN_8B" "${DOWNLOAD_32B:+$QWEN_32B}"; do
+    [ -z "$M" ] && continue
+    echo "--- $M"
+    python - "$M" <<'PY'
+import sys
+from huggingface_hub import snapshot_download
+p = snapshot_download(sys.argv[1], allow_patterns=[
+    "*.json", "*.txt", "*.safetensors", "*.model", "*.py"])
+print("cached at", p)
+PY
+  done
+  df -h "$HF_HOME" | tail -1
+  echo "OK. Next: bash hyak_qwen_runbook.sh smoke"
+  echo "(For 32B later: DOWNLOAD_32B=1 bash hyak_qwen_runbook.sh weights)"
+  ;;
+
+# ---------------------------------------------------------------------------
+smoke)
+  banner "2-pano GPU smoke — proves env + weights + box mapping on the cluster"
+  cd "$REPO"
+  mkdir -p logs
+  INNER="$(mktemp)"
+  cat > "$INNER" <<INNER_EOF
+set -euo pipefail
+source activate sidewalkcv2
+export HF_HOME="$HF_HOME"
+nvidia-smi --query-gpu=name,memory.total --format=csv
+python -u scripts/model_comparison/compare.py benchmark/richmond \\
+    --models rampnet,qwen:$QWEN_8B --limit 2
+# Visual check: boxes should sit on the ramps. Copy the contact sheet back and
+# look at it before committing to the full run.
+python -u scripts/model_comparison/dump_detections.py benchmark/richmond \\
+    --model qwen:$QWEN_8B --out view_dump/qwen8b
+INNER_EOF
+  # salloc + srun (not a heredoc piped into salloc's shell, which is unreliable
+  # and non-interactive). HF_HOME is baked into the inner script above.
+  salloc -p gpu-l40s --gpus=1 --mem=64G --cpus-per-task=8 --time=1:00:00 \
+      srun bash "$INNER" || true
+  rm -f "$INNER"
+  echo
+  echo "Sanity: the rampnet row must read P 0.9-1.0 on those 2 panos (it reads"
+  echo "detections from the bundle, so anything else means the bundle is wrong)."
+  echo "Then scp view_dump/qwen8b/contact_*.png back and eyeball it."
+  echo "OK. Next: bash hyak_qwen_runbook.sh run"
+  ;;
+
+# ---------------------------------------------------------------------------
+run)
+  banner "Full 8B runs (richmond first, then bend)"
+  cd "$REPO"
+  mkdir -p logs
+  sbatch scripts/model_comparison/run_qwen.slurm
+  if [ -d benchmark/bend/panos ] && [ "$(ls -A benchmark/bend/panos)" ]; then
+    BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_qwen.slurm
+  else
+    echo "benchmark/bend/panos is empty — submit it once the upload lands:"
+    echo "  BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_qwen.slurm"
+  fi
+  squeue -u "$USER"
+  ;;
+
+# ---------------------------------------------------------------------------
+run32b)
+  banner "32B runs — two GPUs, device_map=auto shards the ~64 GB checkpoint"
+  cd "$REPO"
+  mkdir -p logs
+  QWEN_MODEL="$QWEN_32B" sbatch --gpus=2 scripts/model_comparison/run_qwen.slurm
+  QWEN_MODEL="$QWEN_32B" BUNDLE=benchmark/bend sbatch --gpus=2 scripts/model_comparison/run_qwen.slurm
+  squeue -u "$USER"
+  ;;
+
+# ---------------------------------------------------------------------------
+status)
+  squeue -u "$USER"
+  echo
+  for f in $(ls -t "$REPO"/logs/qwen_compare_*.out 2>/dev/null | head -3); do
+    echo "--- $f"
+    tail -20 "$f"
+  done
+  echo
+  echo "Cached detections so far: $(find "$REPO/.model_cache" -name '*.json' 2>/dev/null | wc -l)"
+  ;;
+
+# ---------------------------------------------------------------------------
+collect)
+  banner "Detections are in $REPO/.model_cache — pull them home"
+  find "$REPO/.model_cache" -name '*.json' | wc -l
+  echo "From your machine:"
+  echo "  rsync -av klone:~/RampNet/.model_cache/ <local RampNet checkout>/.model_cache/"
+  echo
+  echo "Then locally, no GPU needed (score_model skips the model load when"
+  echo "everything is cached):"
+  echo "  python scripts/model_comparison/compare.py benchmark/richmond \\"
+  echo "      --models rampnet,gemini:gemini-3.6-flash,gemini:gemini-3.1-pro-preview,qwen:$QWEN_8B"
+  ;;
+
+# ---------------------------------------------------------------------------
+#  Open detectors + pointing models (issue #39). OWLv2 and Grounding DINO are
+#  ~1-2 GB and finish in minutes; they emit calibrated scores, so their runs give
+#  AP / PR curves / a threshold sweep. Molmo-8B is a text generator and takes
+#  hours -- and its wiring has never met real weights, so eyeball it first.
+# ---------------------------------------------------------------------------
+weightsopen)
+  banner "Pre-download the open-detector checkpoints (~2 GB total)"
+  cd "$REPO"
+  # shellcheck disable=SC1091
+  source activate sidewalkcv2
+  mkdir -p "$HF_HOME"
+  for M in "$OWLV2" "$GDINO" ${DOWNLOAD_MOLMO:+$MOLMO}; do
+    echo "--- $M"
+    python - "$M" <<'PY'
+import sys
+from huggingface_hub import snapshot_download
+print("cached at", snapshot_download(sys.argv[1], allow_patterns=[
+    "*.json", "*.txt", "*.safetensors", "*.model", "*.py"]))
+PY
+  done
+  echo "OK. Next: bash hyak_qwen_runbook.sh smokeopen"
+  echo "(Molmo too: DOWNLOAD_MOLMO=1 bash hyak_qwen_runbook.sh weightsopen)"
+  ;;
+
+# ---------------------------------------------------------------------------
+smokeopen)
+  banner "2-pano GPU smoke for OWLv2 + Grounding DINO, then a box overlay"
+  cd "$REPO"
+  mkdir -p logs
+  INNER="$(mktemp)"
+  cat > "$INNER" <<INNER_EOF
+set -euo pipefail
+source activate sidewalkcv2
+export HF_HOME="$HF_HOME"
+nvidia-smi --query-gpu=name,memory.total --format=csv
+python -u scripts/model_comparison/compare.py benchmark/richmond \\
+    --models rampnet,owlv2,gdino --limit 2 --sweep
+# Boxes should sit on ramps. 0.15 just declutters the overlay.
+python -u scripts/model_comparison/dump_detections.py benchmark/richmond \\
+    --model owlv2 --score-threshold 0.15 --out view_dump/owlv2
+INNER_EOF
+  salloc -p gpu-l40s --gpus=1 --mem=64G --cpus-per-task=8 --time=1:00:00 \
+      srun bash "$INNER" || true
+  rm -f "$INNER"
+  echo
+  echo "Expect: both models FP-heavy at the 0.05 floor but with high recall, and"
+  echo "the sweep showing what tightening the threshold buys. scp the contact"
+  echo "sheet back before committing to the full run."
+  echo "OK. Next: bash hyak_qwen_runbook.sh runopen"
+  ;;
+
+# ---------------------------------------------------------------------------
+runopen)
+  banner "Full OWLv2 + Grounding DINO runs (minutes, one card)"
+  cd "$REPO"
+  mkdir -p logs
+  sbatch scripts/model_comparison/run_open_models.slurm
+  if [ -d benchmark/bend/panos ] && [ "$(ls -A benchmark/bend/panos)" ]; then
+    BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_open_models.slurm
+  else
+    echo "benchmark/bend/panos is empty — submit it once the upload lands:"
+    echo "  BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_open_models.slurm"
+  fi
+  squeue -u "$USER"
+  ;;
+
+# ---------------------------------------------------------------------------
+runmolmo)
+  banner "Molmo — VERIFY THE OVERLAY FIRST, this path has never seen real weights"
+  cd "$REPO"
+  mkdir -p logs
+  # Molmo runs its own Hub code and its card pins transformers==4.57.1; if the
+  # load fails on a newer transformers, build it a separate env at that pin
+  # rather than downgrading the env the other models use.
+  INNER="$(mktemp)"
+  cat > "$INNER" <<INNER_EOF
+set -euo pipefail
+source activate sidewalkcv2
+export HF_HOME="$HF_HOME"
+python -u scripts/model_comparison/dump_detections.py benchmark/richmond \\
+    --model molmo:$MOLMO --out view_dump/molmo
+INNER_EOF
+  salloc -p gpu-l40s --gpus=1 --mem=64G --cpus-per-task=8 --time=1:00:00 \
+      srun bash "$INNER" || true
+  rm -f "$INNER"
+  echo
+  echo "Look at view_dump/molmo/contact_*.png. Red crosshairs must sit ON ramps."
+  echo "Nothing detected at all => the coordinate scale is wrong; re-run with"
+  echo "  --molmo-coord-scale 100   (or 1000)"
+  echo "Only once that looks right:"
+  echo "  MODELS=rampnet,molmo:$MOLMO sbatch scripts/model_comparison/run_open_models.slurm"
+  ;;
+
+*)
+  echo "unknown stage '$STAGE' (env | weights | smoke | run | run32b | status |"
+  echo "collect | push | weightsopen | smokeopen | runopen | runmolmo)"
+  exit 2
+  ;;
+esac

--- a/hyak_qwen_runbook.sh
+++ b/hyak_qwen_runbook.sh
@@ -2,8 +2,9 @@
 # ============================================================================
 #  Qwen3-VL benchmark run on Hyak (klone) — self-contained runbook.
 #
-#  UNTRACKED: this file is a scratch operator script, like the earlier
-#  hyak_runbook.sh. Do not commit it.
+#  Tracked operator runbook — this repo commits its .slurm launchers, and a
+#  runbook is the same kind of artifact. Paths and identity are parameterized
+#  ($USER, $REPO, netid placeholders in `push`), so edit nothing to run it.
 #
 #  Claude cannot drive klone (gssapi/keyboard-interactive only — UW password +
 #  Duo on every connection), so you run these stages. Each is idempotent and
@@ -24,6 +25,9 @@ set -euo pipefail
 
 REPO="${REPO:-$HOME/RampNet}"
 USER="${USER:-$(whoami)}"          # set -u would trip on this off-cluster
+# HF cache lives on scratch (home quota is tiny). NOTE: /gscratch/scrubbed is
+# auto-purged after ~21 idle days, so a much-later run may need `weights` /
+# `weightsopen` again — both are idempotent, so re-fetching is cheap.
 export HF_HOME="${HF_HOME:-/gscratch/scrubbed/$USER/hf}"
 QWEN_8B="Qwen/Qwen3-VL-8B-Instruct"
 QWEN_32B="Qwen/Qwen3-VL-32B-Instruct"
@@ -215,6 +219,9 @@ collect)
 #  ~1-2 GB and finish in minutes; they emit calibrated scores, so their runs give
 #  AP / PR curves / a threshold sweep. Molmo-8B is a text generator and takes
 #  hours -- and its wiring has never met real weights, so eyeball it first.
+#
+#  These stages drive scripts/model_comparison/run_open_models.slurm, which ships
+#  with PR #40 — merge this runbook AFTER #40 or `runopen` aborts with a guard.
 # ---------------------------------------------------------------------------
 weightsopen)
   banner "Pre-download the open-detector checkpoints (~2 GB total)"
@@ -267,12 +274,14 @@ runopen)
   banner "Full OWLv2 + Grounding DINO runs (minutes, one card)"
   cd "$REPO"
   mkdir -p logs
-  sbatch scripts/model_comparison/run_open_models.slurm
+  SLURM_OPEN=scripts/model_comparison/run_open_models.slurm
+  [ -f "$SLURM_OPEN" ] || { echo "$SLURM_OPEN missing — it ships with PR #40; merge that first."; exit 2; }
+  sbatch "$SLURM_OPEN"
   if [ -d benchmark/bend/panos ] && [ "$(ls -A benchmark/bend/panos)" ]; then
-    BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_open_models.slurm
+    BUNDLE=benchmark/bend sbatch "$SLURM_OPEN"
   else
     echo "benchmark/bend/panos is empty — submit it once the upload lands:"
-    echo "  BUNDLE=benchmark/bend sbatch scripts/model_comparison/run_open_models.slurm"
+    echo "  BUNDLE=benchmark/bend sbatch $SLURM_OPEN"
   fi
   squeue -u "$USER"
   ;;


### PR DESCRIPTION
The stage-by-stage script actually used to run the Qwen benchmark on klone end to end. Kept as an executable runbook rather than prose, because every step of it has now been run for real.

**Scope changed since this PR was opened — please read.** #41 originally also carried three launcher/dependency fixes (`-A` required, `--nodes=1` for multi-GPU, torchvision). Those are now **redundant**: #40 has absorbed all of them. I verified rather than assumed — `scripts/model_comparison/run_qwen.slurm` is byte-identical between the two branches, `requirements-vlm.txt` has zero lines unique to mine, and the `docs/model_comparison.md` lines unique to mine are all older text that #40's version supersedes. Keeping them here would have guaranteed a three-file conflict for no gain, so I dropped them. **#40 is the PR that delivers those fixes.** This one is now a single new file.

## What it is

Stages: `push` (prints the rsync commands to stage repo + imagery), `env`, `weights`, `smoke`, `run`, `run32b`, `status`, `collect`, plus `weightsopen`, `smokeopen`, `runopen`, `runmolmo` for the open-detector and Molmo legs. Each is idempotent and safe to re-run.

It encodes the things that cost time to discover:

- **klone has no publickey auth** (`gssapi-keyex, gssapi-with-mic, keyboard-interactive` only), so an SSH control-master connection is the only way to avoid a password + Duo prompt on every single command.
- **Reuses the `sidewalkcv2` conda env** (`environment.yml`) rather than a bespoke one, but creates it with `CONDA_OVERRIDE_CUDA=12.6`: on a GPU-less login node conda-forge otherwise solves to CPU-only pytorch, and Qwen then crawls on CPU while the allocated GPU idles. `transformers` is then pip-upgraded (`requirements-vlm.txt`) to the ≥4.57 that first shipped Qwen3-VL — transformers carries no torch dependency, so that can't clobber the CUDA build.
- **Weights are pre-fetched on a login node**, so GPU time isn't spent on a 17–79 GB download.
- **Ship NATIVE panos.** Tempting to pre-downscale (bend is 1.7 GB and the harness only uses 4096 px), but re-encoding the JPEG moved P +2.2 / R −1.8 on its own in the gold-set re-eval. Not a trade worth making on a benchmark number.
- **The smoke stage** runs two panos plus a box overlay before anything long is queued.

Paths and identity are parameterized (`$USER`, placeholders for the local checkout and netid) so it isn't specific to one operator.

## Why track it at all

The earlier `hyak_runbook.sh` was deliberately untracked, and I initially followed that convention here. On reflection it doesn't apply: that one was a one-off for a since-finished task, whereas this is already shared infrastructure — the open-detector work extended it with four new stages before this PR existed. This repo also already commits its `.slurm` launchers, and a runbook is the same category of artifact.

## Note

The `*open` stages call `scripts/model_comparison/run_open_models.slurm`, which arrives with #40 — **merge this after #40**, or those four stages will reference a file that isn't there yet.

Refs #20, #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

