### PR TITLE
Fix import-broken analysis scripts (_confidence -> prediction_confidence)

### DIFF
--- a/scripts/analysis/complementarity.py
+++ b/scripts/analysis/complementarity.py
@@ -14,7 +14,7 @@ sys.path.insert(0, REPO)
 sys.path.insert(0, os.path.join(REPO, "scripts", "model_comparison"))
 
 from rampnet.detection_eval import (
-    build_ground_truth, score_pano, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, _confidence)
+    build_ground_truth, score_pano, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, prediction_confidence)
 from compare import load_bundle, DetectionCache, cache_key
 from detectors import build_detector
 
@@ -27,7 +27,7 @@ RSQ = radius_sq_for()
 
 def matched_gt(preds, gt_points):
     """Greedy 1:1 match (mirrors score_pano); return the set of GT indices covered."""
-    confs = [_confidence(p) for p in preds]
+    confs = [prediction_confidence(p) for p in preds]
     order = (sorted(range(len(preds)), key=lambda i: confs[i] if confs[i] is not None else float("-inf"),
                     reverse=True) if any(c is not None for c in confs) else range(len(preds)))
     claimed, hit = [False] * len(gt_points), set()

--- a/scripts/analysis/depth_extract_da3.py
+++ b/scripts/analysis/depth_extract_da3.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.join(REPO, "scripts", "model_comparison"))
 import numpy as np
 import torch
 from rampnet.detection_eval import (
-    build_ground_truth, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, _confidence)
+    build_ground_truth, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, prediction_confidence)
 from compare import load_bundle, DetectionCache, cache_key
 from detectors import build_detector, load_pano_image
 from equirect_tiling import default_views, equirect_to_perspective, equirect_point_to_perspective
@@ -55,7 +55,7 @@ def dist2(p, q):
 
 
 def matched_gt(preds, gt_points):
-    confs = [_confidence(p) for p in preds]
+    confs = [prediction_confidence(p) for p in preds]
     order = (sorted(range(len(preds)), key=lambda i: confs[i] if confs[i] is not None else -1e9,
                     reverse=True) if any(c is not None for c in confs) else range(len(preds)))
     claimed, hit = [False] * len(gt_points), set()

--- a/scripts/analysis/miss_analysis.py
+++ b/scripts/analysis/miss_analysis.py
@@ -23,7 +23,7 @@ sys.path.insert(0, REPO)
 sys.path.insert(0, os.path.join(REPO, "scripts", "model_comparison"))
 
 from rampnet.detection_eval import (
-    build_ground_truth, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, _confidence)
+    build_ground_truth, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, prediction_confidence)
 from compare import load_bundle, DetectionCache, cache_key
 from detectors import build_detector
 
@@ -39,7 +39,7 @@ def d(p, q):
 
 
 def matched_gt(preds, gt_points):
-    confs = [_confidence(p) for p in preds]
+    confs = [prediction_confidence(p) for p in preds]
     order = (sorted(range(len(preds)), key=lambda i: confs[i] if confs[i] is not None else float("-inf"),
                     reverse=True) if any(c is not None for c in confs) else range(len(preds)))
     claimed, hit = [False] * len(gt_points), set()

--- a/scripts/analysis/overlap_test.py
+++ b/scripts/analysis/overlap_test.py
@@ -12,12 +12,12 @@ _os.makedirs(OUT, exist_ok=True)
 DA3_SRC = _os.environ.get("DA3_SRC")  # path to Depth-Anything-3/src (see README)
 import json, math, os, sys, warnings
 warnings.filterwarnings("ignore")
-sys.path.insert(0, HERE)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO); sys.path.insert(0, os.path.join(REPO, "scripts", "model_comparison"))
 import numpy as np, torch
 from threshold_sweep import load_model, load_bundle, heatmap_for, peaks_to_dets
 from rampnet.detection_eval import (build_ground_truth, radius_sq_for,
-                                    PANO_SCALE_X, PANO_SCALE_Y, _xy, _confidence)
+                                    PANO_SCALE_X, PANO_SCALE_Y, _xy, prediction_confidence)
 R = math.sqrt(radius_sq_for())
 THRS = [0.55, 0.35, 0.25, 0.15]
 
@@ -25,7 +25,7 @@ def d2(p, q):
     return math.hypot((p[0]-q[0])*PANO_SCALE_X, (p[1]-q[1])*PANO_SCALE_Y)
 
 def matched(preds, gts):
-    confs=[_confidence(p) for p in preds]
+    confs=[prediction_confidence(p) for p in preds]
     order=sorted(range(len(preds)), key=lambda i: confs[i] if confs[i] is not None else -1e9, reverse=True)
     claimed=[False]*len(gts); hit=set()
     for i in order:

--- a/scripts/analysis/precision_by_distance.py
+++ b/scripts/analysis/precision_by_distance.py
@@ -16,7 +16,7 @@ import math, os, sys, warnings
 warnings.filterwarnings("ignore")
 sys.path.insert(0, REPO); sys.path.insert(0, os.path.join(REPO, "scripts", "model_comparison"))
 from rampnet.detection_eval import (
-    build_ground_truth, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, _confidence)
+    build_ground_truth, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, prediction_confidence)
 from compare import load_bundle
 
 R = math.sqrt(radius_sq_for())

--- a/scripts/analysis/size_analysis.py
+++ b/scripts/analysis/size_analysis.py
@@ -23,7 +23,7 @@ sys.path.insert(0, REPO)
 sys.path.insert(0, os.path.join(REPO, "scripts", "model_comparison"))
 
 from rampnet.detection_eval import (
-    build_ground_truth, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, _confidence)
+    build_ground_truth, radius_sq_for, PANO_SCALE_X, PANO_SCALE_Y, _xy, prediction_confidence)
 from compare import load_bundle, DetectionCache, cache_key
 from detectors import build_detector
 
@@ -51,7 +51,7 @@ def dist(p, q):
 
 
 def matched_gt(preds, gt_points):
-    confs = [_confidence(p) for p in preds]
+    confs = [prediction_confidence(p) for p in preds]
     order = (sorted(range(len(preds)), key=lambda i: confs[i] if confs[i] is not None else -1e9,
                     reverse=True) if any(c is not None for c in confs) else range(len(preds)))
     claimed, hit = [False] * len(gt_points), set()


### PR DESCRIPTION
## What

The six `scripts/analysis/*.py` from #37 are **import-broken on `main`**: PR #42 renamed `rampnet.detection_eval._confidence` to the public `prediction_confidence`, but these scripts still import the old private name, so each fails immediately at import.

Mechanical fix:
- `_confidence` → `prediction_confidence` (import + call sites) in `complementarity.py`, `depth_extract_da3.py`, `miss_analysis.py`, `overlap_test.py`, `precision_by_distance.py`, `size_analysis.py`.
- Fix `overlap_test.py`'s separate `NameError` — `sys.path.insert(0, HERE)` with `HERE` never defined → the script's own dir, so `from threshold_sweep import ...` resolves.

## Verify
- All six `py_compile` clean.
- Every name they import from `detection_eval` (incl. `prediction_confidence`) now resolves.
- `overlap_test.py` (whose `*_test.py` name made pytest import it and break bare-`pytest` collection) now imports cleanly.

No behavior change — same values, renamed symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
