### PR TITLE
Ignore Claude Code local state and regenerable comparison output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,22 @@ benchmark/*/heatmap_cache/
 view_dump/
 .model_cache/
 analysis_out/
+
+# Claude Code local state. settings.local.json is per-machine (absolute paths,
+# session ids) and worktrees/ holds full repo checkouts -- gigabytes. Listed
+# individually rather than ignoring all of .claude/, so a shared
+# .claude/settings.json could still be committed if we ever want one.
+.claude/settings.local.json
+.claude/worktrees/
+
+# PR curves written by scripts/model_comparison/compare.py --pr-out (the
+# commands in docs/model_comparison.md write here). Regenerable output.
+# Anchored to the repo root on purpose: the committed curves under
+# stage_one/.../evaluation_results/ and stage_two/evaluation_results*/ must
+# stay tracked.
+/evaluation_results/
+
+# sha256 manifest of a split's panos/ bundle, exported next to the imagery by
+# the auto-labeler. Belongs with the imagery, which is intentionally not in git
+# (see benchmark/README.md) -- nothing in this repo reads it.
+benchmark/*/index.csv


### PR DESCRIPTION
## What this does

Three untracked directories had been sitting in working trees. None of them belong in git, so this adds `.gitignore` rules for all three. **No files are added or removed** — this is `.gitignore` only.

| Path | Verdict | Why |
|---|---|---|
| `.claude/settings.local.json`, `.claude/worktrees/` | ignore | Per-machine Claude Code state; the worktrees are full repo checkouts (2.1 GB locally) |
| `/evaluation_results/` | ignore | PR curves written by the documented `compare.py --pr-out` commands — regenerable |
| `benchmark/*/index.csv` | ignore | sha256 manifest of a split's `panos/` bundle, which is intentionally not in git |

## Two details worth a look in review

**The `/evaluation_results/` rule is anchored on purpose.** An unanchored `evaluation_results/` would also match `stage_two/evaluation_results/`, `stage_two/evaluation_results_new/`, and `stage_one/crop_model/ps_and_manual_model/evaluation_results/` — all committed, and all cited from the README's erratum. Already-tracked files would survive, but new files added there would be silently ignored later. The leading slash confines it to the repo root.

Verified both directions with `git check-ignore -v`: the four intended paths match, and the committed `evaluation_results` files under `stage_one/` and `stage_two/` do not.

**`.claude/` is listed entry-by-entry rather than wholesale**, so a shared `.claude/settings.json` (or project skills/commands) remains committable if that's ever wanted. Only the personal and bulky parts are ignored.

## The judgment call — `benchmark/*/index.csv`

This is the one a reviewer might reasonably flip, so here is the reasoning rather than just the verdict.

Each is ~14 KB of `panorama_id,filename,bytes,sha256` covering a split's `panos/` imagery — which `benchmark/README.md` says is "archived separately and published to HF; they are intentionally not in git." Arguments for committing it: it is small, and a checksum manifest is precisely how you make an out-of-band archive verifiable.

I ignored it anyway because:

- Nothing in the repo reads or writes it — no script, doc, or test mentions `index.csv`.
- It is not in the documented split layout in `benchmark/README.md`.
- Only 3 of the 5 splits have one (clovis, morgantown, budapest_district5); richmond and bend do not. Committing it would make the layout inconsistent across splits.
- `docs/data_provenance.md` establishes no checksum convention it would slot into.

It is an artifact of the auto-labeler's `export_benchmark.py`, which hands over `panos/` + `records.jsonl` together — so it travels with the imagery, not the repo. If we do want imagery checksums under version control, the better home is the HF benchmark dataset in #21, alongside the data they describe, and applied to all five splits rather than the three that happen to have one locally.

Easy to reverse: delete the last rule and `git add` the three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)