### PR TITLE
README: point paper readers at the v1.0-iccv2025 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@
 </p>
 
 > [!NOTE]
-> **Using RampNet exactly as the ICCV'25 paper describes it?** Use the tagged release
-> [`v1.0-iccv2025`](https://github.com/ProjectSidewalk/RampNet/releases/tag/v1.0-iccv2025) — the
-> repository frozen at paper state. The `main` branch keeps evolving (post-paper analyses,
-> benchmarks, and groundwork for what comes next), while the published
+> **Looking for a fixed version of this repository?** There are two tagged releases:
+> [`v1.0-iccv2025`](https://github.com/ProjectSidewalk/RampNet/releases/tag/v1.0-iccv2025) is the
+> repository frozen at paper state — use it to reproduce the ICCV'25 paper exactly as written.
+> [`v1.1-corrected-eval`](https://github.com/ProjectSidewalk/RampNet/releases/tag/v1.1-corrected-eval)
+> is the same code and the same model weights with the **corrected evaluation protocol** (see the
+> [Erratum](#erratum-evaluation-metrics-july-2026) below) — use it to score RampNet's model under
+> standard one-to-one matching. The `main` branch keeps evolving (post-paper analyses, benchmarks,
+> and groundwork for what comes next), while the published
 > [model](https://huggingface.co/projectsidewalk/rampnet-model) and
 > [dataset](https://huggingface.co/datasets/projectsidewalk/rampnet-dataset) on Hugging Face are
 > versioned independently and match the paper.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@
 <p>
 <strong>RampNet</strong> is a two-stage pipeline that addresses the scarcity of curb ramp detection datasets by using government location data to automatically generate over 210,000 annotated Google Street View panoramas. This new dataset is then used to train a state-of-the-art curb ramp detection model that significantly outperforms previous efforts. In this repo, we provide code for training and testing our system.
 </p>
+
+> [!NOTE]
+> **Using RampNet exactly as the ICCV'25 paper describes it?** Use the tagged release
+> [`v1.0-iccv2025`](https://github.com/ProjectSidewalk/RampNet/releases/tag/v1.0-iccv2025) — the
+> repository frozen at paper state. The `main` branch keeps evolving (post-paper analyses,
+> benchmarks, and groundwork for what comes next), while the published
+> [model](https://huggingface.co/projectsidewalk/rampnet-model) and
+> [dataset](https://huggingface.co/datasets/projectsidewalk/rampnet-dataset) on Hugging Face are
+> versioned independently and match the paper.
+
 <br>
 
 ## Citation


### PR DESCRIPTION
`main` has moved well past the ICCV'25 paper (post-paper analyses, benchmarks, RampNet 2.0 groundwork), and it will keep moving. The frozen paper artifact already exists — the `v1.0-iccv2025` tag and its "paper state" GitHub Release — but nothing on the README told a paper reader that, or where to find it. This adds a callout at the top pointing at the frozen releases, and notes that the published HF model/dataset are versioned independently and match the paper.

**Two pointers, not one** (added in code review, `4190e4c`): the note originally sent a paper reader to `v1.0-iccv2025` alone — which is exactly the tag whose evaluators the Erratum fifteen lines below says bias precision and recall upward. It now names both `v1.0-iccv2025` (reproduce the paper as written) and `v1.1-corrected-eval` (same code and weights, standard one-to-one matching), and links the Erratum from the note itself.

> ⚠️ **Merge ordering:** `v1.1-corrected-eval` does not exist yet. Do not merge until the tag and its release are created (proposed anchor `ee42044`, 2026-07-24 — see the review comment for why), or `main`'s README ships a 404.

Decided with Jon (2026-08-03): RampNet2-era work stays in this repo with the tag as the paper boundary; a repo split is only revisited if a genuinely new pipeline stops importing this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)
