### PR TITLE
Peak-NMS check for #62: suppression at the match radius prunes real ramps

### DIFF
--- a/scripts/analysis/peak_nms_check.py
+++ b/scripts/analysis/peak_nms_check.py
@@ -1,0 +1,135 @@
+"""Would Euclidean peak-NMS at the match radius help? No — checked, it hurts.
+
+Issue #62 proposed suppressing extracted peaks that sit closer together than
+the match radius (min_distance=10 heatmap px vs R = 0.022*1024 = 22.5 px), on
+the theory that the matcher can score at most one of them. That theory silently
+assumes only one GT ramp is nearby. This script checks the committed benchmark
+records and finds the opposite:
+
+  - five of six splits contain detection pairs inside one match radius
+    (8 pairs across the reviewed cities, 63 in manual_gold);
+  - reviewers confirmed BOTH members real on 5 of the 8 reviewed pairs —
+    adjacent real ramps genuinely sit 0.67-0.83 R apart in pano space;
+  - real and junk pairs occupy the same 15-19 px separation band, so no
+    suppression radius can split them;
+  - rescoring with NMS applied lowers F1 on four of six splits (bend, whose
+    one redundant FP motivated #62, is the only split it helps) and costs
+    manual_gold 33 TPs to remove 8 FPs at the deployed 0.55 operating point.
+
+Conclusion: min_distance < R is load-bearing headroom for real adjacent ramps,
+not a defect. The matcher already charges redundant second hits as false
+positives, which is the right accounting. Full write-up in the #62 discussion.
+
+Pure CPU, no model rerun: NMS only prunes the recorded peak set, and
+keep-highest NMS commutes with threshold_abs (a suppressor always outscores
+the peak it suppresses, so it survives any threshold the suppressed one does),
+so applying it to records.jsonl reproduces exactly what
+(threshold, min_distance=10, +NMS-at-R) extraction would emit.
+
+    python scripts/analysis/peak_nms_check.py
+"""
+import json
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, REPO)
+
+from rampnet.detection_eval import (
+    PANO_SCALE_X, PANO_SCALE_Y, aggregate, build_ground_truth,
+    load_yolo_ground_truths, radius_sq_for, score_pano)
+
+VERDICT_CITIES = ("richmond", "bend", "clovis", "morgantown", "budapest_district5")
+RSQ = radius_sq_for()
+SX, SY = PANO_SCALE_X, PANO_SCALE_Y
+
+
+def suppress_duplicate_peaks(peaks, radius_sq, scale_x, scale_y):
+    """Keep-highest greedy Euclidean NMS over (x_norm, y_norm, confidence) peaks.
+
+    Deliberately local to this script, not in rampnet/: the whole point of the
+    analysis is that nothing in the production pipeline should apply it.
+    Returns (kept peaks in input order, indices of the pruned peaks).
+    """
+    order = sorted(range(len(peaks)), key=lambda i: (-peaks[i][2], i))
+    kept_scaled, kept_idx = [], set()
+    for i in order:
+        x, y = peaks[i][0] * scale_x, peaks[i][1] * scale_y
+        if all((x - kx) ** 2 + (y - ky) ** 2 >= radius_sq for kx, ky in kept_scaled):
+            kept_scaled.append((x, y))
+            kept_idx.add(i)
+    return ([p for i, p in enumerate(peaks) if i in kept_idx],
+            [i for i in range(len(peaks)) if i not in kept_idx])
+
+
+def load_records(city):
+    recs = {}
+    with open(os.path.join(REPO, "benchmark", city, "records.jsonl"), encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                r = json.loads(line)
+                recs[r["pano"]["panorama_id"]] = r
+    return recs
+
+
+def load_verdicts(city):
+    with open(os.path.join(REPO, "benchmark", city, "verdicts.json"), encoding="utf-8") as f:
+        return json.load(f)["panos"]
+
+
+def dets_as_tuples(rec):
+    return [(float(d["x_normalized"]), float(d["y_normalized"]), float(d["confidence"]))
+            for d in rec["detections"]]
+
+
+def report(name, scores):
+    rep = aggregate(scores)
+    ap = f" AP={rep.ap:.4f}" if rep.ap is not None else ""
+    print(f"  {name:36s} P={rep.precision:.4f} R={rep.recall:.4f} F1={rep.f1:.4f} "
+          f"tp={rep.tp} fp={rep.fp} fn={rep.fn}{ap}")
+
+
+def main():
+    print("=== (a) what NMS at the match radius would prune, and the reviewers' verdicts ===")
+    for city in VERDICT_CITIES:
+        recs, verdicts = load_records(city), load_verdicts(city)
+        for pid, entry in verdicts.items():
+            dets = dets_as_tuples(recs[pid])
+            _, pruned = suppress_duplicate_peaks(dets, RSQ, SX, SY)
+            for i in pruned:
+                print(f"  {city:18s} {pid}  pruned det #{i} conf={dets[i][2]:.2f} "
+                      f"verdict={entry['dets'][i]!r}")
+
+    print("\n=== (b) reviewed cities, scored as committed vs with NMS ===")
+    for city in VERDICT_CITIES:
+        recs, verdicts = load_records(city), load_verdicts(city)
+        for tag, use_nms in (("as committed", False), ("with NMS", True)):
+            scores = []
+            for pid, entry in verdicts.items():
+                gt = build_ground_truth(recs[pid]["detections"], entry["dets"],
+                                        entry["missed"], entry["no_missed"])
+                preds = dets_as_tuples(recs[pid])
+                if use_nms:
+                    preds, _ = suppress_duplicate_peaks(preds, RSQ, SX, SY)
+                scores.append(score_pano(preds, gt))
+            report(f"{city} {tag}", scores)
+
+    print("\n=== (c) manual_gold (YOLO GT), deployed 0.55 operating point and full sweep ===")
+    gts = load_yolo_ground_truths(os.path.join(REPO, "manual_labels"))
+    recs = load_records("manual_gold")
+    for thr in (0.55, 0.0):
+        for tag, use_nms in (("as committed", False), ("with NMS", True)):
+            scores, n_pruned = [], 0
+            for pid, rec in recs.items():
+                preds = [p for p in dets_as_tuples(rec) if p[2] >= thr]
+                if use_nms:
+                    preds, pruned = suppress_duplicate_peaks(preds, RSQ, SX, SY)
+                    n_pruned += len(pruned)
+                scores.append(score_pano(preds, gts[pid]))
+            report(f"manual_gold thr>={thr} {tag}", scores)
+            if use_nms:
+                print(f"    ({n_pruned} detections pruned at this threshold)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/threshold_sweep.py
+++ b/scripts/analysis/threshold_sweep.py
@@ -7,6 +7,11 @@ ground truth. Tests the two untested cheap recall levers:
   - min_distance below 10 (10 heatmap px = 40 pano px, vs a 90 px match radius, so
     adjacent ramps can collapse into one peak)
 
+min_distance must not be raised toward the match radius either: the committed
+records hold reviewer-confirmed REAL ramp pairs 15-19 heatmap px apart, in the
+same separation band as the rare duplicate — no suppression radius separates
+them (see scripts/analysis/peak_nms_check.py and the issue #62 discussion).
+
 Inference replicates sidewalk-auto-labeler/detectors/curb_ramp.py exactly
 (resize 2048x4096 bilinear, ImageNet norm, no TTA) so (0.55, 10) should reproduce
 the committed records.jsonl numbers.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -51,6 +51,21 @@ def test_nearest_unclaimed_gt_wins():
     assert details == [(0.9, True), (0.8, True)]
 
 
+def test_two_real_ramps_inside_one_match_radius_both_score():
+    # Issue #62: the committed benchmarks hold reviewer-confirmed pairs of real
+    # ramps only 0.67-0.83 R apart — inside one match radius. The matcher scores
+    # both as TPs because each claims its own GT point, which is exactly why
+    # peak extraction must NOT suppress peaks at the match radius: separation
+    # distance cannot tell these pairs from genuine duplicates
+    # (scripts/analysis/peak_nms_check.py quantifies the damage if it tried).
+    r2 = (0.022 * 1024) ** 2
+    sep = 15 / 1024  # 15 heatmap px = 0.67 R, the closest real pair on record
+    gts = [(0.5, 0.5), (0.5 + sep, 0.5)]
+    preds = [(0.5, 0.5, 0.9), (0.5 + sep, 0.5, 0.8)]
+    details = match_predictions(preds, gts, r2, 1024, 512)
+    assert details == [(0.9, True), (0.8, True)]
+
+
 def test_ap_perfect_detector():
     details = [(0.9, True), (0.8, True), (0.7, True)]
     ap, _, _, _, _ = calculate_ap_and_pr_curve(details, total_gt_points=3)


### PR DESCRIPTION
## Summary

#62 diagnosed a real geometric mismatch — `min_distance=10` is under half the 22.5 px match radius — but its proposed fix (suppressing extracted peaks at the match radius) turns out to be empirically wrong: **most of what it would prune are reviewer-confirmed real curb ramps.** This PR adds that check as a reproducible script, pins the load-bearing matcher behaviour with a regression test, and documents the finding where the next threshold sweep will see it. **No production behaviour changes.**

The full correction of the issue's fix-section claims (including the skimage `min_distance` Chebyshev/max-filter semantics) is in the #62 discussion.

## The check

NMS only prunes the recorded peak set, and keep-highest NMS commutes with `threshold_abs`, so applying it to the committed `records.jsonl` reproduces exactly what NMS-at-extraction would emit — no GPU rerun:

```bash
python scripts/analysis/peak_nms_check.py
```

The committed records contain 8 within-radius detection pairs across the five reviewed cities (and 63 in manual_gold). The reviewers' verdicts on those pairs:

| split | pano | separation | pair verdicts |
|---|---|---|---|
| richmond | 1309093164014619 | 15.0 px (0.67 R) | True / True |
| richmond | 1092133469495462 | 15.0 px (0.67 R) | True / True |
| richmond | 1288163659019705 | 17.0 px (0.75 R) | True / True |
| richmond | 1288163659019705 | 16.6 px (0.73 R) | unsure / unsure |
| bend | LN819vhVLLeYwzRsBh2zAg | 15.0 px (0.67 R) | True / False |
| bend | 9DA1aapwjQcdUP2HEfrhfg | 18.8 px (0.83 R) | True / duplicate |
| morgantown | 1455316282454101 | 17.0 px (0.75 R) | True / True |
| budapest_district5 | 945894851803282 | 15.0 px (0.67 R) | True / True |

**5 of the 8 members NMS would prune are confirmed real ramps.** The junk (bend's `False` and `duplicate`) sits in the same 15–19 px separation band as the real pairs, so no suppression radius separates them.

## Rescoring every split with NMS applied

| split | F1 | Δtp | Δfp | AP |
|---|---|---|---|---|
| richmond | 0.8546 → 0.8484 | −3 | 0 | 0.7635 → 0.7538 |
| bend | 0.8498 → 0.8527 | 0 | −2 | 0.7543 → 0.7550 |
| clovis | 0.8012 (unchanged) | 0 | 0 | unchanged |
| morgantown | 0.8351 → 0.8326 | −1 | 0 | 0.7281 → 0.7243 |
| budapest_district5 | 0.6442 → 0.6414 | −1 | 0 | 0.4782 → 0.4749 |
| manual_gold @ 0.55 | 0.9085 → 0.9046 | −33 | −8 | 0.8615 → 0.8534 |

NMS helps exactly one split — bend, whose single redundant FP motivated #62 — and hurts everywhere else. `min_distance < R` is load-bearing headroom that lets the extractor emit both members of a real adjacent-ramp pair, which the matcher scores as two TPs whenever both are in GT; the occasional redundant second hit is already charged as an FP, which is the right accounting.

## Changes

- `scripts/analysis/peak_nms_check.py` — reproduces every number above from the committed records
- `tests/test_metrics.py` — regression test: two real ramps inside one match radius must both score as TPs
- `scripts/analysis/threshold_sweep.py` — docstring note warning against raising `min_distance` toward the match radius

Closes #62 (as won't-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
