### PR TITLE
Onboard Tillicum: cluster doc, Slurm port, and first-login recon (#51/#70)

### DIFF
--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -153,15 +153,27 @@ Two conclusions:
   `ls -lU | head -201` on `tiles/images/train` timed out. That is metadata throughput,
   not bandwidth.
 
-**So transfer an archive, never the tree.** `tar` per split on klone → move a handful of
-large files → untar on Tillicum. A per-file `rsync`/`scp` would pay ~911,000 round trips.
-Run the `tar` inside a Slurm job, **not on a klone login node** — that is exactly the
-heavy-login-process reap that kills the SSH master. Note the untar on `/gpfs` is itself
-metadata-heavy, so time it: it is our first real measurement of whether Tillicum's flash
-actually fixes this, which is the same question the tiles training arm is asking.
+**So pack into SquashFS, never copy the tree** — see
+`scripts/model_comparison/pack_yolo_dataset.slurm`, and UW-IT's own recommendation in the
+answers below. A per-file `rsync`/`scp` pays ~911,000 round trips; `tar` fixes the
+transfer but not the destination, since untarring recreates all 911k files on `/gpfs` and
+pays the metadata cost permanently. A SquashFS image is mounted read-only, so the
+destination only ever holds **one file**.
+
+Run the pack inside a Slurm job, **not on a klone login node** — that is exactly the
+heavy-login-process reap that kills the SSH master.
+
+**The subtle part is the Ultralytics label cache.** Ultralytics writes
+`labels/<split>.cache` and validates it against a hash of the label+image **absolute
+paths**. So (a) the `.cache` files must be *inside* the image — they exist on klone
+already and a read-only mount cannot create them — and (b) mounting at a different path
+than they were built under silently invalidates them and forces a full ~911k-file
+rescan. Budget one slow first epoch on Tillicum to regenerate them, and do not mistake
+it for the steady-state cost. Getting this wrong is invisible: training still works, it
+is just permanently slow.
 
 Staging order: **`pano` first (76 GB, 193k files)** — it unblocks the smoke test and the
-pano epoch-time measurement while the much larger `tiles` archive moves behind it.
+pano epoch-time measurement while the much larger `tiles` image builds behind it.
 
 > The docs describe demo accounts as receiving "100 GB of dedicated project storage,"
 > while our provisioning email says 1 TB. Assume 1 TB (the email is specific to us) but
@@ -233,17 +245,51 @@ Record the measured epoch times back into this file and into #70.
 - **Budget changes:** contact UW-IT; enforcement semantics (blocks new submissions vs.
   cancels running jobs) are **UNVERIFIED** and were asked about on 2026-07-30.
 
-## Open questions
+## Answers from UW-IT (Sumaiya Sathar, 2026-07-30)
 
-Sent to UW-IT 2026-07-30, unanswered at time of writing:
+All six questions answered. Several change the plan, so they are recorded here rather
+than left in a mailbox.
 
-1. Does budget enforcement block *new submissions* or *cancel running jobs*?
-2. Is there any way to get more CPUs per job without the GPU billing multiplier?
-3. Guidance for many-small-file datasets on `/gpfs`; is packing into an archive or
-   container format recommended?
-4. Storage: quota-increase path, and what "purged at the end of the project" means.
-5. Do the 100 free demo hours expire?
-6. How to request `long` QoS access.
+1. **Budget enforcement is safe.** Set to **$1,500/month, enforcement active**. Enforced
+   budgets **do not cancel running jobs** — a job already running continues to
+   completion; enforcement only **blocks new submissions** until the cap is raised or
+   the period rolls over. So the cap cannot destroy an in-flight experiment, which was
+   the only reason to have preferred warn-only.
+2. **No CPUs without GPUs — confirmed, and it is a rate-model constraint, not a
+   scheduling one.** There is no QoS granting extra cores without the matching GPU
+   allocation; UW-IT is considering it, but the UW-approved rate model cannot charge for
+   CPUs independently, and unbalanced nodes are undesirable. **So the 2-GPU dataloader
+   trick is the only lever**, and its 2× billing is unavoidable — see the trap above.
+3. **Many small files → `/gpfs/scrubbed`, and pack into SquashFS.** This is the big one.
+   Active many-small-file datasets belong on **`/gpfs/scrubbed`** (larger capacity, has
+   an automatic cleanup policy) rather than the 1 TB project quota, and UW-IT explicitly
+   recommends **SquashFS** for this shape. Data Commons is an option if the dataset can
+   be public.
+4. **Storage grows in 1 TB increments** on request to `help@uw.edu` (subject "Tillicum")
+   with a workflow justification — it is shared active-compute storage, not archival.
+5. **No project end date.** "Purged at the end of the project" simply means that if we
+   stop using Tillicum we must copy data off so the space can be reclaimed. Nothing
+   expires on a timer.
+6. **1 TB is correct for us** — the 100 GB figure in the public docs applies to *demo*
+   accounts. Providing a worktag makes it a regular account, which is why we got 1 TB.
+7. **The 100 free GPU hours do not expire.** They remain until used.
+8. **`long` QoS requires the Special QoS Access Request Form** — still to be submitted,
+   then reviewed. Not a blocker for the measurement phase (everything fits in 24 h), but
+   it gates comfortable production runs.
+
+### What this changes
+
+- **Dataset goes to `/gpfs/scrubbed`, not `/gpfs/projects/makelab`.** The 1 TB project
+  quota is for artifacts we want backed up (checkpoints, results), not the 286 GB of
+  training data. This also removes storage pressure from the plan entirely.
+- **Pack with SquashFS, not tar.** See
+  `scripts/model_comparison/pack_yolo_dataset.slurm`. tar fixes the *transfer* but not
+  the *destination* — untarring recreates all ~911k files on `/gpfs` and pays the
+  metadata cost permanently. A SquashFS image is mounted read-only and the destination
+  only ever holds one file.
+- **Enforced budget is safe to leave on**, so the runaway-spend guard costs us nothing.
+- **The `DEVICE=0` / 2-GPU design in the Tillicum launcher is now confirmed necessary**
+  rather than a workaround pending a better answer.
 
 ## Related
 

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -109,6 +109,33 @@ At that ceiling:
 
 Monitor with `hyakusage`.
 
+### `debug` is free — but the two cost tools disagree (measured 2026-07-31)
+
+The full QoS table, from `sacctmgr show qos`:
+
+| QoS | Priority | UsageFactor | MaxWall | per-user cap |
+|---|---:|---:|---|---|
+| `debug` | 50 | **0.000000** | 1 h | 1 GPU, 8 CPU, 200 G, 1 node |
+| `normal` | 25 | 1.000000 | 1 day | 48 GPU |
+| `interactive` | 35 | 1.000000 | 8 h | — |
+| `urgent` | 200 | 1.000000 | 3 days | 64 GPU |
+| `long` | 25 | 1.000000 | 7 days | — |
+| `wide` | 25 | 1.000000 | 1 day | 96 GPU |
+
+`debug` bills at **UsageFactor 0** and carries *higher* priority than `normal` (50 vs
+25), so every environment and throughput probe belongs there. That is the basis for the
+"costs nothing" claim in `scripts/tillicum_smoke.slurm`.
+
+**Caveat, unresolved:** `hyakusage` does not agree. The smoke job (`198638`, 2 min on
+`debug`) shows up in its QoS breakdown as **0.03 GPU-hours, $0.03** — i.e. raw
+wall-clock × $0.90 with the 0.0 UsageFactor apparently *not* applied, even though
+`hyakusage`'s own header says "billable GPU hours = raw GPU hours × QOS multiplier."
+Slurm's accounting config and the reporting tool are stating different things, and we do
+not know which one ITBill actually follows. Worth asking UW-IT, but not urgent: `debug`
+is capped at 1 h × 1 GPU, so the exposure is **at most $0.90 per job** even if
+`hyakusage` turns out to be the honest one. Do not quote a "free" figure from this
+without saying which tool it came from.
+
 ### The 2-GPU trap for I/O-bound arms
 
 This is the cost decision specific to our workload. Our tiles arm is **I/O-bound, not
@@ -249,8 +276,38 @@ are DockerHub and the NVIDIA NGC catalog.
 **Our `environment.yml` should not be assumed to transfer.** It pins linux-64 packages
 against **CUDA 11.8**, and Tillicum is H200 (sm_90) on Rocky 9. CUDA 11.8 nominally
 covers sm_90, but a stack built for klone's OS and driver is not a safe bet on a
-different distro and a newer card. **UNVERIFIED — do not plan around either outcome
-until someone tries it.** The low-risk path is an NGC PyTorch container.
+different distro and a newer card. **Still UNVERIFIED** — nobody has tried to solve
+`environment.yml` here, because the YOLO baseline does not need it. The low-risk path
+remains an NGC PyTorch container.
+
+### The YOLO stack, however, is VERIFIED (2026-07-31)
+
+`scripts/tillicum_setup_env.sh` builds it, and it reproduces the klone `#51` toolchain
+**exactly** — confirmed by running the interpreter, not by reading a lockfile:
+
+```
+3.11.15   torch 2.13.0+cu126   ultralytics 8.4.105
+```
+
+which is character-for-character what klone's training logs report
+(`Ultralytics 8.4.105 · Python-3.11.15 · torch-2.13.0+cu126`). It lives at
+`/gpfs/projects/makelab/$USER/envs/rampnet-yolo` — the backed-up 1 TB allocation rather
+than `scrubbed`, because the environment is small and annoying to rebuild while the
+dataset is huge and reproducible. It has since driven a full 4 h 40 m production job
+(`198910`) without incident.
+
+Two details in that script worth keeping if it is ever edited:
+
+- **Conda is not optional here.** Tillicum's *system* python is 3.9.25, and the cu126
+  wheel index tops out at torch 2.8.0 for 3.9 — so a naive `pip install torch
+  ultralytics` silently yields 2.8.0 + 8.4.113 and a baseline nobody can publish. The
+  conda module is the only way to get 3.11 on this cluster.
+- **The version check is a gate, not a report.** The script refuses to install a
+  substitute torch and exits non-zero on any mismatch. That matters because installing
+  `ultralytics` last can pull its own torch over the pinned one; the post-install assert
+  is what catches it. A mismatched toolchain produces plausible numbers and an
+  unpublishable comparison, which is the failure mode `#71`'s protocol exists to
+  prevent.
 
 ## Migrating our Slurm scripts
 

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -1,0 +1,227 @@
+# Tillicum — access, migration, and what it costs
+
+Working notes for running RampNet jobs on **Tillicum**, UW-IT's usage-billed GPU
+cluster. The makelab group was provisioned on **2026-07-29**.
+
+This doc exists because Tillicum is **not** klone-with-different-hostnames — the
+scheduler model, the walltime ceiling, the CPU:GPU ratio, and the cost model all
+differ in ways that make our existing `.slurm` scripts **non-submittable as written**.
+See [Migrating our Slurm scripts](#migrating-our-slurm-scripts) for the diff.
+
+> **Sourcing.** Everything in the tables below is from the [Tillicum
+> docs](https://hyak.uw.edu/docs/systems/tillicum/scheduling-jobs) and the provisioning
+> email (2026-07-29), read on 2026-07-30. Sections marked **UNVERIFIED** are our
+> inference or are undocumented — we have not run a single job on Tillicum yet, so
+> nothing here is confirmed by experience. Correct this file from measurement, not
+> from re-reading the docs.
+
+## Why we care: the klone problem this solves
+
+The supervised-YOLO baseline (#51) ran on klone's `ckpt` scavenger partition, which is
+free but **preemptable**. As of 2026-07-30 that had stopped working as a compute
+strategy:
+
+- **496.5 GPU-hours consumed** on the baseline since 2026-07-24 (`sacct`, all arms).
+- **170 job restarts in one night** across five jobs (39 / 37 / 33 / 33 / 28).
+- **Zero completed epochs** on five of six arms over that same night; four of the six
+  arms are still "one-epoch models" holding an ep1 `best.pt`.
+
+The binding constraint is not the nominal 8.24 h checkpoint slice — it is the
+**effective** contiguous run the partition hands out, which collapsed to minutes. Any
+arm whose epoch exceeds that interval can never complete one. See #51 and #70.
+
+**Tillicum does not preempt.** The docs state that even the `urgent` QoS will "not
+cancel or preempt jobs that are already running." That is the entire reason to pay.
+
+## Access
+
+```bash
+ssh <UWNetID>@tillicum.hyak.uw.edu
+```
+
+Duo 2FA, same as klone — **Claude cannot authenticate this.** The `wsl-ssh.ps1` helper
+in `dotfiles` has no `tillicum` target yet; adding one (with a `ControlPersist` master,
+mirroring the `klone` block in `ssh_config.wsl`) is a prerequisite for driving Tillicum
+from an agent session. Until then, Tillicum is Jon-only.
+
+> The get-started page writes the hostname two ways — `tillicum.hyak.uw.edu` in the
+> hostname field and `tillicum.hyak.edu` in the `ssh` example. The former is almost
+> certainly correct; **UNVERIFIED** until someone logs in.
+
+## The scheduler model: QoS, not partitions
+
+klone is a condo: you get partitions tied to hardware your group owns or scavenges
+(`-p ckpt-g2 -q ckpt-gpu`). **Tillicum has no partitions at all.** You pick a QoS, and
+billing handles the rest.
+
+| QoS | Max time | Max GPUs/job | Concurrent | Notes |
+|---|---|---|---|---|
+| `normal` | **24 h** | 16 | 48 GPUs | default |
+| `debug` | 1 h | 1 | 1 job | smoke tests |
+| `interactive` | 8 h | 2 | 2 jobs | `salloc` work |
+| `long` | **7 days** | 16 | 96 GPUs (shared) | **pre-approval required** |
+| `wide` | 24 h | unlimited | 96 GPUs (shared) | **pre-approval required** |
+| `urgent` | 3 days | 64 | 96 GPUs (shared) | **pre-approval required** |
+
+**The 24 h ceiling on `normal` is a real constraint for us.** Our tiles epochs ran
+4.1–9.5 h on klone; a 60-epoch schedule does not fit in 24 h. Two options:
+
+1. **Request `long` QoS** (7 days) via the Tillicum Special QoS Access Request Form.
+   This is the clean answer and should be requested now — it gates the #70 rerun.
+2. **Chain 24 h `normal` jobs**, resuming from `weights/last.pt`. Our
+   `run_yolo_train.slurm` already has the resume block for this, and without
+   preemption a resume boundary is predictable rather than random.
+
+Option 2 works today and needs no approval; option 1 is less operationally fiddly.
+Do 1, fall back to 2.
+
+## Hardware
+
+192 × NVIDIA **H200** (141 GB HBM3e, NVLink 4.0), 8 GPUs per node, 24 × Dell XE9680,
+1,536 Intel Emerald Rapids cores, 400 Gbps NDR InfiniBand, ~3 PB flash, Rocky 9.
+
+Per-GPU binding: **200 GB system RAM and 8 CPUs**. This ratio is not negotiable —
+the docs are explicit that exceeding 8 CPUs per GPU requires requesting *additional
+GPUs*. **CPU-only jobs are prohibited**; every job must request ≥1 GPU.
+
+> Operational consequence: our CPU-side data prep (`run_yolo_data.slurm`,
+> `run_yolo_prep.slurm`) has no business on Tillicum. Keep prep on klone, train on
+> Tillicum.
+
+## Cost model
+
+**$0.90 per GPU-hour**, where **GPU-hour = elapsed wall-clock × N GPUs**. Billed
+monthly via ITBill to the lab's UW worktag. (**The worktag and subscription IDs are
+deliberately not recorded in this repo** — it is public. Ask Jon, or see the Tillicum
+provisioning email.)
+
+- **100 free GPU demo hours** on the new account (≈ $90). Whether these expire is
+  **UNVERIFIED**.
+- Budget requested 2026-07-30: **$1,500/month** ≈ **1,666 GPU-hours/month**.
+
+At that ceiling:
+
+| job shape | wall-clock hours/month |
+|---|---|
+| 1 GPU | ~1,666 |
+| 2 GPUs | ~833 |
+| 8 GPUs (full node) | ~208 |
+
+Monitor with `hyakusage`.
+
+### The 2-GPU trap for I/O-bound arms
+
+This is the cost decision specific to our workload. Our tiles arm is **I/O-bound, not
+GPU-bound** — the same epoch took 4.1–9.5 h on klone depending only on which node it
+landed on. The obvious fix is more dataloader workers, but on Tillicum **more CPUs
+means more GPUs**, and billing multiplies by GPU count:
+
+- 1 GPU → 8 dataloader CPUs → 1× billing rate
+- 2 GPUs → 16 dataloader CPUs → **2× billing rate**
+
+So 2 GPUs is only cheaper *per epoch* if 16 CPUs makes the tiles epoch **more than
+twice** as fast. That is an empirical question, and it is the single best use of the
+free demo hours. See [First runs](#first-runs-what-to-measure).
+
+## Storage
+
+`/gpfs/projects/makelab` — **1 TB**, backed up daily, "purged at the end of the
+project." Note this is *not* archival: `/gscratch/makelab` on klone remains the system
+of record for durable weights (see `scripts/model_comparison/yolo_baseline/README.md`).
+Keep the existing pattern: **train on Tillicum, `rsync` `best.pt` back to
+`/gscratch/makelab`.**
+
+Undocumented and pending a reply from UW-IT: the quota-increase path, what defines
+"end of project," and guidance for **many-small-file** access patterns. That last one
+matters to us more than bandwidth — our tiles dataset is hundreds of thousands of small
+JPEGs, and `du -sh` over it on klone's `/gscratch/scrubbed` exceeds a 2-minute timeout,
+which is a metadata-throughput symptom rather than a size one.
+
+> The docs describe demo accounts as receiving "100 GB of dedicated project storage,"
+> while our provisioning email says 1 TB. Assume 1 TB (the email is specific to us) but
+> confirm.
+
+## Software environment
+
+Tillicum's documented path is **Apptainer containers**, not conda modules —
+see [UWrc/tillicum-containers](https://github.com/UWrc/tillicum-containers), which
+ships a `pytorch_timm.def` example (we use `timm` for the ConvNeXt-V2 backbone) plus
+`run_inference.slurm` and `array_inference.slurm` templates. Recommended image sources
+are DockerHub and the NVIDIA NGC catalog.
+
+**Our `environment.yml` should not be assumed to transfer.** It pins linux-64 packages
+against **CUDA 11.8**, and Tillicum is H200 (sm_90) on Rocky 9. CUDA 11.8 nominally
+covers sm_90, but a stack built for klone's OS and driver is not a safe bet on a
+different distro and a newer card. **UNVERIFIED — do not plan around either outcome
+until someone tries it.** The low-risk path is an NGC PyTorch container.
+
+## Migrating our Slurm scripts
+
+Our current header (`scripts/model_comparison/run_yolo_train.slurm`) against what
+Tillicum accepts:
+
+| klone (current) | Tillicum | why |
+|---|---|---|
+| `#SBATCH -p ckpt-g2` | **delete** | no partitions exist |
+| `#SBATCH -q ckpt-gpu` | `#SBATCH --qos=normal` | or `long` once approved |
+| `#SBATCH --requeue` | **delete** | nothing preempts |
+| `#SBATCH --time=72:00:00` | `24:00:00` | 72 h needs `long` QoS |
+| `#SBATCH --gpus-per-node=1` | `#SBATCH --gres=gpu:1` | also `--gpus=1` / `-G 1` |
+| `#SBATCH --cpus-per-task=12` | **`8`** (1 GPU) | 12 CPUs on 1 GPU is rejected |
+| `#SBATCH --mem=64G` | keep, or up to `200G` | no default; must be explicit |
+| `#SBATCH --nodes=1 --ntasks=1` | unchanged | |
+
+**`--cpus-per-task=12` with one GPU is the blocking incompatibility** — it is not a
+tuning preference, it exceeds the hard 8:1 ratio and the job will not run.
+
+Also drop the inherited mail settings. Our klone jobs carry
+`MailType=END,FAIL,TIME_LIMIT` from a site default or the submit environment (it is
+*not* in the script), which on a preemptable partition produced ~170 emails in one
+night. On Tillicum there is no requeue storm to amplify it, but set `--mail-type=NONE`
+explicitly so the behavior is the script's decision rather than the site's.
+
+## First runs: what to measure
+
+Spend the free demo hours on measurement, not on a production run. Three jobs, ~15
+GPU-hours total, answering the questions the #70 budget depends on:
+
+1. **`debug` QoS smoke test** (1 h, ~1 GPU-h) — does our environment run at all?
+   This is where the conda-vs-container question gets settled.
+2. **One pano epoch, 1 GPU** (~1–3 h). klone L40S baseline: 2.6–2.8 h/epoch. An H200
+   should be meaningfully faster, but *how much* is the number the budget needs.
+3. **One tiles epoch, 1 GPU (8 CPU) vs 2 GPUs (16 CPU)** (~10 GPU-h). Settles the
+   2-GPU trap above, and — more importantly — tells us whether tiles-vs-pano in the
+   #51 results is an **architecture finding or a storage artifact**. That question is
+   currently unresolved and it materially affects what the baseline means.
+
+Record the measured epoch times back into this file and into #70.
+
+## Admin
+
+- **Group:** `u_hyak_tillicum_makelab` (UW Groups Service). Jon is a member manager and
+  can add users via the Membership tab; UW-IT can grant member-manager rights to others
+  on request.
+- **Maintenance:** second Tuesday monthly. Join the mailing list; put it on the run
+  calendar so long jobs are not scheduled across it.
+- **Support:** `help@uw.edu` with "Tillicum" in the subject; twice-weekly office hours.
+- **Budget changes:** contact UW-IT; enforcement semantics (blocks new submissions vs.
+  cancels running jobs) are **UNVERIFIED** and were asked about on 2026-07-30.
+
+## Open questions
+
+Sent to UW-IT 2026-07-30, unanswered at time of writing:
+
+1. Does budget enforcement block *new submissions* or *cancel running jobs*?
+2. Is there any way to get more CPUs per job without the GPU billing multiplier?
+3. Guidance for many-small-file datasets on `/gpfs`; is packing into an archive or
+   container format recommended?
+4. Storage: quota-increase path, and what "purged at the end of the project" means.
+5. Do the 100 free demo hours expire?
+6. How to request `long` QoS access.
+
+## Related
+
+- #51 — supervised YOLO baseline (the runs that motivated this)
+- #70 — stabilized rerun; **this is its unblocking dependency**
+- `scripts/model_comparison/yolo_baseline/README.md` — preserved klone training record
+- `hyak_yolo_runbook.sh`, `hyak_qwen_runbook.sh` — klone runbooks (repo root)

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -179,6 +179,65 @@ pano epoch-time measurement while the much larger `tiles` image builds behind it
 > while our provisioning email says 1 TB. Assume 1 TB (the email is specific to us) but
 > confirm.
 
+### How the data actually got there: regenerate, don't transfer (resolved 2026-07-31)
+
+The SquashFS plan above is sound and it **worked** — klone job `37940649` packed
+`pano` into a single 76 GB `pano.sqfs` in 2 h 38 m (sha256 `75be5150…aea1dd0a`, still on
+klone at `/gscratch/scrubbed/jfroehli/yolo_squashfs/`). It solved the destination
+problem exactly as designed: one file instead of 193k.
+
+**It did not solve the transfer, and the transfer is the real blocker.** There is no
+automated klone → Tillicum path: no shared filesystem (`/gscratch` and `/mmfs1` do not
+exist on Tillicum), and neither end can authenticate to the other non-interactively —
+both are Duo/keyboard-interactive with no `publickey`, so `BatchMode` fails in both
+directions. Globus CLI is installed on neither side. Verified 2026-07-30.
+
+So we **regenerated the dataset on Tillicum from Hugging Face** instead
+(`scripts/model_comparison/run_yolo_data_prep_tillicum.slurm`, job `198910`, 4 h 40 m).
+This is safe rather than merely convenient, because the prep is deterministic by
+construction: `prepare_yolo_dataset.py` thins background tiles with an md5 of the file
+stem specifically so the choice is stable across processes and runs (see
+`_keep_background` and its comment about salted `hash()`).
+
+**Verified equivalent to klone, 2026-07-31.** Counts match the #51 record in all eight
+directories — and, because klone's tree is still live, we could go further than counts.
+The md5 of the sorted filename list is **identical on both clusters for all eight**, so
+the two datasets contain the same files under the same train/val split, not merely the
+same number of them:
+
+| directory | files | md5 of sorted filename list (klone == Tillicum) |
+|---|---:|---|
+| `tiles/images/train` | 557,413 | `f5e664fbd64651be0ff89045d217ff50` |
+| `tiles/images/val`   | 161,002 | `f48f91878d34e72a7b0b2dfd48f6c90a` |
+| `pano/images/train`  | 150,063 | `a8f3af23a61952ef1209435ca0e295ea` |
+| `pano/images/val`    |  42,875 | `83f5371483f3dbfa5a6aece939b86901` |
+| `tiles/labels/train` | 557,413 | `19c5c38ae148a907042d213c84002cc6` |
+| `tiles/labels/val`   | 161,002 | `711d5a59a2d6019ac1857133b167266e` |
+| `pano/labels/train`  | 150,063 | `015fc700faee211e37af3f8edeca0dfc` |
+| `pano/labels/val`    |  42,875 | `2fc039583a9b0cc08ca57b11739f5a5a` |
+
+Reproduce on either cluster with, per directory:
+`ls -U <root>/yolo/<d> | sort | md5sum` — klone root `/gscratch/scrubbed/jfroehli`,
+Tillicum root `/gpfs/scrubbed/jfroehli`. The prep run itself reported 767,840 boxes over
+192,938 panos with **0 read errors**. Anything trained on Tillicum is therefore
+comparable to the #51 klone arms on the data axis.
+
+Two caveats that travel with this:
+
+- **It cost $4.20** — 4.67 GPU-hours at `normal` QoS. Tillicum rejects CPU-only jobs, so
+  a data-prep job must hold an H200 it never uses. That is structural, not an error, but
+  it is the argument for keeping prep on klone (free) whenever a dataset already exists
+  there and *can* be reached. Here it could not be.
+- **It landed on `/gpfs/scrubbed`, not the 1 TB project quota** — 1.61 TB across 2.28 M
+  files, counting the ~462 GB Hugging Face source cache. `scrubbed` is purged on an
+  inactivity timer, so this copy is not durable: it is fine while an arm is actively
+  reading it, and must not be assumed to survive a gap between arms. Durable artifacts
+  still belong on klone's `/gscratch/makelab`.
+
+Keep the SquashFS path documented anyway: it is the right answer the moment a transfer
+route exists (a Globus endpoint, or an intermediate host either end can reach), and the
+`pano.sqfs` image is already built.
+
 ## Software environment
 
 Tillicum's documented path is **Apptainer containers**, not conda modules —

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -419,6 +419,57 @@ stopwatch. This probe prices that run; it does not substitute for it.
 - **The probe's mAP is not a reportable result.** It is a third lineage of this arm, run to
   measure time. Report its throughput; report accuracy only from the klone arm.
 
+#### As run — job `217298`, 2026-08-09
+
+Submitted 16:5x PDT, node **`g016`** (H200, 143,771 MiB). Exact commands, in order, from a
+clean starting point. They assume the tiles dataset is already on Tillicum, which it is —
+`/gpfs/scrubbed/jfroehli/yolo/tiles`, regenerated from HF and md5-verified against klone per
+the table above.
+
+```bash
+# 1. Stage the checkpoint from the DURABLE SNAPSHOT, not the live run dir.
+#    sha256 52cf5013e696885b6c30cb0bf783256bf06d4b756c123277e6482e9f453fc064
+#    verified identical at all three hops: klone -> workstation -> Tillicum.
+RUN=/gpfs/projects/makelab/jfroehli/yolo_runs/y11x_tiles_h200_probe
+mkdir -p $RUN/weights
+# scp klone:/gscratch/makelab/jonf/rampnet_yolo_baseline_51/y11x_tiles/weights/last.pt $RUN/weights/
+# scp klone:/gscratch/makelab/jonf/rampnet_yolo_baseline_51/y11x_tiles/results.csv      $RUN/
+sha256sum $RUN/weights/last.pt $RUN/results.csv
+
+# 2. Rewrite the six cluster-absolute paths. Without this, resume=True restores the
+#    checkpoint's save_dir and writes back into the klone run directory.
+/gpfs/projects/makelab/jfroehli/envs/rampnet-yolo/bin/python \
+  ~/RampNet/scripts/model_comparison/retarget_yolo_checkpoint.py \
+  $RUN/weights/last.pt \
+  --data /gpfs/scrubbed/jfroehli/yolo/tiles/data.yaml \
+  --project /gpfs/projects/makelab/jfroehli/yolo_runs \
+  --name y11x_tiles_h200_probe --apply
+# -> backup at weights/last.pt.preretarget; out sha256 b2c6210c0b5f...762b;
+#    "verified: all six path keys persisted on reload"
+
+# 3. Submit, bounded at 7 h.
+cd ~/RampNet && mkdir -p logs
+PYTHON=/gpfs/projects/makelab/jfroehli/envs/rampnet-yolo/bin/python \
+YOLO_DATA=/gpfs/scrubbed/jfroehli/yolo/tiles/data.yaml \
+YOLO_IMGSZ=1024 BATCH=12 EPOCHS=60 NAME=y11x_tiles_h200_probe \
+  sbatch --time=07:00:00 --job-name=y11x_tiles_h200_probe \
+         scripts/model_comparison/run_yolo_train_tillicum.slurm
+```
+
+Confirmed at startup, from the job's own echoed args: `batch=12, imgsz=1024, workers=8,
+epochs=60, patience=20, seed=0, lr0=0.01, close_mosaic=10, optimizer=auto`, and
+`save_dir=…/y11x_tiles_h200_probe` — identical training math to the klone arm, writing to its
+own directory. The retarget dry run also reported `epochs done: 21 of 60,
+best_fitness: 0.47072`, which equals the klone arm's ep21 `mAP50-95` to five decimals —
+an independent confirmation that this Ultralytics build selects on **mAP50-95 alone**, not the
+0.1/0.9 blend (see `scripts/model_comparison/yolo_baseline/README.md`).
+
+**Cosmetic wart, same one klone had.** The launcher's header echoes `base: yolo11l.pt` on a
+resume, because `YOLO_CKPT` is unset and `resume=True` ignores it anyway. The klone script was
+fixed to print `MODE: RESUME` / `MODE: FRESH`; this one has not been. The `[resume]` line
+below it is the trustworthy signal. Do not read the `base:` line as the architecture — confirm
+from the `YOLO11x summary: … parameters` line instead.
+
 ## Admin
 
 - **Group:** `u_hyak_tillicum_makelab` (UW Groups Service). Jon is a member manager and

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -133,9 +133,35 @@ Keep the existing pattern: **train on Tillicum, `rsync` `best.pt` back to
 
 Undocumented and pending a reply from UW-IT: the quota-increase path, what defines
 "end of project," and guidance for **many-small-file** access patterns. That last one
-matters to us more than bandwidth — our tiles dataset is hundreds of thousands of small
-JPEGs, and `du -sh` over it on klone's `/gscratch/scrubbed` exceeds a 2-minute timeout,
-which is a metadata-throughput symptom rather than a size one.
+matters to us more than bandwidth.
+
+### What actually has to move (measured 2026-07-30 on klone)
+
+| dataset | size | train files | val files |
+|---|---|---|---|
+| `yolo/tiles` | **210 GB** | 557,413 | 161,002 |
+| `yolo/pano` | **76 GB** | 150,063 | 42,875 |
+| **total** | **286 GB** | **~911,000 files**, ~300 KB average | |
+
+Two conclusions:
+
+- **286 GB fits the 1 TB allocation** with room for checkpoints and run dirs. Storage
+  quota is not a blocker for the #70 rerun.
+- **~911,000 files is the blocker.** This is the many-small-file pathology in its pure
+  form, and it is not hypothetical: `du -sh` over the tiles tree exceeded a 2-minute
+  timeout three separate times before completing on a 550 s budget, and even
+  `ls -lU | head -201` on `tiles/images/train` timed out. That is metadata throughput,
+  not bandwidth.
+
+**So transfer an archive, never the tree.** `tar` per split on klone → move a handful of
+large files → untar on Tillicum. A per-file `rsync`/`scp` would pay ~911,000 round trips.
+Run the `tar` inside a Slurm job, **not on a klone login node** — that is exactly the
+heavy-login-process reap that kills the SSH master. Note the untar on `/gpfs` is itself
+metadata-heavy, so time it: it is our first real measurement of whether Tillicum's flash
+actually fixes this, which is the same question the tiles training arm is asking.
+
+Staging order: **`pano` first (76 GB, 193k files)** — it unblocks the smoke test and the
+pano epoch-time measurement while the much larger `tiles` archive moves behind it.
 
 > The docs describe demo accounts as receiving "100 GB of dedicated project storage,"
 > while our provisioning email says 1 TB. Assume 1 TB (the email is specific to us) but

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -49,12 +49,12 @@ Jon has already opened. Opening it is still Jon-only, because of Duo.
 that form is wrong. Jobs `198638`, `198910` and `217298` have since run, so everything
 in this section is now from experience rather than from the docs.
 
-> **Still open: the per-user home path.** It is undocumented, and the recon pass never
-> wrote its answer back here. The as-run commands below use `~/RampNet` and work;
-> `scripts/model_comparison/run_yolo_data_prep_tillicum.slurm` hardcodes
-> `/gpfs/home/$USER/RampNet` as a guess, and whether those are the same path is
-> **UNVERIFIED**. `scripts/tillicum_recon.sh` prints it as item 1 — run it and record
-> the result here. Do not assume it mirrors klone's `/mmfs1/...` layout.
+> **The per-user home path is `/gpfs/home/<netid>`** — measured 2026-08-18 with
+> `cd ~ && pwd` on a login node, which returned `/gpfs/home/jfroehli`. So the guess in
+> `scripts/model_comparison/run_yolo_data_prep_tillicum.slurm`
+> (`/gpfs/home/$USER/RampNet`) and the as-run `~/RampNet` are the **same directory**;
+> `/gpfs/home/jfroehli/RampNet` exists. Note it does **not** mirror klone's `/mmfs1/...`
+> layout, so nothing that hardcodes a klone home transfers.
 
 ## The scheduler model: QoS, not partitions
 

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -350,6 +350,75 @@ GPU-hours total, answering the questions the #70 budget depends on:
 
 Record the measured epoch times back into this file and into #70.
 
+### Measurement 3, pre-registered in full (2026-08-09)
+
+Written **before the job was submitted**, so the reading cannot be chosen after seeing the
+number. Same discipline as the #71 checkpoint-selection protocol.
+
+**What runs.** One epoch of `y11x_tiles` on **1 H200 / 8 CPU**, resumed from a *copy* of its
+epoch-21 checkpoint, with `batch=12`, `imgsz=1024`, `workers=8` — i.e. training math
+identical to the klone arm, so throughput is the only variable. `--time=07:00:00` bounds the
+cost at **7 GPU-h = $6.30**, inside the remaining $29.65 credit.
+
+**Why 7 h is the wall.** It is deliberately the falsification threshold, not a round number:
+klone's dedicated L40S does this epoch in **7.06–7.38 h**. A job that cannot complete one
+epoch inside a 7 h wall has ruled out the migration by itself, at a cost of $6.30.
+
+**Why this arm and not another.** `docs/tillicum.md` says above that our tiles arm is
+I/O-bound, which would make a faster GPU worthless. That is true of `y26_tiles` and
+`y11l_tiles`; it is **not** true of `y11x_tiles`, and the distinction is what makes this
+measurement worth paying for. On the same dedicated node and the same storage,
+`y26_tiles_l40s` sustains **34.0 img/s** while `y11x_tiles` sustains **25.2 img/s** — the
+larger model is slower against storage that demonstrably serves the smaller one faster. The
+July batch probe agrees: batch 3 and batch 12 both sustained ~15.6 img/s, so throughput is
+not batch- or queue-limited. `y11x_tiles` is the one tiles arm where H200 silicon should
+convert into wall-clock.
+
+**Baseline to beat** (measured on klone `gpu-l40s`, job `38063498`, 21 epochs):
+
+| quantity | klone L40S |
+|---|---|
+| epoch wall-clock | 7.06–7.38 h (dead flat) |
+| sustained rate | **2.1 it/s** at batch 12 (46,452 iters/epoch) = 25.2 img/s |
+| Ultralytics storage probe | `read: 8.3–11.8 MB/s, size: 252–338 KB` |
+
+**Primary metric: sustained it/s**, because it is readable within ~30 minutes of the job
+reaching steady state and is directly comparable at identical batch and imgsz. Secondary:
+the full epoch wall from `results.csv`, and the `Slow image access` probe line, which is what
+tells us whether Tillicum's `/gpfs/scrubbed` is better or worse than klone's for ~300 KB
+files.
+
+**Pre-registered readings.** Speedup `S` = (measured it/s) / 2.1:
+
+| S | reading | consequence |
+|---|---|---|
+| **≥ 1.7×** | the pano arm's 1.74–2.05× transfers to tiles | finishing the arm costs **~$121–138** and lands ~5 days earlier than klone. Worth putting to Jon as a funded decision. |
+| **1.2–1.7×** | real but modest | not worth ~$100+ on an arm whose curve is flat at +0.00037/epoch. Stay on klone, free. |
+| **< 1.2×** | the H200 buys nothing here | migration is dead, **and** the compute-bound reading of the klone evidence above is wrong — the arm is storage-bound on both clusters and the img/s gap between `y11x` and `y26` needs another explanation. |
+
+**What this does NOT answer, correcting item 3 above.** That item claims this measurement
+"tells us whether tiles-vs-pano in the #51 results is an architecture finding or a storage
+artifact." It does not, and the overstatement is worth fixing before it is quoted. Timing one
+epoch establishes whether *tiles training throughput* is storage-limited on a given
+filesystem. Whether the tiles arms' **accuracy** trails pano because they were starved of
+epochs is a different question, and it is answered by running a tiles arm to ep60 — not by a
+stopwatch. This probe prices that run; it does not substitute for it.
+
+**Contamination controls.**
+
+- The source is the **durable snapshot** `/gscratch/makelab/jonf/rampnet_yolo_baseline_51/y11x_tiles/weights/last.pt`,
+  not the live file, which the running klone job rewrites at every epoch boundary. sha256
+  `52cf5013e696…c064`, verified at each hop.
+- It writes to its **own run directory**, `y11x_tiles_h200_probe`. The klone arm keeps
+  running, untouched. Paths are rewritten with the committed
+  `retarget_yolo_checkpoint.py` — without it, `resume=True` restores the checkpoint's
+  `save_dir` and writes back into the original run directory.
+- `epochs=60` is **left alone**. Shortening it would change the LR-decay denominator, and
+  leaving it means the probe run is a legitimate continuation that can simply keep going if
+  the answer is favourable.
+- **The probe's mAP is not a reportable result.** It is a third lineage of this arm, run to
+  measure time. Report its throughput; report accuracy only from the klone arm.
+
 ## Admin
 
 - **Group:** `u_hyak_tillicum_makelab` (UW Groups Service). Jon is a member manager and

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -39,14 +39,22 @@ cancel or preempt jobs that are already running." That is the entire reason to p
 ssh <UWNetID>@tillicum.hyak.uw.edu
 ```
 
-Duo 2FA, same as klone — **Claude cannot authenticate this.** The `wsl-ssh.ps1` helper
-in `dotfiles` has no `tillicum` target yet; adding one (with a `ControlPersist` master,
-mirroring the `klone` block in `ssh_config.wsl`) is a prerequisite for driving Tillicum
-from an agent session. Until then, Tillicum is Jon-only.
+Duo 2FA, same as klone — **Claude cannot authenticate this.** `dotfiles` now has a
+`tillicum` target for `wsl-ssh.ps1` with a `ControlPersist` master, mirroring the
+`klone` block in `ssh_config.wsl`, so an agent session can drive Tillicum over a master
+Jon has already opened. Opening it is still Jon-only, because of Duo.
 
-> The get-started page writes the hostname two ways — `tillicum.hyak.uw.edu` in the
-> hostname field and `tillicum.hyak.edu` in the `ssh` example. The former is almost
-> certainly correct; **UNVERIFIED** until someone logs in.
+**Settled on first login (2026-07-31).** `tillicum.hyak.uw.edu` is the correct hostname
+— the get-started page also writes `tillicum.hyak.edu` in its own `ssh` example, and
+that form is wrong. Jobs `198638`, `198910` and `217298` have since run, so everything
+in this section is now from experience rather than from the docs.
+
+> **Still open: the per-user home path.** It is undocumented, and the recon pass never
+> wrote its answer back here. The as-run commands below use `~/RampNet` and work;
+> `scripts/model_comparison/run_yolo_data_prep_tillicum.slurm` hardcodes
+> `/gpfs/home/$USER/RampNet` as a guess, and whether those are the same path is
+> **UNVERIFIED**. `scripts/tillicum_recon.sh` prints it as item 1 — run it and record
+> the result here. Do not assume it mirrors klone's `/mmfs1/...` layout.
 
 ## The scheduler model: QoS, not partitions
 
@@ -68,9 +76,21 @@ billing handles the rest.
 
 1. **Request `long` QoS** (7 days) via the Tillicum Special QoS Access Request Form.
    This is the clean answer and should be requested now — it gates the #70 rerun.
-2. **Chain 24 h `normal` jobs**, resuming from `weights/last.pt`. Our
-   `run_yolo_train.slurm` already has the resume block for this, and without
-   preemption a resume boundary is predictable rather than random.
+2. **Chain 24 h `normal` jobs**, resuming from `weights/last.pt`. Without preemption a
+   resume boundary is predictable rather than random. `run_yolo_train_tillicum.slurm`
+   implements this as `CHAIN=<n>`: it queues `n` follow-on jobs with
+   `--dependency=afterany`, each decrementing the counter, so the chain is finite and
+   its worst-case cost is fixed at submit time.
+
+   ```bash
+   CHAIN=5 NAME=y11x_tiles_till YOLO_DATA=$DATA/tiles/data.yaml \
+       sbatch scripts/model_comparison/run_yolo_train_tillicum.slurm
+   ```
+
+   `afterany`, not `afterok`: hitting the 24 h wall is the *expected* exit and reports
+   as `TIMEOUT`, so `afterok` would break the chain at the first link. The next job is
+   queued before training starts, so the chain also survives a node failure. It is
+   **off by default** (`CHAIN=0`) because every link bills.
 
 Option 2 works today and needs no approval; option 1 is less operationally fiddly.
 Do 1, fall back to 2.
@@ -87,6 +107,14 @@ GPUs*. **CPU-only jobs are prohibited**; every job must request ≥1 GPU.
 > Operational consequence: our CPU-side data prep (`run_yolo_data.slurm`,
 > `run_yolo_prep.slurm`) has no business on Tillicum. Keep prep on klone, train on
 > Tillicum.
+>
+> **Superseded 2026-07-31 — see "How the data actually got there" below.** The
+> reasoning here is still right (a prep job must hold an H200 it never uses, and it
+> cost us $4.20 to do exactly that), but it assumed a klone → Tillicum transfer path
+> exists. None does, so prep had to run on Tillicum after all, via
+> `scripts/model_comparison/run_yolo_data_prep_tillicum.slurm`. Read "keep prep on
+> klone" as the preference, not the rule: it holds whenever the dataset is already on
+> klone *and can be reached from here*.
 
 ## Cost model
 
@@ -150,6 +178,17 @@ So 2 GPUs is only cheaper *per epoch* if 16 CPUs makes the tiles epoch **more th
 twice** as fast. That is an empirical question, and it is the single best use of the
 free demo hours. See [First runs](#first-runs-what-to-measure).
 
+> **The trick needs `WORKERS` set, or it measures nothing.** Ultralytics defaults to
+> `workers: 8` and then caps at `min(os.cpu_count() // nd, workers)`, so the loader pool
+> does **not** grow with the allocation — it has to be passed explicitly. Until
+> 2026-08-17 `run_yolo_train_tillicum.slurm` never passed it, so a
+> `--gres=gpu:2 --cpus-per-task=16` run would have paid 2× for 8 workers and come back
+> "no faster", answering the question above for the wrong reason. Job `217298` running
+> at `workers=8` on a 1-GPU/8-CPU allocation is the correct value by coincidence, not
+> evidence the knob worked. The script now binds `WORKERS` to `SLURM_CPUS_PER_TASK`;
+> **set it on the first job of a chain**, because a `resume=True` link inherits the
+> loader count baked into `last.pt` and ignores the environment.
+
 ## Storage
 
 `/gpfs/projects/makelab` — **1 TB**, backed up daily, "purged at the end of the
@@ -198,6 +237,14 @@ than they were built under silently invalidates them and forces a full ~911k-fil
 rescan. Budget one slow first epoch on Tillicum to regenerate them, and do not mistake
 it for the steady-state cost. Getting this wrong is invisible: training still works, it
 is just permanently slow.
+
+**And the cache is not the only absolute path in the image.** `prepare_yolo_dataset.py`
+writes `path: <out>` into `data.yaml`, so the packed copy carries the klone path it was
+built under. Ultralytics resolves `train: images/train` against that absolute `path:`,
+and `/gscratch` does not exist here, so the dataset fails to load no matter where the
+image is mounted — and a read-only mount cannot rewrite the file. Bind-mount a
+corrected `data.yaml` over the packed one; the exact commands are in the next-steps
+block `pack_yolo_dataset.slurm` prints. Unlike the cache, this one fails loudly.
 
 Staging order: **`pano` first (76 GB, 193k files)** — it unblocks the smoke test and the
 pano epoch-time measurement while the much larger `tiles` image builds behind it.

--- a/docs/tillicum.md
+++ b/docs/tillicum.md
@@ -470,6 +470,56 @@ fixed to print `MODE: RESUME` / `MODE: FRESH`; this one has not been. The `[resu
 below it is the trustworthy signal. Do not read the `base:` line as the architecture — confirm
 from the `YOLO11x summary: … parameters` line instead.
 
+#### Result: 2.38×, and the reason is storage, not the GPU
+
+Read at iteration ~880 of 46,452, i.e. early in the epoch and well clear of warmup. **The
+confirmed full-epoch time is still pending** and will be differenced from two consecutive
+`results.csv` rows once the job reaches the 7 h wall.
+
+| | klone L40S (`38063498`) | Tillicum H200 (`217298`) | ratio |
+|---|---:|---:|---:|
+| sustained | 2.1 it/s | **5.0 it/s** | **2.38×** |
+| images/s at batch 12 | 25.2 | 60.0 | 2.38× |
+| Ultralytics storage verdict | `Slow image access detected` | **`Fast image access ✅`** | |
+| measured read | 8.3 ± 3.3 / 11.8 ± 4.8 MB/s | **542.9 ± 78.3 MB/s** | **~46–65×** |
+| ping | 0.7 ± 0.1 / 1.3 ± 1.6 ms | 0.5 ± 0.1 ms | |
+| file size probed | 252–338 KB | 338.1 KB | identical |
+
+`S = 2.38 ≥ 1.7`, so by the pre-registered table the migration is **worth putting to Jon as a
+funded decision**. Revised cost, using ~3.0 h/epoch (2.58 h of training at 5.0 it/s plus
+validation over 161,002 tiles): **39 epochs ≈ 117 GPU-h ≈ $105**, about 4.9 days of compute
+against klone's 11.5 days. That is *cheaper* than the $121–138 the pre-registration projected,
+because the speedup beat the pano arm's 1.74–2.05×.
+
+**The pre-registered rationale for choosing this arm was wrong, and the data says so plainly.**
+The section above argued `y11x_tiles` was worth moving because it is *compute*-bound on klone,
+inferring that from `y26_tiles_l40s` sustaining 34.0 img/s against `y11x_tiles`' 25.2 on the
+same storage. Multiply those through by the file size and the inference collapses:
+
+- `y11x_tiles` consumed 25.2 img/s × 338 KB = **8.5 MB/s**
+- `y26_tiles_l40s` consumed 34.0 img/s × 338 KB = **11.5 MB/s**
+- klone's own probe measured that filesystem at **8.3–11.8 MB/s**
+
+Both arms were sitting *on* the storage ceiling, and the img/s gap I read as an architecture
+difference is inside the measured variance of a contended shared filesystem. On Tillicum the
+same arm consumes 20.3 MB/s against 542.9 MB/s available — **4% of capacity** — so there it is
+genuinely GPU-bound, and 2.38× is the H200-vs-L40S compute ratio showing through once storage
+stops being the wall.
+
+The pre-registration anticipated this reading being falsified only by a result *below* 1.2×.
+It was falsified by a result well above it, via a channel the threshold table did not
+contemplate — the storage probe line, which was listed only as a secondary metric. Worth
+remembering that the secondary metric carried the finding.
+
+**What this implies beyond the arm we probed, and did not pay to learn.** If klone's tiles
+throughput is a storage ceiling rather than a per-model property, it applies to `y11l_tiles`
+and `y26_tiles` too — the two arms currently at ep9 after ~23 and ~35 days of projected
+runway. They are smaller models than `y11x`, so unbinding storage should help them at least as
+much. That reframes the whole tiles column of #51 from "these arms are slow" to "these arms
+are on the wrong filesystem", and it is a much better explanation of the ckpt slice-ceiling
+history recorded above than anything model-specific. **It is an inference, not a measurement**
+— no tiles arm other than `y11x` has been timed on Tillicum.
+
 ## Admin
 
 - **Group:** `u_hyak_tillicum_makelab` (UW Groups Service). Jon is a member manager and

--- a/hyak_yolo_runbook.sh
+++ b/hyak_yolo_runbook.sh
@@ -138,13 +138,27 @@ prep)
   # compute-node job instead of running here on a login node:
   #   sbatch -A gpu-l40s-makelab scripts/model_comparison/run_yolo_prep.slurm
   cd "$REPO"
+  # Bind the worker pool to the allocation whenever we are inside one. Left to itself
+  # prepare_yolo_dataset.py defaults to os.cpu_count()-1, and os.cpu_count() reports the
+  # whole NODE while ignoring the Slurm cgroup — so an 8-CPU allocation forks ~63 PIL
+  # workers, each spawning its own BLAS threads and each holding a decoded pano.
+  # run_yolo_prep.slurm has always passed --workers for this reason; callers coming in
+  # through the runbook instead (run_yolo_data_prep_tillicum.slurm) were silently
+  # missing it. Unset and outside Slurm, behaviour is unchanged from the #51 runs.
+  WORKERS="${WORKERS:-${SLURM_CPUS_PER_TASK:-}}"
+  W_ARG=()
+  if [ -n "$WORKERS" ]; then
+      W_ARG=(--workers "$WORKERS")
+      export OPENBLAS_NUM_THREADS=1   # one BLAS thread per worker (no RLIMIT_NPROC storm)
+      echo "workers=$WORKERS  OPENBLAS_NUM_THREADS=1"
+  fi
   "$PYBIN" scripts/model_comparison/prepare_yolo_dataset.py \
       --dataset-root "$REPO/dataset" --out "$YOLODATA/tiles" \
       --geometry tiles --box-size "$BOX_SIZE" --ramp-size-m "$RAMP_SIZE_M" \
-      --bg-keep-frac "$BG_KEEP"
+      --bg-keep-frac "$BG_KEEP" "${W_ARG[@]}"
   "$PYBIN" scripts/model_comparison/prepare_yolo_dataset.py \
       --dataset-root "$REPO/dataset" --out "$YOLODATA/pano" \
-      --geometry pano --box-size "$BOX_SIZE" --ramp-size-m "$RAMP_SIZE_M"
+      --geometry pano --box-size "$BOX_SIZE" --ramp-size-m "$RAMP_SIZE_M" "${W_ARG[@]}"
   echo "OK. Next: bash hyak_yolo_runbook.sh train"
   ;;
 

--- a/scripts/model_comparison/pack_yolo_dataset.slurm
+++ b/scripts/model_comparison/pack_yolo_dataset.slurm
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Pack one YOLO dataset into a SquashFS image, for transfer klone -> Tillicum.
+#
+# WHY SQUASHFS AND NOT rsync/scp/tar
+# The dataset is 286 GB in ~911,000 files (tiles 210 GB / 718,415; pano 76 GB /
+# 192,938 -- measured 2026-07-30). That is metadata-bound, not bandwidth-bound: `du -sh`
+# over the tiles tree beat three timeouts before finishing on a 550 s budget, and even
+# `ls -lU | head -201` on tiles/images/train timed out.
+#
+#   - rsync/scp of the tree pays ~911k round trips. No.
+#   - tar fixes the TRANSFER but not the DESTINATION: untarring recreates all 911k files
+#     on /gpfs, paying the metadata cost again and permanently.
+#   - SquashFS pays it ONCE, here, and the destination only ever sees ONE file. The
+#     training job mounts it read-only and the kernel serves the tree from a compact
+#     in-image index. This is also what UW-IT recommends for many-small-file datasets
+#     (Sumaiya, 2026-07-30).
+#
+# WHY A SLURM JOB AND NOT A LOGIN NODE
+# klone reaps heavy login processes, and that reap also kills the SSH control master
+# every agent session depends on. Never run this interactively.
+#
+# WHERE IT WRITES
+# /gscratch/scrubbed, NOT /gscratch/makelab: lab storage is 84% full with ~168 GB free
+# (checked 2026-07-30) and cannot hold this. scrubbed has ~15 TB free, and its ~21-day
+# purge does not matter for a transient staging area.
+#
+#   DS=pano  sbatch -A ckpt-makelab scripts/model_comparison/pack_yolo_dataset.slurm
+#   DS=tiles sbatch -A ckpt-makelab scripts/model_comparison/pack_yolo_dataset.slurm
+#
+#SBATCH --job-name=yolo_pack
+#SBATCH -p ckpt
+#SBATCH -q ckpt
+#SBATCH --requeue
+#SBATCH --time=12:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --mail-type=NONE
+#SBATCH --output=logs/yolo_pack_%j.out
+#SBATCH --error=logs/yolo_pack_%j.err
+
+set -euo pipefail
+
+DS="${DS:?set DS to pano or tiles}"
+SRC="${SRC:-/gscratch/scrubbed/$USER/yolo}"
+OUT="${OUT:-/gscratch/scrubbed/$USER/yolo_squashfs}"
+mkdir -p "$OUT"
+
+IMG="$OUT/${DS}.sqfs"
+SUM="$IMG.sha256"
+
+echo "--- pack $DS ---"
+echo "src: $SRC/$DS   out: $IMG"
+df -h "$OUT" | tail -1
+
+# Idempotent: a completed, verified image is left alone, so a ckpt requeue or a manual
+# resubmit is free rather than a restart from zero.
+if [ -f "$IMG" ] && [ -f "$SUM" ]; then
+    echo "[skip] image exists; verifying..."
+    if ( cd "$OUT" && sha256sum -c "$(basename "$SUM")" ); then
+        echo "[skip] verified, nothing to do"; exit 0
+    fi
+    echo "[warn] checksum FAILED -- rebuilding"
+    rm -f "$IMG" "$SUM"
+fi
+
+# ---------------------------------------------------------------------------------
+# THE ULTRALYTICS LABEL CACHE IS THE SUBTLE PART -- READ BEFORE CHANGING THIS.
+#
+# Ultralytics writes labels/<split>.cache next to the labels and validates it against a
+# hash of the label+image FILE PATHS. Two consequences:
+#
+#   1. The .cache files MUST be inside the image. They already exist on klone (built
+#      2026-07-25/26), and a read-only mount cannot create them. Without them every run
+#      rescans ~911k files -- exactly the cost this whole exercise exists to avoid.
+#
+#   2. The hash covers absolute paths, so mounting at a DIFFERENT path than the one the
+#      cache was built under INVALIDATES it and forces that same rescan. Mount the image
+#      on Tillicum at a stable path and expect to regenerate the cache ONCE there (it
+#      needs a writable overlay, or a one-off run with labels/ bind-mounted writable).
+#      Budget one slow first epoch; do not mistake it for the steady-state cost.
+#
+# This is called out in docs/tillicum.md too, because getting it wrong is invisible --
+# training still works, it is just silently slow forever.
+# ---------------------------------------------------------------------------------
+echo "[check] label caches that will be packed:"
+ls -la "$SRC/$DS/labels/"*.cache 2>/dev/null || echo "  NONE -- expect a full rescan on first use"
+
+# -noD: do NOT compress data blocks. The payload is JPEG, already compressed; deflating
+# it would burn hours of CPU for ~nothing and make reads slower. Metadata/inodes are
+# still compressed, which is where the win actually is.
+# -no-xattrs: nothing here uses them, and they bloat the index.
+echo "[mksquashfs] starting $(date)"
+mksquashfs "$SRC/$DS" "$IMG" \
+    -noD \
+    -no-xattrs \
+    -processors "${SLURM_CPUS_PER_TASK:-8}" \
+    -info
+echo "[mksquashfs] done $(date)"
+
+# The checksum travels with the image and is verified after transfer, same discipline as
+# the weight snapshot's MANIFEST.md.
+( cd "$OUT" && sha256sum "$(basename "$IMG")" > "$(basename "$SUM")" )
+
+ls -lh "$IMG"
+cat "$SUM"
+
+cat <<EOF
+
+[ok] $DS packed.
+
+Next, on Tillicum -- note /gpfs/scrubbed, not the 1 TB /gpfs/projects/makelab quota
+(UW-IT recommends scrubbed for active many-small-file datasets):
+
+  # mount read-only, no untar, no 911k files ever created on /gpfs
+  apptainer exec --nv \\
+      --bind /gpfs/scrubbed/\$USER/${DS}.sqfs:/data/${DS}:image-src=/ \\
+      <image.sif> <command>
+
+Verify the checksum on arrival BEFORE trusting it:
+  sha256sum -c $(basename "$SUM")
+EOF

--- a/scripts/model_comparison/pack_yolo_dataset.slurm
+++ b/scripts/model_comparison/pack_yolo_dataset.slurm
@@ -62,8 +62,15 @@ if [ -f "$IMG" ] && [ -f "$SUM" ]; then
         echo "[skip] verified, nothing to do"; exit 0
     fi
     echo "[warn] checksum FAILED -- rebuilding"
-    rm -f "$IMG" "$SUM"
 fi
+
+# Unconditional, and OUTSIDE the guard above. A ckpt preemption mid-mksquashfs leaves
+# the image present but the checksum absent, so the guard does not fire and the rm
+# inside it never runs -- and mksquashfs APPENDS to an existing image by default. That
+# path ends with a duplicated image carrying a freshly-written, perfectly valid
+# checksum, which is worse than no checksum at all. -noappend below is the belt to this
+# rm's braces.
+rm -f "$IMG" "$SUM"
 
 # ---------------------------------------------------------------------------------
 # THE ULTRALYTICS LABEL CACHE IS THE SUBTLE PART -- READ BEFORE CHANGING THIS.
@@ -83,6 +90,15 @@ fi
 #
 # This is called out in docs/tillicum.md too, because getting it wrong is invisible --
 # training still works, it is just silently slow forever.
+#
+# THE CACHE IS NOT THE ONLY ABSOLUTE PATH IN HERE. prepare_yolo_dataset.py writes
+# `path: <out>` into data.yaml, so the packed copy carries the klone path it was built
+# under (e.g. /gscratch/scrubbed/$USER/yolo/tiles). Ultralytics resolves
+# `train: images/train` against that absolute `path:`, and /gscratch does not exist on
+# Tillicum -- so the dataset load fails outright no matter where the image is mounted,
+# and a read-only mount cannot rewrite the file to fix it. Unlike the cache, this one
+# fails loudly rather than silently. Handle it at mount time by bind-mounting a
+# rewritten data.yaml over the packed one (see the next-steps block at the end).
 # ---------------------------------------------------------------------------------
 echo "[check] label caches that will be packed:"
 ls -la "$SRC/$DS/labels/"*.cache 2>/dev/null || echo "  NONE -- expect a full rescan on first use"
@@ -92,7 +108,10 @@ ls -la "$SRC/$DS/labels/"*.cache 2>/dev/null || echo "  NONE -- expect a full re
 # still compressed, which is where the win actually is.
 # -no-xattrs: nothing here uses them, and they bloat the index.
 echo "[mksquashfs] starting $(date)"
+# -noappend: mksquashfs's default is to APPEND to an existing image. With --requeue on
+# a preemptable partition that default is a live hazard, not a theoretical one.
 mksquashfs "$SRC/$DS" "$IMG" \
+    -noappend \
     -noD \
     -no-xattrs \
     -processors "${SLURM_CPUS_PER_TASK:-8}" \
@@ -113,9 +132,20 @@ cat <<EOF
 Next, on Tillicum -- note /gpfs/scrubbed, not the 1 TB /gpfs/projects/makelab quota
 (UW-IT recommends scrubbed for active many-small-file datasets):
 
-  # mount read-only, no untar, no 911k files ever created on /gpfs
+  # 1. the packed data.yaml still says path: $SRC/${DS} -- a klone path that does not
+  #    exist on Tillicum, and the image is read-only, so write a corrected copy OUTSIDE
+  #    the image and bind it over the packed one.
+  mkdir -p /gpfs/scrubbed/\$USER/yolo_cfg/${DS}
+  sed 's|^path: .*|path: /data/${DS}|' \\
+      /gpfs/scrubbed/\$USER/yolo_cfg/${DS}/data.yaml.orig \\
+      > /gpfs/scrubbed/\$USER/yolo_cfg/${DS}/data.yaml
+  # (data.yaml.orig is one unsquashfs -f of just that file, or copy it from klone --
+  #  it is a few hundred bytes, so this is the one file worth moving by hand.)
+
+  # 2. mount read-only, no untar, no 911k files ever created on /gpfs
   apptainer exec --nv \\
       --bind /gpfs/scrubbed/\$USER/${DS}.sqfs:/data/${DS}:image-src=/ \\
+      --bind /gpfs/scrubbed/\$USER/yolo_cfg/${DS}/data.yaml:/data/${DS}/data.yaml \\
       <image.sif> <command>
 
 Verify the checksum on arrival BEFORE trusting it:

--- a/scripts/model_comparison/run_yolo_data_prep_tillicum.slurm
+++ b/scripts/model_comparison/run_yolo_data_prep_tillicum.slurm
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Rebuild the YOLO training dataset ON TILLICUM, from Hugging Face. Download + prep.
+#
+# WHY REGENERATE RATHER THAN TRANSFER FROM KLONE
+# There is no automated path from klone to Tillicum: no shared filesystem (/gscratch and
+# /mmfs1 do not exist here), and Tillicum cannot authenticate to klone non-interactively
+# — both ends are Duo/keyboard-interactive with no publickey, so BatchMode fails. Globus
+# CLI is on neither side. Verified 2026-07-30.
+#
+# Regenerating sidesteps all of it, and is SAFE because the prep is deterministic by
+# construction: prepare_yolo_dataset.py thins background tiles with an md5 of the file
+# stem specifically so the choice is stable across processes and runs (see
+# `_keep_background`, and its comment about salted hash()).
+#
+# VERIFY, DO NOT ASSUME. The committed record gives the exact counts klone produced:
+#     tiles 557,413 train / 161,002 val      pano 150,063 train / 42,875 val
+# This job prints its own counts at the end. If they do not match, the datasets are NOT
+# equivalent and nothing trained here is comparable to the #51 runs — stop and diff.
+#
+# WHY A GPU JOB FOR CPU WORK
+# Tillicum prohibits CPU-only jobs; every job must request >=1 GPU. The runbook also
+# warns that login nodes reap heavy long-running processes, and on Tillicum that would
+# take the Duo-authenticated SSH master with it. So we hold one GPU and eat the cost:
+# roughly 6-12 h at $0.90/h, i.e. $5-11. Cheap against a $1,500/month cap.
+#
+#   sbatch scripts/model_comparison/run_yolo_data_prep_tillicum.slurm
+#
+#SBATCH --job-name=yolo_data_prep
+#SBATCH --qos=normal
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=200G
+#SBATCH --time=12:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --mail-type=NONE
+#SBATCH --output=logs/yolo_data_prep_%j.out
+#SBATCH --error=logs/yolo_data_prep_%j.err
+
+set -euo pipefail
+
+export REPO="${REPO:-/gpfs/home/$USER/RampNet}"
+# /gpfs/scrubbed, NOT the 1 TB /gpfs/projects/makelab quota: the HF source is ~462 GB
+# and the prepared YOLO layout another ~286 GB, so this needs ~750 GB. scrubbed has
+# ~484 TB free and is what UW-IT recommends for active many-small-file datasets.
+export SCRATCH="${SCRATCH:-/gpfs/scrubbed/$USER}"
+export PYBIN="${PYBIN:-/gpfs/projects/makelab/$USER/envs/rampnet-yolo/bin/python}"
+export HF_HOME="$SCRATCH/hf"
+export YOLO_CONFIG_DIR="$SCRATCH/ultralytics"
+
+mkdir -p "$SCRATCH"
+
+echo "=== node ==="
+hostname; date
+df -h "$SCRATCH" | tail -1
+echo "=== interpreter (must match the klone #51 runs exactly) ==="
+"$PYBIN" -c "import sys, torch, ultralytics; print('python', sys.version.split()[0], '| torch', torch.__version__, '| ultralytics', ultralytics.__version__)"
+
+cd "$REPO"
+
+echo
+echo "=== STAGE: data (HF download, ~462 GB) ==="
+date
+bash hyak_yolo_runbook.sh data
+
+echo
+echo "=== STAGE: prep (tiles + pano) ==="
+date
+bash hyak_yolo_runbook.sh prep
+
+echo
+echo "=== VERIFICATION — counts must match the klone record ==="
+date
+for ds in tiles pano; do
+    for split in train val; do
+        d="$SCRATCH/yolo/$ds/images/$split"
+        printf "  %-6s %-6s %s\n" "$ds" "$split" "$(ls -U "$d" 2>/dev/null | grep -c '\.jpg$')"
+    done
+done
+cat <<'EOF'
+
+  Expected, from scripts/model_comparison/yolo_baseline/README.md provenance:
+    tiles  train  557413
+    tiles  val    161002
+    pano   train  150063
+    pano   val    42875
+
+  A mismatch means the regenerated dataset is NOT the one the #51 arms trained on.
+  Do not train against it until the difference is understood.
+EOF
+date
+echo "Cost so far: run `hyakusage`"

--- a/scripts/model_comparison/run_yolo_data_prep_tillicum.slurm
+++ b/scripts/model_comparison/run_yolo_data_prep_tillicum.slurm
@@ -66,27 +66,74 @@ bash hyak_yolo_runbook.sh data
 echo
 echo "=== STAGE: prep (tiles + pano) ==="
 date
+# The runbook's prep stage reads SLURM_CPUS_PER_TASK and passes --workers plus
+# OPENBLAS_NUM_THREADS=1 when it is set, matching what run_yolo_prep.slurm does on
+# klone. Without that, prepare_yolo_dataset.py sizes its pool from os.cpu_count(),
+# which reports the whole node and ignores our 8-CPU cgroup.
 bash hyak_yolo_runbook.sh prep
 
 echo
 echo "=== VERIFICATION — counts must match the klone record ==="
 date
+
+# This is a GATE, not a report. The header promises "stop and diff" on a mismatch, so a
+# mismatch has to exit non-zero: a job that prints 557,398 next to 557,413 and still
+# exits 0 reads as green to anyone skimming the tail of the log, and the next person
+# trains an arm that is not comparable to #51 without ever knowing.
+#
+# Expected counts come from scripts/model_comparison/yolo_baseline/README.md provenance.
+# Both images/ and labels/ are checked — they are written as a pair by _write_pair, so a
+# divergence between them is exactly the kind of partial-run damage worth catching.
+declare -A EXPECTED=(
+    [tiles/train]=557413
+    [tiles/val]=161002
+    [pano/train]=150063
+    [pano/val]=42875
+)
+
+fail=0
 for ds in tiles pano; do
     for split in train val; do
-        d="$SCRATCH/yolo/$ds/images/$split"
-        printf "  %-6s %-6s %s\n" "$ds" "$split" "$(ls -U "$d" 2>/dev/null | grep -c '\.jpg$')"
+        want="${EXPECTED[$ds/$split]}"
+        for kind in images labels; do
+            d="$SCRATCH/yolo/$ds/$kind/$split"
+            if [ "$kind" = images ]; then
+                got="$(ls -U "$d" 2>/dev/null | grep -c '\.jpg$' || true)"
+            else
+                got="$(ls -U "$d" 2>/dev/null | grep -c '\.txt$' || true)"
+            fi
+            if [ "$got" -eq "$want" ]; then
+                printf "  ok   %-5s %-6s %-5s %8s\n" "$ds" "$kind" "$split" "$got"
+            else
+                printf "  FAIL %-5s %-6s %-5s %8s  (expected %s)\n" \
+                    "$ds" "$kind" "$split" "$got" "$want"
+                fail=1
+            fi
+        done
     done
 done
-cat <<'EOF'
 
-  Expected, from scripts/model_comparison/yolo_baseline/README.md provenance:
-    tiles  train  557413
-    tiles  val    161002
-    pano   train  150063
-    pano   val    42875
+if [ "$fail" -ne 0 ]; then
+    cat <<'EOF'
 
-  A mismatch means the regenerated dataset is NOT the one the #51 arms trained on.
-  Do not train against it until the difference is understood.
+!! MISMATCH. The regenerated dataset is NOT the one the #51 arms trained on.
+!! Do not train against it until the difference is understood.
+
+Next step is the filename-level check, which is stronger than counts and is what the
+doc's equivalence table reports. Per directory, on BOTH clusters:
+
+    ls -U <root>/yolo/<dir> | sort | md5sum
+
+  klone root    /gscratch/scrubbed/jfroehli
+  Tillicum root /gpfs/scrubbed/jfroehli
 EOF
+    date
+    exit 1
+fi
+
+echo
+echo "  All eight directories match the klone record."
+echo "  Counts are necessary, not sufficient — for the filename-level check see"
+echo "  docs/tillicum.md, 'Verified equivalent to klone'."
 date
-echo "Cost so far: run `hyakusage`"
+echo 'Cost so far: run `hyakusage`'

--- a/scripts/model_comparison/run_yolo_train_tillicum.slurm
+++ b/scripts/model_comparison/run_yolo_train_tillicum.slurm
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Train one YOLO curb-ramp detector on the RampNet dataset, on TILLICUM.
+#
+# Port of run_yolo_train.slurm (klone). Kept as a SEPARATE file rather than
+# branching inside the klone script, because nearly every scheduler directive
+# differs and the klone version is the preserved record of the #51 runs -- it
+# should not churn. See docs/tillicum.md for the directive-by-directive diff.
+#
+# WHAT CHANGED FROM THE KLONE VERSION, AND WHY
+#   -p ckpt-g2 / -q ckpt-gpu  ->  --qos=normal   Tillicum has NO partitions; QoS only.
+#   --requeue                 ->  dropped        Nothing preempts on Tillicum.
+#   --time=72:00:00           ->  24:00:00       normal QoS caps at 24 h. 7-day jobs
+#                                                need `long` QoS (pre-approval).
+#   --gpus-per-node=1         ->  --gres=gpu:N   Tillicum's documented spelling.
+#   --cpus-per-task=12        ->  8 x N GPUs     HARD 8:1 ratio; 12-on-1 is REJECTED.
+#   (no mail directive)       ->  --mail-type=NONE   Be explicit so the site default
+#                                                cannot decide for us (on klone an
+#                                                inherited END,FAIL,TIME_LIMIT produced
+#                                                ~1 email per minute under preemption).
+#
+#   YOLO_DATA=$DATA/pano/data.yaml YOLO_IMGSZ=1280 BATCH=4 NAME=y26_pano_till \
+#       sbatch scripts/model_comparison/run_yolo_train_tillicum.slurm
+#
+# COST. Tillicum BILLS: $0.90/GPU-hour where GPU-hour = elapsed x N GPUs. A 24 h
+# 2-GPU job is 48 GPU-hours (~$43). Do not leave allocations idle. Check `hyakusage`.
+#SBATCH --qos=normal
+#SBATCH --job-name=yolo_curb_ramp_train
+#SBATCH --time=24:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --mail-type=NONE
+#SBATCH --output=logs/yolo_train_till_%j.out
+#SBATCH --error=logs/yolo_train_till_%j.err
+# gres/cpus/mem are NOT hardcoded -- see the GPUS block below, which must be kept in
+# step with them. Override at submit time with: sbatch --gres=gpu:2 --cpus-per-task=16
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=200G
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------------
+# The 2-GPU dataloader trick, and why DEVICE is separate from the allocation.
+#
+# Tillicum fixes CPUs at 8 per GPU. Our tiles arm is I/O-bound (the same epoch took
+# 4.1-9.5 h on klone depending only on which node it landed on), so more dataloader
+# workers is the obvious lever -- but on Tillicum more CPUs means more GPUs.
+#
+# The naive move -- allocate 2 GPUs and let ultralytics use both -- is NOT a clean
+# experiment: 2 GPUs puts ultralytics into DDP, which changes the effective batch and
+# the LR dynamics, so the result is no longer comparable to the klone single-GPU runs.
+#
+# So: allocate 2 GPUs for their 16 CPUs, but pin DEVICE=0 so training math is
+# IDENTICAL to a 1-GPU run. The second GPU sits idle and we pay for it. That is the
+# point -- it isolates dataloader throughput as the only changed variable, and it
+# answers whether the 2x bill buys more than a 2x speedup. Set DEVICE=0,1 only if you
+# deliberately want a DDP run, and label it as a different arm.
+# ---------------------------------------------------------------------------------
+DEVICE="${DEVICE:-0}"
+
+YOLO_CKPT="${YOLO_CKPT:-yolo11l.pt}"
+YOLO_DATA="${YOLO_DATA:?set YOLO_DATA to a prepared data.yaml}"
+YOLO_IMGSZ="${YOLO_IMGSZ:-1024}"
+EPOCHS="${EPOCHS:-60}"
+BATCH="${BATCH:--1}"                          # pin per config to match the klone runs
+PATIENCE="${PATIENCE:-20}"
+# On klone this defaulted to 0 because ultralytics `time=` restarts its clock on every
+# preemption. Tillicum never preempts, so `time=` is safe here -- but leave it 0 for
+# any run meant to be comparable to the #51 klone results, which are epoch-based.
+TRAIN_HOURS="${TRAIN_HOURS:-0}"
+NAME="${NAME:-yolo_run_till}"
+
+# Tillicum storage. /gpfs/projects/makelab is 1 TB, backed up daily, and PURGED AT END
+# OF PROJECT -- it is NOT archival. Only best.pt matters downstream: rsync it back to
+# klone /gscratch/makelab, which stays the system of record.
+GPFS="${GPFS:-/gpfs/projects/makelab/$USER}"
+export HF_HOME="${HF_HOME:-$GPFS/hf}"
+PROJECT="${PROJECT:-$GPFS/yolo_runs}"
+export YOLO_CONFIG_DIR="${YOLO_CONFIG_DIR:-$GPFS/ultralytics}"
+mkdir -p "$PROJECT" "$YOLO_CONFIG_DIR" "$HF_HOME"
+
+# PYTHON points at an interpreter with ultralytics. On Tillicum the DOCUMENTED path is
+# an Apptainer container (NGC PyTorch + `pip install ultralytics`), not a conda module
+# -- our environment.yml pins CUDA 11.8 against what is now a Rocky 9 / H200 host and
+# should not be assumed to transfer. Set PYTHON, or set APPTAINER_IMG to run in one.
+PYTHON="${PYTHON:-python}"
+APPTAINER_IMG="${APPTAINER_IMG:-}"
+
+echo "--- YOLO train on TILLICUM (issue #51 / #70) ---"
+echo "base:   ${YOLO_CKPT}"
+echo "data:   ${YOLO_DATA}"
+echo "imgsz:  ${YOLO_IMGSZ}   epochs: ${EPOCHS}   batch: ${BATCH}   patience: ${PATIENCE}"
+echo "alloc:  ${SLURM_GPUS_ON_NODE:-?} GPU(s), ${SLURM_CPUS_PER_TASK:-?} CPUs on ${SLURMD_NODENAME:-?}"
+echo "device: ${DEVICE}   (allocation and device differ on purpose -- see header)"
+echo "out:    ${PROJECT}/${NAME}/weights/best.pt"
+nvidia-smi --query-gpu=name,memory.total --format=csv || true
+echo "------------------------------------------------"
+
+run_train() {
+    "$@" - "$YOLO_CKPT" "$YOLO_DATA" "$YOLO_IMGSZ" "$EPOCHS" "$BATCH" "$PATIENCE" \
+            "$PROJECT" "$NAME" "$TRAIN_HOURS" "$DEVICE" <<'PY'
+import os, sys
+from ultralytics import YOLO
+ckpt, data, imgsz, epochs, batch, patience, project, name, hours, device = sys.argv[1:11]
+last = os.path.join(project, name, "weights", "last.pt")
+# Still needed on Tillicum, but for a different reason than on klone: not preemption,
+# but the 24 h normal-QoS ceiling. A 60-epoch tiles schedule does not fit in one job,
+# so chain jobs and resume. Unlike klone the boundary is predictable, not random.
+if os.path.exists(last):
+    print(f"[resume] {last} exists -> resuming", flush=True)
+    YOLO(last).train(resume=True)
+else:
+    bf = float(batch)
+    batch_arg = int(bf) if bf.is_integer() else bf
+    dev = [int(d) for d in device.split(",")] if "," in device else int(device)
+    kw = dict(
+        data=data, imgsz=int(imgsz), epochs=int(epochs), batch=batch_arg,
+        patience=int(patience), project=project, name=name, device=dev, exist_ok=True,
+    )
+    if float(hours) > 0:
+        kw["time"] = float(hours)
+    YOLO(ckpt).train(**kw)
+PY
+}
+
+# run_train takes the interpreter as "$@", so the container case is just a longer
+# command word -- the heredoc still lands on its stdin and every shell variable is
+# expanded HERE, outside the container, before apptainer is ever invoked.
+# --nv exposes the GPUs; bind /gpfs so the container sees data, runs and cache.
+if [ -n "$APPTAINER_IMG" ]; then
+    run_train apptainer exec --nv --bind /gpfs:/gpfs "$APPTAINER_IMG" python
+else
+    run_train "$PYTHON"
+fi

--- a/scripts/model_comparison/run_yolo_train_tillicum.slurm
+++ b/scripts/model_comparison/run_yolo_train_tillicum.slurm
@@ -8,7 +8,11 @@
 #
 # WHAT CHANGED FROM THE KLONE VERSION, AND WHY
 #   -p ckpt-g2 / -q ckpt-gpu  ->  --qos=normal   Tillicum has NO partitions; QoS only.
-#   --requeue                 ->  dropped        Nothing preempts on Tillicum.
+#   --requeue                 ->  CHAIN=<n>      Nothing preempts on Tillicum, so the
+#                                                requeue is unnecessary -- but the 24 h
+#                                                ceiling is not, so the unattended
+#                                                continuation it also bought is replaced
+#                                                by a bounded afterany chain, not lost.
 #   --time=72:00:00           ->  24:00:00       normal QoS caps at 24 h. 7-day jobs
 #                                                need `long` QoS (pre-approval).
 #   --gpus-per-node=1         ->  --gres=gpu:N   Tillicum's documented spelling.
@@ -18,8 +22,12 @@
 #                                                inherited END,FAIL,TIME_LIMIT produced
 #                                                ~1 email per minute under preemption).
 #
-#   YOLO_DATA=$DATA/pano/data.yaml YOLO_IMGSZ=1280 BATCH=4 NAME=y26_pano_till \
-#       sbatch scripts/model_comparison/run_yolo_train_tillicum.slurm
+#   YOLO_CKPT=yolo26l.pt YOLO_DATA=$DATA/pano/data.yaml YOLO_IMGSZ=1280 BATCH=4 \
+#       NAME=y26_pano_till sbatch scripts/model_comparison/run_yolo_train_tillicum.slurm
+#
+#   ALWAYS set YOLO_CKPT explicitly. It defaults to yolo11l.pt, so omitting it under a
+#   y26_* NAME trains the wrong architecture under a right-looking name, and the only
+#   signal is one `base:` line in the log header.
 #
 # COST. Tillicum BILLS: $0.90/GPU-hour where GPU-hour = elapsed x N GPUs. A 24 h
 # 2-GPU job is 48 GPU-hours (~$43). Do not leave allocations idle. Check `hyakusage`.
@@ -31,8 +39,14 @@
 #SBATCH --mail-type=NONE
 #SBATCH --output=logs/yolo_train_till_%j.out
 #SBATCH --error=logs/yolo_train_till_%j.err
-# gres/cpus/mem are NOT hardcoded -- see the GPUS block below, which must be kept in
-# step with them. Override at submit time with: sbatch --gres=gpu:2 --cpus-per-task=16
+# The 1-GPU defaults below are deliberate, and all THREE move together: Tillicum binds
+# 8 CPUs *and* 200 GB per GPU, so overriding one alone gets you a starved job rather
+# than a bigger one. For the 2-GPU dataloader arm (see the DEVICE block) override all
+# three, and raise WORKERS to match -- ultralytics will not use the extra CPUs on its
+# own:
+#
+#   WORKERS=16 ... sbatch --gres=gpu:2 --cpus-per-task=16 --mem=400G <this script>
+#
 #SBATCH --gres=gpu:1
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=200G
@@ -55,8 +69,15 @@ set -euo pipefail
 # point -- it isolates dataloader throughput as the only changed variable, and it
 # answers whether the 2x bill buys more than a 2x speedup. Set DEVICE=0,1 only if you
 # deliberately want a DDP run, and label it as a different arm.
+#
+# NONE OF WHICH WORKS WITHOUT WORKERS. Ultralytics defaults to `workers: 8` and then
+# caps at min(os.cpu_count() // nd, workers), so the loader pool does NOT grow with the
+# allocation -- it has to be passed explicitly. Until this was wired up, the whole
+# trick bought an idle second GPU and nothing else: job 217298 echoed `workers=8` while
+# holding CPUs it never used. Bind it to the allocation and it follows --cpus-per-task.
 # ---------------------------------------------------------------------------------
 DEVICE="${DEVICE:-0}"
+WORKERS="${WORKERS:-${SLURM_CPUS_PER_TASK:-8}}"
 
 YOLO_CKPT="${YOLO_CKPT:-yolo11l.pt}"
 YOLO_DATA="${YOLO_DATA:?set YOLO_DATA to a prepared data.yaml}"
@@ -86,6 +107,24 @@ SAVE_PERIOD="${SAVE_PERIOD:-5}"
 TRAIN_HOURS="${TRAIN_HOURS:-0}"
 NAME="${NAME:-yolo_run_till}"
 
+# CHAIN: how many follow-on jobs to queue behind this one, each resuming from
+# weights/last.pt. Default 0 -- this BILLS, so it is opt-in and bounded rather than an
+# open-ended requeue loop.
+#
+# klone's --requeue gave unattended continuation for free. Tillicum never preempts, but
+# --time=24:00:00 is a hard ceiling, so a 60-epoch tiles schedule at ~3.0 h/epoch still
+# needs about five slices. Without this, each slice is a resubmit somebody has to
+# remember -- the same silent-stall failure mode that stranded the #51 ckpt arms.
+#
+#   CHAIN=5 NAME=y11x_tiles_till YOLO_DATA=... sbatch <this script>
+#
+# afterany, not afterok: hitting the walltime is the EXPECTED exit here and it reports
+# as TIMEOUT, so afterok would break the chain at the first link.
+CHAIN="${CHAIN:-0}"
+# $0 inside a batch job is Slurm's spool copy, not this file, so the chain needs an
+# explicit path back to the repo checkout.
+SELF="${SELF:-$HOME/RampNet/scripts/model_comparison/run_yolo_train_tillicum.slurm}"
+
 # Tillicum storage. /gpfs/projects/makelab is 1 TB, backed up daily, and PURGED AT END
 # OF PROJECT -- it is NOT archival. Only best.pt matters downstream: rsync it back to
 # klone /gscratch/makelab, which stays the system of record.
@@ -107,18 +146,38 @@ echo "base:   ${YOLO_CKPT}"
 echo "data:   ${YOLO_DATA}"
 echo "imgsz:  ${YOLO_IMGSZ}   epochs: ${EPOCHS}   batch: ${BATCH}   patience: ${PATIENCE}"
 echo "alloc:  ${SLURM_GPUS_ON_NODE:-?} GPU(s), ${SLURM_CPUS_PER_TASK:-?} CPUs on ${SLURMD_NODENAME:-?}"
-echo "device: ${DEVICE}   (allocation and device differ on purpose -- see header)"
+echo "device: ${DEVICE}   workers: ${WORKERS}   (allocation and device differ on purpose -- see header)"
+echo "chain:  ${CHAIN} follow-on job(s) queued after this one"
 echo "out:    ${PROJECT}/${NAME}/weights/best.pt"
 nvidia-smi --query-gpu=name,memory.total --format=csv || true
 echo "------------------------------------------------"
 
+# Queue the next link BEFORE training starts, so the chain survives this job dying for
+# any reason -- walltime, node failure, OOM. Each link decrements CHAIN, so the total
+# cost is bounded at submit time and the chain terminates on its own.
+if [ "${CHAIN}" -gt 0 ] 2>/dev/null; then
+    if [ ! -f "$SELF" ]; then
+        echo "[chain] SKIPPED -- \$SELF ($SELF) is not a file. Set SELF to this script's"
+        echo "[chain] path in the repo checkout, or resubmit by hand."
+    else
+        echo "[chain] queueing 1 follow-on job (it will carry CHAIN=$((CHAIN - 1)))"
+        CHAIN="$((CHAIN - 1))" sbatch \
+            --dependency=afterany:"${SLURM_JOB_ID}" \
+            --gres="gpu:${SLURM_GPUS_ON_NODE:-1}" \
+            --cpus-per-task="${SLURM_CPUS_PER_TASK:-8}" \
+            --mem="${SLURM_MEM_PER_NODE:-200G}" \
+            "$SELF" \
+            || echo "[chain] sbatch FAILED -- this job continues, but nothing follows it"
+    fi
+fi
+
 run_train() {
     "$@" - "$YOLO_CKPT" "$YOLO_DATA" "$YOLO_IMGSZ" "$EPOCHS" "$BATCH" "$PATIENCE" \
-            "$PROJECT" "$NAME" "$TRAIN_HOURS" "$DEVICE" "$SAVE_PERIOD" <<'PY'
+            "$PROJECT" "$NAME" "$TRAIN_HOURS" "$DEVICE" "$SAVE_PERIOD" "$WORKERS" <<'PY'
 import os, sys
 from ultralytics import YOLO
 (ckpt, data, imgsz, epochs, batch, patience, project, name, hours, device,
- save_period) = sys.argv[1:12]
+ save_period, workers) = sys.argv[1:13]
 last = os.path.join(project, name, "weights", "last.pt")
 # Still needed on Tillicum, but for a different reason than on klone: not preemption,
 # but the 24 h normal-QoS ceiling. A 60-epoch tiles schedule does not fit in one job,
@@ -128,6 +187,11 @@ last = os.path.join(project, name, "weights", "last.pt")
 # resumed from a klone checkpoint keeps that run's save_period=-1 -- SAVE_PERIOD above
 # does NOT apply to it. Per-epoch checkpoints therefore exist only for runs STARTED
 # under this script. For the klone arms the early-epoch weights are already gone.
+#
+# The same applies to WORKERS: a resumed run keeps the loader count baked into the
+# checkpoint, so raising it here has no effect on a resume. To change workers you have
+# to START a run under this script. That matters for the CHAIN path above -- set
+# WORKERS on the FIRST link, because links 2..n inherit it from last.pt regardless.
 #
 # That is less costly than it sounds: the compute-matched point we most want (YOLO at
 # roughly RampNet's ~1-epoch budget) is exactly the ep1 best.pt that four of the six
@@ -142,7 +206,7 @@ else:
     kw = dict(
         data=data, imgsz=int(imgsz), epochs=int(epochs), batch=batch_arg,
         patience=int(patience), project=project, name=name, device=dev, exist_ok=True,
-        save_period=int(save_period),
+        save_period=int(save_period), workers=int(workers),
     )
     if float(hours) > 0:
         kw["time"] = float(hours)

--- a/scripts/model_comparison/run_yolo_train_tillicum.slurm
+++ b/scripts/model_comparison/run_yolo_train_tillicum.slurm
@@ -64,6 +64,22 @@ YOLO_IMGSZ="${YOLO_IMGSZ:-1024}"
 EPOCHS="${EPOCHS:-60}"
 BATCH="${BATCH:--1}"                          # pin per config to match the klone runs
 PATIENCE="${PATIENCE:-20}"
+
+# Keep a checkpoint every N epochs. Ultralytics defaults save_period=-1, keeping ONLY
+# last.pt and best.pt -- which forecloses, permanently and retroactively, any analysis
+# that needs a checkpoint from a specific epoch.
+#
+# The one we care about: RampNet's published model was trained for ~1 epoch / ~9.4k
+# steps at constant LR (#84), while this baseline gets 60 epochs with a schedule. If
+# RampNet wins anyway that is a STRONGER result -- but only if we can also report a
+# COMPUTE-MATCHED YOLO point, i.e. the checkpoint at the epoch where YOLO has consumed
+# comparable training, not just the converged one. That requires the checkpoint to
+# still exist. results.csv gives per-epoch val metrics but no weights, so it cannot be
+# reconstructed after the fact.
+#
+# Cost is disk (~150 MB per checkpoint per arm) against a 1 TB allocation. Cheap
+# insurance for an option that cannot be bought back later.
+SAVE_PERIOD="${SAVE_PERIOD:-5}"
 # On klone this defaulted to 0 because ultralytics `time=` restarts its clock on every
 # preemption. Tillicum never preempts, so `time=` is safe here -- but leave it 0 for
 # any run meant to be comparable to the #51 klone results, which are epoch-based.
@@ -98,14 +114,24 @@ echo "------------------------------------------------"
 
 run_train() {
     "$@" - "$YOLO_CKPT" "$YOLO_DATA" "$YOLO_IMGSZ" "$EPOCHS" "$BATCH" "$PATIENCE" \
-            "$PROJECT" "$NAME" "$TRAIN_HOURS" "$DEVICE" <<'PY'
+            "$PROJECT" "$NAME" "$TRAIN_HOURS" "$DEVICE" "$SAVE_PERIOD" <<'PY'
 import os, sys
 from ultralytics import YOLO
-ckpt, data, imgsz, epochs, batch, patience, project, name, hours, device = sys.argv[1:11]
+(ckpt, data, imgsz, epochs, batch, patience, project, name, hours, device,
+ save_period) = sys.argv[1:12]
 last = os.path.join(project, name, "weights", "last.pt")
 # Still needed on Tillicum, but for a different reason than on klone: not preemption,
 # but the 24 h normal-QoS ceiling. A 60-epoch tiles schedule does not fit in one job,
 # so chain jobs and resume. Unlike klone the boundary is predictable, not random.
+#
+# CAVEAT: resume=True reuses every training arg SAVED IN THE CHECKPOINT, so a run
+# resumed from a klone checkpoint keeps that run's save_period=-1 -- SAVE_PERIOD above
+# does NOT apply to it. Per-epoch checkpoints therefore exist only for runs STARTED
+# under this script. For the klone arms the early-epoch weights are already gone.
+#
+# That is less costly than it sounds: the compute-matched point we most want (YOLO at
+# roughly RampNet's ~1-epoch budget) is exactly the ep1 best.pt that four of the six
+# klone arms are still holding. The "one-epoch models" are the matched comparison.
 if os.path.exists(last):
     print(f"[resume] {last} exists -> resuming", flush=True)
     YOLO(last).train(resume=True)
@@ -116,6 +142,7 @@ else:
     kw = dict(
         data=data, imgsz=int(imgsz), epochs=int(epochs), batch=batch_arg,
         patience=int(patience), project=project, name=name, device=dev, exist_ok=True,
+        save_period=int(save_period),
     )
     if float(hours) > 0:
         kw["time"] = float(hours)

--- a/scripts/tillicum_recon.sh
+++ b/scripts/tillicum_recon.sh
@@ -43,8 +43,13 @@ sinfo -o "%.14P %.6a %.10l %.6D %.6t %N" 2>&1 | head -10 | sed 's/^/  /'
 echo "-- QoS available to us --"
 sacctmgr -nP show assoc user="$USER" format=Account,QOS 2>&1 | sed 's/^/  /'
 echo "-- do we already have long/wide/urgent? --"
-sacctmgr -nP show assoc user="$USER" format=QOS 2>/dev/null | tr ',' '\n' \
-    | grep -iE "long|wide|urgent" | sed 's/^/  /' || echo "  (none -- long QoS needs the request form)"
+# The || has to sit INSIDE the subshell, before the sed: sed exits 0 on empty input, so
+# attaching the fallback to the whole pipeline makes it unreachable and a no-QoS result
+# prints as a blank section indistinguishable from sacctmgr having failed. Same shape as
+# the quota and hyakusage checks above and below.
+( sacctmgr -nP show assoc user="$USER" format=QOS 2>/dev/null | tr ',' '\n' \
+    | grep -iE "long|wide|urgent" || echo "(none -- long QoS needs the request form)" ) \
+    | sed 's/^/  /'
 
 echo
 echo "## 4. BILLING"

--- a/scripts/tillicum_recon.sh
+++ b/scripts/tillicum_recon.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Tillicum first-login recon. Read-only, ~10 seconds, submits nothing and costs nothing.
+#
+# Everything in docs/tillicum.md marked UNVERIFIED was written from the public docs
+# without an account. This settles those items in one pass so the doc, the dotfiles
+# ssh target, and run_yolo_train_tillicum.slurm can be corrected from fact.
+#
+#   ./scripts/tillicum_recon.sh              (on a Tillicum login node)
+#   wsl-ssh.ps1 tillicum script scripts/tillicum_recon.sh     (from a Claude session)
+#
+# CPU-only jobs are prohibited on Tillicum, so this deliberately runs on the LOGIN
+# node -- it is all metadata queries, nothing that would warrant an allocation.
+
+echo "=============================================================="
+echo " Tillicum recon -- $(date)"
+echo " host: $(hostname)   user: $USER"
+echo "=============================================================="
+
+echo
+echo "## 1. HOME PATH  (the top unknown -- wsl-ssh.ps1 currently guesses)"
+echo "home:      $(cd ~ && pwd)"
+echo "quota:"
+( quota -s 2>/dev/null || echo "  (quota not available)" ) | sed 's/^/  /'
+
+echo
+echo "## 2. PROJECT STORAGE"
+for d in /gpfs/projects/makelab /gpfs/projects /gpfs; do
+    if [ -d "$d" ]; then
+        echo "$d exists; writable=$( [ -w "$d" ] && echo yes || echo NO )"
+        df -h "$d" 2>/dev/null | tail -1 | sed 's/^/  /'
+        break
+    else
+        echo "$d MISSING"
+    fi
+done
+echo "contents of /gpfs/projects/makelab:"
+ls -la /gpfs/projects/makelab 2>&1 | head -10 | sed 's/^/  /'
+
+echo
+echo "## 3. SCHEDULER  (expect: no partitions, QoS-driven)"
+echo "-- sinfo --"
+sinfo -o "%.14P %.6a %.10l %.6D %.6t %N" 2>&1 | head -10 | sed 's/^/  /'
+echo "-- QoS available to us --"
+sacctmgr -nP show assoc user="$USER" format=Account,QOS 2>&1 | sed 's/^/  /'
+echo "-- do we already have long/wide/urgent? --"
+sacctmgr -nP show assoc user="$USER" format=QOS 2>/dev/null | tr ',' '\n' \
+    | grep -iE "long|wide|urgent" | sed 's/^/  /' || echo "  (none -- long QoS needs the request form)"
+
+echo
+echo "## 4. BILLING"
+echo "-- hyakusage --"
+( command -v hyakusage >/dev/null && hyakusage 2>&1 || echo "  hyakusage NOT on PATH" ) | sed 's/^/  /'
+
+echo
+echo "## 5. SOFTWARE  (docs say Apptainer, not modules -- verify)"
+for t in apptainer singularity module conda python3 nvidia-smi rsync globus; do
+    p=$(command -v "$t" 2>/dev/null)
+    printf "  %-12s %s\n" "$t" "${p:-NOT FOUND}"
+done
+echo "-- apptainer version --"
+( apptainer --version 2>&1 || echo "  n/a" ) | sed 's/^/  /'
+echo "-- modules, if any --"
+( module avail 2>&1 | head -15 || echo "  n/a" ) | sed 's/^/  /'
+
+echo
+echo "## 6. MAIL  (klone forced END,FAIL,TIME_LIMIT via a lua job_submit plugin and"
+echo "##     ~1 email/min under preemption -- check whether Tillicum does the same)"
+scontrol show config 2>/dev/null \
+    | grep -iE "JobSubmitPlugins|MailProg|MailDomain|PreemptMode|MaxJobCount" | sed 's/^/  /'
+
+echo
+echo "## 7. NETWORK PATH BACK TO KLONE  (286 GB / ~911k files has to cross)"
+echo "  NOTE: transfer ARCHIVES, not the tree. Per-file copy would pay ~911k round trips."
+for h in klone.hyak.uw.edu; do
+    printf "  %-24s " "$h"
+    ( timeout 5 bash -c "</dev/tcp/$h/22" 2>/dev/null && echo "port 22 reachable" ) || echo "port 22 NOT reachable from here"
+done
+
+echo
+echo "=============================================================="
+echo " Next: update docs/tillicum.md (home path, QoS, mail, software),"
+echo " fix Home in wsl-ssh.ps1 \$Targets, then run the debug smoke test."
+echo "=============================================================="

--- a/scripts/tillicum_setup_env.sh
+++ b/scripts/tillicum_setup_env.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Build a Tillicum training environment that MATCHES the klone #51 runs exactly.
+#
+# WHY EXACT PINS AND NOT "latest"
+# The whole point of the Tillicum move is to finish the supervised-YOLO baseline so it
+# can be compared against RampNet without a "you undertrained the baseline" objection.
+# Resuming klone checkpoints into a different torch/ultralytics, or comparing a
+# Tillicum-trained arm against a klone-trained one across library versions, reintroduces
+# exactly the uncontrolled variable that #71's protocol exists to eliminate.
+#
+# The reference is not the README -- it is the training job logs themselves
+# (logs/yolo_train_37745363.out on klone), which report:
+#
+#     Python-3.11.15   Ultralytics 8.4.105   torch-2.13.0+cu126
+#
+# A naive `pip install torch ultralytics` on Tillicum gives torch 2.8.0 + ultralytics
+# 8.4.113, because Tillicum's SYSTEM python is 3.9.25 and the cu126 index tops out at
+# 2.8.0 for 3.9. Hence the conda module: it is the only way to get 3.11 here.
+#
+# WHERE IT LIVES
+# /gpfs/projects/makelab -- the 1 TB backed-up allocation, not /gpfs/scrubbed. The
+# dataset belongs on scrubbed (it is huge and reproducible); the environment is small
+# and annoying to rebuild, so it belongs where there are backups.
+#
+#   wsl-ssh.ps1 tillicum script scripts/tillicum_setup_env.sh
+
+set -euo pipefail
+
+PYVER="3.11.15"
+TORCH="2.13.0+cu126"
+ULTRA="8.4.105"
+TORCH_INDEX="https://download.pytorch.org/whl/cu126"
+
+ENVROOT="${ENVROOT:-/gpfs/projects/makelab/$USER/envs}"
+ENVDIR="$ENVROOT/rampnet-yolo"
+
+echo "=== target: python $PYVER / torch $TORCH / ultralytics $ULTRA ==="
+mkdir -p "$ENVROOT"
+
+module load conda
+conda --version
+
+if [ ! -x "$ENVDIR/bin/python" ]; then
+    echo "=== creating conda env at $ENVDIR ==="
+    conda create -y -p "$ENVDIR" "python=$PYVER"
+else
+    echo "=== env exists, reusing $ENVDIR ==="
+fi
+
+PY="$ENVDIR/bin/python"
+"$PY" -V
+
+echo "=== is the pinned torch actually available for this interpreter? ==="
+# Fail loudly HERE rather than silently installing a different version: a mismatched
+# torch is the kind of thing that produces plausible numbers and an unpublishable
+# comparison.
+if ! "$PY" -m pip index versions torch --index-url "$TORCH_INDEX" 2>&1 | grep -q "${TORCH}"; then
+    echo "!! torch $TORCH NOT available for $("$PY" -V). Available:"
+    "$PY" -m pip index versions torch --index-url "$TORCH_INDEX" 2>&1 | head -3
+    echo "!! Refusing to install a substitute -- that would break comparability with #51."
+    exit 1
+fi
+
+echo "=== installing pinned torch ==="
+"$PY" -m pip install --upgrade pip
+"$PY" -m pip install "torch==$TORCH" --index-url "$TORCH_INDEX"
+
+echo "=== installing pinned ultralytics ==="
+# --no-deps would risk a broken install; instead pin ultralytics and let it resolve its
+# own deps, then assert torch was not silently upgraded underneath us.
+"$PY" -m pip install "ultralytics==$ULTRA"
+
+echo "=== VERIFY (this is the gate, not the install) ==="
+"$PY" - <<PY
+import sys, torch, ultralytics
+ok = True
+print("python     :", sys.version.split()[0])
+print("torch      :", torch.__version__)
+print("ultralytics:", ultralytics.__version__)
+if not sys.version.startswith("$PYVER"):        print("!! python mismatch");      ok = False
+if torch.__version__ != "$TORCH":               print("!! torch mismatch");       ok = False
+if ultralytics.__version__ != "$ULTRA":         print("!! ultralytics mismatch"); ok = False
+print("cuda available:", torch.cuda.is_available(), "(False is EXPECTED on a login node)")
+print("MATCHES KLONE" if ok else "DOES NOT MATCH KLONE -- do not train with this")
+sys.exit(0 if ok else 1)
+PY
+
+echo
+echo "=== done ==="
+echo "env: $ENVDIR"
+echo "Use it from the launcher with:  PYTHON=$ENVDIR/bin/python"

--- a/scripts/tillicum_setup_env.sh
+++ b/scripts/tillicum_setup_env.sh
@@ -61,25 +61,60 @@ if ! "$PY" -m pip index versions torch --index-url "$TORCH_INDEX" 2>&1 | grep -q
     exit 1
 fi
 
-echo "=== installing pinned torch ==="
+echo "=== installing pinned torch (+ torchvision, from the SAME index) ==="
 "$PY" -m pip install --upgrade pip
-"$PY" -m pip install "torch==$TORCH" --index-url "$TORCH_INDEX"
+# torchvision must come from the cu126 index too, exactly as the klone runbook does it
+# (`pip install torch torchvision --index-url .../cu126`, hyak_yolo_runbook.sh). Install
+# torch alone and ultralytics later drags torchvision in from PyPI instead -- a build
+# with its own hard `torch==` pin, which either downgrades the torch we just pinned or
+# lands a copy compiled against a different CUDA. The second case is the dangerous one:
+# it is invisible unless the gate below looks for it, which is why it now does.
+"$PY" -m pip install "torch==$TORCH" torchvision --index-url "$TORCH_INDEX"
 
-echo "=== installing pinned ultralytics ==="
+echo "=== installing pinned ultralytics + the dataset deps ==="
 # --no-deps would risk a broken install; instead pin ultralytics and let it resolve its
 # own deps, then assert torch was not silently upgraded underneath us.
-"$PY" -m pip install "ultralytics==$ULTRA"
+#
+# datasets + huggingface_hub are NOT optional here, and they are not ultralytics deps.
+# run_yolo_data_prep_tillicum.slurm points PYBIN at this env and calls the runbook's
+# `data` stage, which runs download_dataset.py -- whose first import is
+# `from datasets import load_dataset`. Without these the prep job dies on import under
+# `set -euo pipefail`, after the H200 allocation has already started billing. The klone
+# runbook installs the same three (hyak_yolo_runbook.sh).
+"$PY" -m pip install "ultralytics==$ULTRA" datasets huggingface_hub
 
 echo "=== VERIFY (this is the gate, not the install) ==="
 "$PY" - <<PY
-import sys, torch, ultralytics
+import sys, torch, torchvision, ultralytics
 ok = True
 print("python     :", sys.version.split()[0])
 print("torch      :", torch.__version__)
+print("torchvision:", torchvision.__version__)
 print("ultralytics:", ultralytics.__version__)
 if not sys.version.startswith("$PYVER"):        print("!! python mismatch");      ok = False
 if torch.__version__ != "$TORCH":               print("!! torch mismatch");       ok = False
 if ultralytics.__version__ != "$ULTRA":         print("!! ultralytics mismatch"); ok = False
+# torchvision has no pinned target -- it just has to be a build whose compiled
+# extension actually links against THIS torch. Test that by behaviour rather than by
+# parsing a version string: local version labels (+cu126) are a packaging convention
+# that has changed before, and a gate that fails a good env is worse than the hole it
+# closes. Running one real op exercises the C++ extension, which is what breaks when
+# ultralytics drags a mismatched torchvision in from PyPI.
+try:
+    import torch as _t
+    from torchvision.ops import nms
+    nms(_t.tensor([[0.0, 0.0, 1.0, 1.0]]), _t.tensor([0.5]), 0.5)
+except Exception as e:
+    print(f"!! torchvision does not link against this torch: {type(e).__name__}: {e}")
+    ok = False
+# The prep job imports these before it touches a GPU; catching it here costs nothing,
+# catching it there costs an H200 allocation.
+for mod in ("datasets", "huggingface_hub"):
+    try:
+        __import__(mod)
+    except ImportError:
+        print(f"!! {mod} missing -- download_dataset.py cannot run in this env")
+        ok = False
 print("cuda available:", torch.cuda.is_available(), "(False is EXPECTED on a login node)")
 print("MATCHES KLONE" if ok else "DOES NOT MATCH KLONE -- do not train with this")
 sys.exit(0 if ok else 1)

--- a/scripts/tillicum_smoke.slurm
+++ b/scripts/tillicum_smoke.slurm
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Tillicum environment smoke test — settles "does our stack run on H200/Rocky 9?"
+#
+# COSTS NOTHING. The `debug` QoS bills at UsageFactor 0.000000 (verified with
+# `sacctmgr show qos`), so this is free, and it carries a HIGHER priority than normal
+# (50 vs 25) so it should also start fast. Limits: 1 h, 1 GPU, 8 CPU, 200G, 1 node.
+# Do every environment/throughput probe here before spending a cent of the $90 credit.
+#
+#   sbatch scripts/tillicum_smoke.slurm
+#
+# The open question this answers: our environment.yml pins linux-64 packages against
+# CUDA 11.8, and Tillicum is H200 (sm_90) on Rocky 9. The recon found BOTH a
+# conda/Miniforge3 module and apptainer 1.5.2, so either path is available and we do
+# not yet know which is less work. This tries conda first because it reuses what we
+# already have; the container fallback is the documented UW-IT path if it fails.
+#
+#SBATCH --job-name=tillicum_smoke
+#SBATCH --qos=debug
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=200G
+#SBATCH --time=01:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --mail-type=NONE
+#SBATCH --output=logs/tillicum_smoke_%j.out
+#SBATCH --error=logs/tillicum_smoke_%j.err
+
+set -uo pipefail   # NOT -e: this is a probe. A failing step is a RESULT, not a reason
+                   # to abort and lose the rest of the report.
+
+say() { echo; echo "=== $* ==="; }
+
+say "NODE"
+hostname; date
+nvidia-smi --query-gpu=name,memory.total,driver_version,compute_cap --format=csv
+echo "CPUs allocated: ${SLURM_CPUS_PER_TASK:-?}   GPUs: ${SLURM_GPUS_ON_NODE:-?}"
+
+say "STORAGE — where the dataset should land"
+for d in /gpfs/scrubbed /gpfs/scrubbed/$USER /gpfs/projects/makelab /gpfs/home/$USER; do
+    if [ -d "$d" ]; then
+        printf "%-32s exists  writable=%s  " "$d" "$( [ -w "$d" ] && echo yes || echo NO )"
+        df -h "$d" 2>/dev/null | tail -1 | awk '{printf "size=%s avail=%s\n", $2, $4}'
+    else
+        printf "%-32s MISSING\n" "$d"
+    fi
+done
+
+say "SQUASHFS SUPPORT — can we mount the packed dataset at all?"
+for t in mksquashfs unsquashfs squashfuse apptainer; do
+    printf "  %-12s %s\n" "$t" "$(command -v $t 2>/dev/null || echo NOT_FOUND)"
+done
+echo "  kernel squashfs: $(grep -qw squashfs /proc/filesystems && echo yes || echo 'no (use apptainer --bind image-src=/)')"
+
+say "CONDA MODULE PATH"
+module load conda 2>&1 | head -5
+command -v conda && conda --version
+
+# Build somewhere durable and shared, not node-local /tmp. Keep it out of the 286 GB
+# dataset's way: envs are small but numerous-filed, so scrubbed is the better home.
+ENVROOT="${ENVROOT:-/gpfs/scrubbed/$USER/envs}"
+if ! mkdir -p "$ENVROOT" 2>/dev/null; then
+    echo "  (could not write $ENVROOT -- falling back to the project dir)"
+    ENVROOT="/gpfs/projects/makelab/$USER/envs"
+    mkdir -p "$ENVROOT"
+fi
+VENV="$ENVROOT/ultra"
+echo "env root: $ENVROOT"
+
+say "BUILD A MINIMAL ULTRALYTICS ENV"
+# A venv on top of the module python is far lighter than solving environment.yml, and
+# the only question that matters here is whether a CUDA-12 torch wheel drives an H200.
+if [ ! -x "$VENV/bin/python" ]; then
+    python3 -m venv "$VENV" 2>&1 | tail -2
+fi
+"$VENV/bin/python" -m pip install -q --upgrade pip 2>&1 | tail -2
+# cu126 wheels: Tillicum is sm_90, and our klone stack is torch 2.13.0+cu126 (see the
+# yolo_baseline record), so matching it keeps the comparison honest.
+"$VENV/bin/python" -m pip install -q torch --index-url https://download.pytorch.org/whl/cu126 2>&1 | tail -3
+"$VENV/bin/python" -m pip install -q ultralytics 2>&1 | tail -3
+
+say "DOES IT SEE THE GPU?"
+"$VENV/bin/python" - <<'PY'
+import sys
+try:
+    import torch
+    print("torch:", torch.__version__, "| cuda build:", torch.version.cuda)
+    print("cuda available:", torch.cuda.is_available())
+    if torch.cuda.is_available():
+        print("device:", torch.cuda.get_device_name(0))
+        print("capability:", torch.cuda.get_device_capability(0), "(expect (9,0) for H200)")
+        import time
+        a = torch.randn(8192, 8192, device="cuda", dtype=torch.bfloat16)
+        torch.cuda.synchronize(); t0 = time.time()
+        for _ in range(50):
+            a @ a
+        torch.cuda.synchronize()
+        dt = time.time() - t0
+        tflops = 50 * 2 * 8192**3 / dt / 1e12
+        print(f"bf16 matmul: {tflops:.0f} TFLOP/s  ({dt:.2f}s for 50 iters)")
+        print("  ref: L40S ~180 dense. A large ratio here is the H200 speedup we are betting on.")
+except Exception as e:
+    print("TORCH FAILED:", type(e).__name__, e); sys.exit(0)
+
+try:
+    from ultralytics import YOLO
+    import ultralytics
+    print("ultralytics:", ultralytics.__version__)
+    m = YOLO("yolo11n.yaml")          # from config, no download needed
+    print("model constructed OK")
+except Exception as e:
+    print("ULTRALYTICS FAILED:", type(e).__name__, e)
+PY
+
+say "SLURM VIEW OF THIS JOB (confirm debug really is free)"
+scontrol show job "$SLURM_JOB_ID" | grep -oE "QOS=[a-z]+|Partition=[a-z0-9-]+|TRES=[^ ]+" | head -5
+
+say "DONE"
+date
+echo "Check cost with: hyakusage   (this job should add 0.00)"

--- a/scripts/tillicum_smoke.slurm
+++ b/scripts/tillicum_smoke.slurm
@@ -58,6 +58,12 @@ command -v conda && conda --version
 
 # Build somewhere durable and shared, not node-local /tmp. Keep it out of the 286 GB
 # dataset's way: envs are small but numerous-filed, so scrubbed is the better home.
+#
+# This env is DISPOSABLE and deliberately separate from the training env that
+# tillicum_setup_env.sh builds at /gpfs/projects/makelab/$USER/envs/rampnet-yolo. This
+# one exists to answer "does a cu126 wheel drive an H200"; that one is the gated,
+# klone-matched env everything reportable runs in. Do not train from this one, and do
+# not point PYTHON at it.
 ENVROOT="${ENVROOT:-/gpfs/scrubbed/$USER/envs}"
 if ! mkdir -p "$ENVROOT" 2>/dev/null; then
     echo "  (could not write $ENVROOT -- falling back to the project dir)"
@@ -74,10 +80,15 @@ if [ ! -x "$VENV/bin/python" ]; then
     python3 -m venv "$VENV" 2>&1 | tail -2
 fi
 "$VENV/bin/python" -m pip install -q --upgrade pip 2>&1 | tail -2
-# cu126 wheels: Tillicum is sm_90, and our klone stack is torch 2.13.0+cu126 (see the
-# yolo_baseline record), so matching it keeps the comparison honest.
-"$VENV/bin/python" -m pip install -q torch --index-url https://download.pytorch.org/whl/cu126 2>&1 | tail -3
-"$VENV/bin/python" -m pip install -q ultralytics 2>&1 | tail -3
+# cu126 wheels: Tillicum is sm_90, and our klone stack is torch 2.13.0+cu126 with
+# ultralytics 8.4.105 (see the yolo_baseline record), so matching it keeps the
+# comparison honest -- which means PINNING it, not hoping the resolver agrees. Unpinned,
+# a python3 that is Tillicum's system 3.9.25 (i.e. `module load conda` above failed
+# quietly) tops out at torch 2.8.0 on the cu126 index and pulls ultralytics 8.4.113,
+# and this probe would report that stack as a green "environment works".
+"$VENV/bin/python" -m pip install -q "torch==2.13.0+cu126" torchvision \
+    --index-url https://download.pytorch.org/whl/cu126 2>&1 | tail -3
+"$VENV/bin/python" -m pip install -q "ultralytics==8.4.105" 2>&1 | tail -3
 
 say "DOES IT SEE THE GPU?"
 "$VENV/bin/python" - <<'PY'


### PR DESCRIPTION
Onboards the lab onto **Tillicum**, UW-IT's usage-billed H200 cluster (makelab provisioned
2026-07-29), and prepares the YOLO baseline to move there. Nothing in flight is touched.
(Additive-only until `3dbbf46`, which adds an optional, off-by-default worker
pass-through to `hyak_yolo_runbook.sh` — see **Review fixes** below.)

## Why

klone's `ckpt` scavenger partition has stopped converting compute into results for #51.
Measured 2026-07-30:

- **496.5 GPU-hours** consumed on the baseline since 2026-07-24 (`sacct`, all arms)
- **170 job restarts in one night** across five jobs (39 / 37 / 33 / 33 / 28)
- **zero completed epochs** on five of six arms across that night; four still hold an ep1
  `best.pt`

The binding constraint is not the nominal 8.24 h checkpoint slice but the **effective**
contiguous run the partition hands out, which has collapsed to minutes. Any arm whose epoch
exceeds that can never complete one. **Tillicum does not preempt** — that is the entire
reason to pay for it.

This matters beyond convenience. The #71 protocol already concedes that every reportable
checkpoint is **undertrained**, so any benchmark number is a *lower bound* on supervised
YOLO. "We ran out of patience on a scavenger partition" is not a defensible reason for a
baseline to underperform, and "you undertrained YOLO" is the first objection any reviewer
raises against the paper's central comparison.

## What's here

**`docs/tillicum.md`** — the first general cluster doc in the repo (we have task runbooks
for klone, but nothing describing a cluster itself). QoS table, cost model, storage terms,
software story, and a directive-by-directive Slurm migration diff.

The headline for anyone submitting: **our `run_yolo_train.slurm` is not submittable on
Tillicum as written.** No partitions exist (QoS only), the default QoS caps at 24 h against
our `--time=72:00:00`, and `--cpus-per-task=12` with one GPU violates a hard 8 CPU : 1 GPU
ratio and is rejected outright.

**`scripts/model_comparison/run_yolo_train_tillicum.slurm`** — a port kept as a separate
file rather than a branch inside the klone script, since nearly every directive differs and
the klone version is the preserved record of the #51 runs and should not churn.

The non-obvious part is that it separates the GPU **allocation** from the ultralytics
**device**. Tillicum fixes CPUs at 8 per GPU, so 16 dataloader workers for the I/O-bound
tiles arm means allocating 2 GPUs — but letting ultralytics use both puts it in DDP, which
changes effective batch and LR dynamics and breaks comparability with the klone single-GPU
runs. So we allocate 2 and pin `DEVICE=0`, paying for an idle GPU on purpose. That isolates
dataloader throughput as the only changed variable, which is exactly the question: does the
2× bill buy more than a 2× speedup?

It also sets `save_period=5`. Ultralytics defaults to keeping only `last.pt`/`best.pt`,
which permanently forecloses a **compute-matched** comparison — RampNet's published model
trained ~1 epoch / ~9.4k steps at constant LR (#84) while this baseline gets 60 epochs with
a schedule, and reporting both the converged *and* the matched point is much stronger than
the converged one alone. `results.csv` has per-epoch metrics but no weights, so it cannot be
reconstructed later.

**`scripts/tillicum_recon.sh`** — read-only, ~10 s, submits nothing, costs nothing. Settles
in one pass every item the doc currently marks UNVERIFIED.

## Measured, not assumed

**The data that has to cross: 286 GB in ~911,000 files** (tiles 210 GB / 718,415; pano
76 GB / 192,938).

- 286 GB **fits the 1 TB allocation** comfortably — storage quota is not a blocker.
- ~911k files **is** the blocker. `du -sh` over the tiles tree beat three separate timeouts
  before completing on a 550 s budget, and even `ls -lU | head -201` on `tiles/images/train`
  timed out. That is metadata throughput, not bandwidth.

Consequences recorded in the doc: transfer archives rather than the tree (a per-file rsync
pays ~911k round trips), run the `tar` inside a Slurm job rather than on a login node, stage
`pano` first so the smoke test is unblocked while `tiles` moves, and **time the untar** —
it is our first direct measurement of whether Tillicum's flash fixes the bottleneck the
tiles training arm is also probing.

## Status

*This section originally read "nothing here has run", which was true when the PR was
opened on 2026-07-30 and has not been true since 2026-07-31. Rewritten 2026-08-17.*

Three jobs have run and are recorded in the doc:

| job | what | result |
|---|---|---|
| `198638` | `debug` smoke test | environment works on H200 / Rocky 9; also surfaced the `hyakusage` vs `sacctmgr` billing disagreement |
| `198910` | data regeneration from HF, 4 h 40 m, $4.20 | dataset verified equivalent to klone — identical counts *and* identical md5 of the sorted filename list across all eight directories |
| `217298` | one `y11x_tiles` epoch, pre-registered | **2.38×** klone's L40S (5.0 vs 2.1 it/s), and it is the filesystem rather than the GPU |

The HostName is settled: `tillicum.hyak.uw.edu` is correct and the get-started page's
`tillicum.hyak.edu` is wrong. **The per-user home path is settled** (2026-08-18, `1b008e3`):
`cd ~ && pwd` on a login node returns `/gpfs/home/jfroehli`, so the as-run `~/RampNet` and
`run_yolo_data_prep_tillicum.slurm`'s `/gpfs/home/$USER/RampNet` are the same directory and
no script needed changing.

Companion change outside this repo: `dotfiles` gains a `tillicum` target for `wsl-ssh.ps1`
plus its operating rules, which are auto-imported into every Claude session.

## Review fixes (3dbbf46)

A deep review of the branch found 15 issues; all are fixed in `3dbbf46`. Two mattered:

- **The 2-GPU dataloader trick did nothing.** `run_yolo_train_tillicum.slurm` never passed
  `workers` to `train()`, and ultralytics defaults to `workers: 8` capped at
  `min(os.cpu_count() // nd, workers)` — so the pool never grew with the allocation. A
  `--gres=gpu:2 --cpus-per-task=16` run would have paid 2× for 8 workers and reported "no
  faster", answering the question above for the wrong reason. `WORKERS` now binds to
  `SLURM_CPUS_PER_TASK`, and it has to be set on the first link of a chain because
  `resume=True` inherits the loader count from `last.pt`.
- **`tillicum_setup_env.sh` could not run the data stage that depends on it** — no
  `datasets`, no `huggingface_hub`, but `download_dataset.py` imports `datasets` at module
  scope. `198910` completed, so that package was hand-installed and lived in no committed
  script. Now installed and gated, along with `torchvision` from the cu126 index.

The rest: a `mksquashfs` append hazard on requeue, the equivalence check made a gate rather
than a report (it promised "stop and diff" while exiting 0), the two prep guards that were
dropped by routing through the runbook, `CHAIN=<n>` to replace the continuation that
dropping `--requeue` gave up, a usage example that trained yolo11l under a y26 name, an
unreachable `|| echo` in the recon, unpinned installs in the smoke test, and the superseded
"keep prep on klone" directive marked as such where it sits.

**Note this PR is no longer additive-only.** `hyak_yolo_runbook.sh` gains an optional
`--workers` / `OPENBLAS_NUM_THREADS` pass-through in its `prep` stage. Behaviour outside a
Slurm allocation is unchanged, so the #51 klone runs are unaffected.

## Related

- #51 — supervised YOLO baseline (the runs that motivated this)
- #70 — stabilized rerun; this is its unblocking dependency
- #90 — LR/warmup sweep; also gated on non-preemptable capacity

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])



