### PR TITLE
Add CI: run the pytest suite on every push and PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,10 +34,16 @@ jobs:
 
       # Installed first, and from the CPU index, so pip does not pull the
       # multi-gigabyte CUDA wheels that are the default for torch on Linux.
-      # The requirements-dev.txt install below then finds torch already
-      # satisfied and leaves it alone.
+      # The requirements-dev.txt install below then finds both already
+      # satisfied and leaves them alone.
+      #
+      # torchvision must come from the same index, in the same command: timm
+      # imports it, and PyPI's Linux torchvision wheel is compiled against a
+      # CUDA torch. Pairing that with a +cpu torch imports cleanly right up
+      # until it doesn't -- "RuntimeError: operator torchvision::nms does not
+      # exist". Resolving both from the CPU index guarantees a matched pair.
       - name: Install CPU-only PyTorch
-        run: pip install "torch>=2.6,<3" --index-url https://download.pytorch.org/whl/cpu
+        run: pip install "torch>=2.6,<3" "torchvision>=0.21" --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.10 is what environment.yml pins (the cluster/paper environment);
+        # 3.12 is what local dev venvs tend to be. Both are in real use.
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      # Installed first, and from the CPU index, so pip does not pull the
+      # multi-gigabyte CUDA wheels that are the default for torch on Linux.
+      # The requirements-dev.txt install below then finds torch already
+      # satisfied and leaves it alone.
+      - name: Install CPU-only PyTorch
+        run: pip install "torch>=2.6,<3" --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install test dependencies
+        run: |
+          pip install -r requirements-dev.txt
+          pip install -e .
+
+      - name: Run tests
+        # The suite is self-contained: every fixture it reads (manual_labels/,
+        # benchmark/*/records.jsonl, benchmark/*/verdicts.json) is committed, and
+        # models are built with pretrained_backbone=False. Forcing the Hugging
+        # Face hub offline makes any accidental network dependency fail loudly
+        # here rather than turning into a slow, flaky job later.
+        env:
+          HF_HUB_OFFLINE: "1"
+        run: pytest -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ Research code for the RampNet paper (ICCV'25 workshop): a two-stage pipeline tha
   conda env create -f environment.yml
   conda activate sidewalkcv2
   ```
-- There is no test suite, build step, or lint config. Scripts are configured by editing constants at the top of each file (e.g. `MODEL_CHECKPOINT_PATH`, `EVALUATE_ON_MANUAL_DATASET`, `CONSIDER_MANUAL`), not CLI args.
+- There is a pytest suite in `tests/` — run it with `pytest -q` (about 30 seconds). It is CPU-only, needs no network, and reads only committed fixtures (`manual_labels/`, `benchmark/*/records.jsonl`, `benchmark/*/verdicts.json`), because models are built with `pretrained_backbone=False`. **Keep it that way**: a test that needs a GPU, a checkpoint, or a network call belongs behind a skip, not in the default run. `requirements-dev.txt` is the minimal dependency set for it, and `.github/workflows/tests.yml` runs it on Python 3.10 and 3.12 for every PR. CI installs CPU-only pip wheels, so a green run verifies the code, **not** that `environment.yml` still solves.
+- There is no lint or formatting config, and no build step beyond `pip install -e .` for the `rampnet` package. Older scripts are configured by editing constants at the top of the file (e.g. `MODEL_CHECKPOINT_PATH`, `CONSIDER_MANUAL`); newer ones (`stage_two/evaluate.py`, most of `scripts/`) take CLI args instead — check the file before assuming.
 - Every long-running script has a matching `.slurm` launcher (the paper's runs used a Slurm cluster; Stage 2 training used 16x L40s). Stage 2 training is DDP — locally it's launched via `torchrun` (see `stage_two/run_train.slurm`); single-process fallback works since `setup_distributed()` defaults to world_size 1.
 - `download_dataset.py` (repo root) downloads the pre-generated Stage 1 dataset from Hugging Face into `./dataset/{train,val,test}` — the shortcut that skips all of Stage 1.
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ Alternatives:
 - `environment.lock.yml` — the exact full conda export used for the paper results (linux-64 only), kept for provenance. Note that despite the paper-era README saying "CUDA 11.8", the lock actually pins CUDA 12.6 pytorch builds.
 
 
+## Running the Tests
+
+A pytest suite in `tests/` covers the shared `rampnet` package — the model definition and its checkpoint compatibility, the evaluation metrics and prediction/ground-truth matching — along with the benchmark bundles and the Hugging Face export tooling. It is CPU-only, needs no network, and reads only fixtures committed to this repo, so it takes about 30 seconds:
+
+```bash
+pytest -q
+```
+
+If you created the conda environment above, you already have everything it needs. For a minimal install that skips the training, geo, and plotting stack:
+
+```bash
+pip install "torch>=2.6,<3" --index-url https://download.pytorch.org/whl/cpu
+pip install -r requirements-dev.txt
+pip install -e .
+```
+
+GitHub Actions runs the same suite on Python 3.10 and 3.12 for every pull request (`.github/workflows/tests.yml`). Because CI installs CPU-only pip wheels rather than the conda environment, a green run verifies the code — not that `environment.yml` still solves or that the CUDA builds are intact.
+
+The suite does not train, evaluate a checkpoint, or touch the Google Street View endpoints; those runs are far too slow and network-dependent to gate a commit on, and are documented in the stage sections below.
+
+
 ## Dataset Summary
 
 | Name | Description | # of Panoramas | # of Labels |

--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ pytest -q
 If you created the conda environment above, you already have everything it needs. For a minimal install that skips the training, geo, and plotting stack:
 
 ```bash
-pip install "torch>=2.6,<3" --index-url https://download.pytorch.org/whl/cpu
+pip install "torch>=2.6,<3" "torchvision>=0.21" --index-url https://download.pytorch.org/whl/cpu
 pip install -r requirements-dev.txt
 pip install -e .
 ```
+
+Install torch and torchvision together from the CPU index as shown. On Linux, PyPI's torchvision wheel is built against a CUDA torch, and mixing it with a CPU-only torch fails at import with `operator torchvision::nms does not exist`.
 
 GitHub Actions runs the same suite on Python 3.10 and 3.12 for every pull request (`.github/workflows/tests.yml`). Because CI installs CPU-only pip wheels rather than the conda environment, a green run verifies the code — not that `environment.yml` still solves or that the CUDA builds are intact.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,8 +5,11 @@
 # neither a GPU nor the geo/plotting/training stack the pipeline scripts use.
 # The suite is CPU-only, needs no network, and runs in about 30 seconds.
 #
-# CPU-only install (what CI does — skips the ~2.5 GB CUDA wheels on Linux):
-#   pip install "torch>=2.6,<3" --index-url https://download.pytorch.org/whl/cpu
+# CPU-only install (what CI does — skips the ~2.5 GB CUDA wheels on Linux).
+# Install torch and torchvision together from the CPU index: on Linux, PyPI's
+# torchvision is built against a CUDA torch, and mixing it with a +cpu torch
+# fails at import with "operator torchvision::nms does not exist".
+#   pip install "torch>=2.6,<3" "torchvision>=0.21" --index-url https://download.pytorch.org/whl/cpu
 #   pip install -r requirements-dev.txt
 #   pip install -e .
 #
@@ -14,6 +17,9 @@
 # and can just run `pytest`.
 
 torch>=2.6,<3
+# Not imported by the tests directly, but timm imports it, so it has to be
+# declared to keep it pinned to the same build as torch (see the note above).
+torchvision>=0.21
 timm
 transformers
 numpy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,24 @@
+# Minimal dependency set for running the test suite.
+#
+# Deliberately much smaller than requirements.txt: the tests cover model
+# definitions, evaluation metrics, and parsing/serialization logic, so they need
+# neither a GPU nor the geo/plotting/training stack the pipeline scripts use.
+# The suite is CPU-only, needs no network, and runs in about 30 seconds.
+#
+# CPU-only install (what CI does — skips the ~2.5 GB CUDA wheels on Linux):
+#   pip install "torch>=2.6,<3" --index-url https://download.pytorch.org/whl/cpu
+#   pip install -r requirements-dev.txt
+#   pip install -e .
+#
+# If you already have the full conda env (environment.yml), you have all of this
+# and can just run `pytest`.
+
+torch>=2.6,<3
+timm
+transformers
+numpy
+pillow
+pytest
+# Needed only because scripts/build_benchmark_dataset.py imports it at module
+# level, and tests/test_benchmark_dataset.py imports that module.
+datasets


### PR DESCRIPTION
## What this does

Adds a GitHub Actions workflow that runs the existing pytest suite on every push to `main` and every pull request. The suite has grown to **177 tests** covering the shared `rampnet` package (model definition and checkpoint compatibility, evaluation metrics, prediction/ground-truth matching), the benchmark bundles, the operating-point curve, and the Hugging Face export tooling — but until now nothing ran it automatically.

The failure mode this guards against is the quiet kind: the published model no longer loading via `trust_remote_code` (the issue #19 class of bug), a stage-1 script forking the shared matcher, gold-label counts drifting out of step with the README table. None of those announce themselves.

## Files

| File | Why |
|---|---|
| `.github/workflows/tests.yml` | ubuntu-latest, Python 3.10 and 3.12 in parallel, pip cached |
| `requirements-dev.txt` | Minimal dependency set for the suite — much smaller than `requirements.txt` |
| `README.md` | New "Running the Tests" section |
| `CLAUDE.md` | Refreshes the stale "there is no test suite" line |

Python 3.10 is what `environment.yml` pins (the cluster/paper environment); 3.12 is what local dev venvs tend to be. Both are in real use, and the two jobs run concurrently so there is no wall-clock cost.

## Two implementation details

- **CPU-only torch is installed first, from the PyTorch CPU index**, so pip does not pull the multi-gigabyte CUDA wheels that are the default for torch on Linux. The `requirements-dev.txt` install then finds torch already satisfied.
- **pytest runs with `HF_HUB_OFFLINE=1`.** The suite reads only committed fixtures (`manual_labels/`, `benchmark/*/records.jsonl`, `benchmark/*/verdicts.json`) and builds models with `pretrained_backbone=False`, so forcing the hub offline makes an accidental network dependency fail loudly here rather than turning into a slow, flaky job later.

## Verification

Validated in a throwaway venv built exactly the way CI builds one — CPU index torch, `requirements-dev.txt`, `pip install -e .`, hub offline:

```
177 passed in 26.36s
torch 2.13.0+cpu  cuda_available=False
```

Building that clean venv is what caught the one real gap: `scripts/build_benchmark_dataset.py` imports `datasets` at module level, so `tests/test_benchmark_dataset.py` needs it. A local conda env hides this; a clean install fails at collection. `datasets` is now in `requirements-dev.txt`.

Caveat: the validation run was Windows/3.12, so the Ubuntu and 3.10 legs are inferred rather than observed. I grepped for 3.11+/3.12-only syntax (`tomllib`, `datetime.UTC`, `itertools.batched`, `Self`, `except*`) and found none.

## Scope

Deliberately **not** included: lint or formatting gates (research code, high churn, low payoff), GPU jobs, training smoke tests, and anything touching the Google Street View endpoints or Hugging Face downloads — those are too slow and network-dependent to gate a commit on, and a flaky check trains everyone to ignore the red X.

Worth stating plainly: **CI installs pip wheels, not the conda environment.** A green run verifies the code — not that `environment.yml` still solves or that the CUDA pins are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)