### PR TITLE
Record what every paid-model run costs, at the time it runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,12 @@ analysis_out/op/*
 # Which silent misses another model witnessed (#46). Small, and it carries the
 # unwitnessed list that is the gallery's actual work queue.
 !analysis_out/silent_witness.json
+# What every paid-model run spent, appended at the time it ran (compare.py
+# --usage-log). A few hundred bytes per leg, and it is the only durable record of
+# API spend -- the billing console's retention is ~6 weeks, so an uncommitted copy
+# becomes unrecoverable rather than merely inconvenient. Append-only; never rewrite
+# a past line, since each one is a measurement.
+!analysis_out/usage_log.jsonl
 # Crop-window sizing eval summaries (#114): per-rule containment/context stats plus
 # the sha256 of the per-box CSV each summarizes (the CSVs themselves regenerate).
 # The glob also covers per-bundle runs against box_gallery extent gold (#116),

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -1044,6 +1044,49 @@ public GSV/Mapillary, so residency is not a concern here). Vertex model ids diff
 AI-Studio aliases (`gemini-flash-latest` only resolves on `global`); pin them explicitly with
 `gemini:<model-id>` in `--models`.
 
+## Cost accounting for paid models
+
+**Standing rule: every experiment that spends API money records what it spent, at the time
+it runs.** A paper reports cost alongside accuracy, and a token count that wasn't captured
+at run time has to be reconstructed later (or lost). Three layers:
+
+1. **At run time** — `compare.py` accumulates each paid provider's own usage metadata
+   (currently Gemini; local GPU models are free in API terms) and appends one JSONL record
+   per model run — token counts, panos scored, estimated cost — to `--usage-log`
+   (default `<cache-dir>/usage_log.jsonl`; `--usage-log none` disables). Cached panos make
+   no call, so the record is what *that run* actually paid, not what a full run would cost.
+2. **Prices** — `scripts/model_comparison/pricing.py` is a verified-only table: each entry
+   carries the date it was checked. Prices change (the Gemini 3.x flash rates are
+   introductory through 2026-12-31 and double after); the token counts are the durable
+   fact, the dollar figure is an estimate, and the billing console is authoritative.
+3. **Reconciliation** — `scripts/analysis/vertex_usage.py` pulls the project's *actual*
+   billed token counts per model from Cloud Monitoring (daily granularity, ~6 weeks
+   retention), which also recovers runs that predate this instrumentation. Caveat: its
+   daily rows are 24 h windows ending at the query's time-of-day (UTC), not calendar days —
+   attribute rows to legs from the run record, not by eye.
+
+**Measured: the complete Gemini history of this benchmark** (Cloud Monitoring,
+2026-08-15; every Gemini leg ever run on the project — richmond/bend 07-23/24 onward —
+falls inside the retention window):
+
+| model | input tokens | output tokens | est. cost |
+|---|---:|---:|---:|
+| gemini-2.5-flash | 4,811,091 | 1,479,263 | $5.14 |
+| gemini-3.6-flash | 17,449,987 | 6,119,688 | $36.04 |
+| gemini-3.1-pro-preview | 17,405,320 | 593,380 | $41.93 |
+| gemini-3.7-flash (leg in flight, through 08-15 06:15 UTC) | 14,471,066 | 3,550,843 | $24.17 |
+| **total** | | | **≈ $107** |
+
+Anatomy of a leg: tokenization is deterministic — a 125-pano city leg is exactly
+**957,000 input tokens** (125 panos × 6 views × 1,276 tokens/view at the 1024×1024 view
+size), so input cost is fixed per bundle and only output varies. That puts a 125-pano
+city leg at roughly **$1.60–$2.20** depending on model, and the 1,000-pano manual_gold
+leg at ~8× that. Two output-side facts worth knowing when budgeting: **thinking tokens
+bill as output** and dominate it (the visible JSON is ~50 tokens/call; observed output is
+~250–350), and models differ enormously in how much they think — on identical input,
+gemini-3.6-flash emitted 6.1M output tokens where gemini-3.1-pro emitted 0.59M, which is
+why flash legs are not as cheap relative to pro as the rate card suggests.
+
 ## Running it
 
 ```bash

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -1052,18 +1052,26 @@ at run time has to be reconstructed later (or lost). Three layers:
 
 1. **At run time** — `compare.py` accumulates each paid provider's own usage metadata
    (currently Gemini; local GPU models are free in API terms) and appends one JSONL record
-   per model run — token counts, panos scored, estimated cost — to `--usage-log`
-   (default `<cache-dir>/usage_log.jsonl`; `--usage-log none` disables). Cached panos make
-   no call, so the record is what *that run* actually paid, not what a full run would cost.
+   per model run — token counts, panos actually scored, detector signature, estimated cost —
+   to `--usage-log` (default **`analysis_out/usage_log.jsonl`**, which is committed;
+   `--usage-log none` disables). Cached panos make no call, so the record is what *that run*
+   actually paid, not what a full run would cost. The append happens in a `finally`, so a leg
+   that dies or is interrupted after paying still records its spend — that is the case the
+   rule exists for — and a failure to write the file degrades to printing the record rather
+   than aborting the comparison.
 2. **Prices** — `scripts/model_comparison/pricing.py` is a verified-only table: each entry
    carries the date it was checked. Prices change (the Gemini 3.x flash rates are
    introductory through 2026-12-31 and double after); the token counts are the durable
    fact, the dollar figure is an estimate, and the billing console is authoritative.
 3. **Reconciliation** — `scripts/analysis/vertex_usage.py` pulls the project's *actual*
    billed token counts per model from Cloud Monitoring (daily granularity, ~6 weeks
-   retention), which also recovers runs that predate this instrumentation. Caveat: its
+   retention), which also recovers runs that predate this instrumentation. Two caveats: its
    daily rows are 24 h windows ending at the query's time-of-day (UTC), not calendar days —
-   attribute rows to legs from the run record, not by eye.
+   attribute rows to legs from the run record, not by eye — and **it reads one cloud
+   project's billing telemetry, so only someone with access to that project can re-derive
+   its numbers.** That is why layer 1 is committed: the table below is transcribed from a
+   source others cannot query, while `analysis_out/usage_log.jsonl` is checkable from a
+   clean clone.
 
 **Measured: the complete Gemini history of this benchmark** (Cloud Monitoring,
 2026-08-15; every Gemini leg ever run on the project — richmond/bend 07-23/24 onward —
@@ -1079,13 +1087,24 @@ falls inside the retention window):
 
 Anatomy of a leg: tokenization is deterministic — a 125-pano city leg is exactly
 **957,000 input tokens** (125 panos × 6 views × 1,276 tokens/view at the 1024×1024 view
-size), so input cost is fixed per bundle and only output varies. That puts a 125-pano
-city leg at roughly **$1.60–$2.20** depending on model, and the 1,000-pano manual_gold
-leg at ~8× that. Two output-side facts worth knowing when budgeting: **thinking tokens
-bill as output** and dominate it (the visible JSON is ~50 tokens/call; observed output is
-~250–350), and models differ enormously in how much they think — on identical input,
-gemini-3.6-flash emitted 6.1M output tokens where gemini-3.1-pro emitted 0.59M, which is
-why flash legs are not as cheap relative to pro as the rate card suggests.
+size), so input cost is fixed per bundle and only output varies. That makes the rest of
+the budget derivable from the table above: dividing each model's input tokens by 1,276
+gives its call count, and hence its output per call and the cost of one 125-pano leg.
+
+| model | output tokens/call | cost, 125-pano leg | cost, 1,000-pano manual_gold |
+|---|---:|---:|---:|
+| gemini-2.5-flash | 392 | $1.02 | ~$8.20 |
+| gemini-3.7-flash | 313 | $1.60 | ~$12.80 |
+| gemini-3.6-flash | 447 | $1.98 | ~$15.80 |
+| gemini-3.1-pro-preview | 43 | $2.31 | ~$18.50 |
+
+The output column is where the interesting variation lives, and it is entirely thinking:
+**thinking tokens bill as output** and dominate it — the visible JSON is ~50 tokens/call,
+so a model emitting 447 is spending ~90% of its output budget on reasoning nobody reads.
+Models differ by an order of magnitude in how much they do that (gemini-3.6-flash emitted
+6.1M output tokens where gemini-3.1-pro emitted 0.59M on comparable input), which is why
+flash legs are not as cheap relative to pro as the rate card suggests — the 3.6-flash /
+3.1-pro gap is $1.98 vs $2.31 per leg, not the 2.7× the input rates alone imply.
 
 ## Running it
 
@@ -1388,6 +1407,12 @@ What this split adds to the story:
   "how much of a detector's recall is real?" table). Cache-only; no GPU, no keys.
 - `scripts/analysis/fp_taxonomy.py` — what the FP flood is made of (duplicate / near_gt / hood /
   isolated), with an exact chance baseline for the near-GT share. Cache-only; no GPU, no keys.
+- `scripts/model_comparison/pricing.py` — verified-only per-token price table (each entry
+  carries the date it was checked); prices what `--usage-log` records.
+- `scripts/analysis/vertex_usage.py` — server-side reconciliation: actual billed tokens per
+  model from Cloud Monitoring. Needs ADC on the billing project, so only its output is
+  replicable from this repo.
+- `analysis_out/usage_log.jsonl` — committed, append-only record of what each paid run spent.
 - `requirements-vlm.txt` — optional VLM deps.
 - `tests/test_detection_eval.py`, `tests/test_model_comparison.py`,
   `tests/test_equirect_tiling.py` — guards.

--- a/docs/model_comparison.md
+++ b/docs/model_comparison.md
@@ -1059,6 +1059,16 @@ at run time has to be reconstructed later (or lost). Three layers:
    that dies or is interrupted after paying still records its spend — that is the case the
    rule exists for — and a failure to write the file degrades to printing the record rather
    than aborting the comparison.
+   Each record also carries **`model_versions`** — the build(s) that actually served the run.
+   **A pinned model id is an alias, not a build**: `gemini:gemini-3.7-flash` in `--models`
+   resolves to whatever the provider currently serves under that name, and the alias moves.
+   Since `signature()` feeds the detection cache key, the build deliberately does *not* go in
+   it — adding it would miss every already-paid cached detection and re-bill the run — so the
+   run record is where provenance lives, and a rotation mid-leg prints a warning. **This
+   cannot be reconstructed after the fact** (`.model_cache` stores detection points only), so
+   anything produced before this instrumentation, including every file currently in
+   `benchmark/model_detections/`, carries no build id and never can. See #121.
+
 2. **Prices** — `scripts/model_comparison/pricing.py` is a verified-only table: each entry
    carries the date it was checked. Prices change (the Gemini 3.x flash rates are
    introductory through 2026-12-31 and double after); the token counts are the durable

--- a/requirements-vlm.txt
+++ b/requirements-vlm.txt
@@ -6,6 +6,11 @@
 #
 # Gemini (API; needs GOOGLE_API_KEY, or Vertex + ADC):
 google-genai
+# scripts/analysis/vertex_usage.py imports these two directly (Cloud Monitoring is
+# a plain REST call, no client library). google-genai already pulls both in, but a
+# script's own imports belong in the file it tells you to install.
+google-auth
+requests
 
 # Qwen3-VL (open weights; run on a cluster GPU — see the Hyak runbook in
 # docs/model_comparison.md). torch comes from the conda env; these are the extras:

--- a/scripts/analysis/vertex_usage.py
+++ b/scripts/analysis/vertex_usage.py
@@ -1,0 +1,119 @@
+"""Actual Vertex AI token usage for a Google Cloud project, from Cloud Monitoring.
+
+The harness records what each run spent as it happens (compare.py --usage-log),
+but that only covers runs made after the instrumentation existed, and a local
+log can be lost. This script recovers the ground truth server-side: Cloud
+Monitoring's publisher-model metrics count every billed token per model id, at
+daily granularity, going back ~6 weeks (Google metric retention). It priced the
+entire Gemini history of this project retroactively on 2026-08-15 — see the
+"Cost accounting" section of docs/model_comparison.md for those numbers.
+
+Read-only. Needs ADC with access to the project (`gcloud auth
+application-default login`) — the same credentials the Gemini legs run under.
+
+    python scripts/analysis/vertex_usage.py                  # 30 days, project rampnet
+    python scripts/analysis/vertex_usage.py --days 42 --project rampnet
+
+Caveat: each daily row is a 24 h window ending at the query time-of-day (UTC),
+NOT a calendar day — a leg run on the evening of the 14th lands in the row
+labeled the 15th. Attribute rows to legs by the run record, not by eye.
+"""
+import argparse
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "model_comparison"))
+from pricing import estimate_cost, price_for  # noqa: E402
+
+TOKEN_METRIC = "aiplatform.googleapis.com/publisher/online_serving/token_count"
+
+
+def fetch_token_series(project, days):
+    try:
+        import google.auth
+        import google.auth.transport.requests
+        import requests
+    except ImportError as e:
+        raise SystemExit(f"needs google-auth + requests (pip install -r "
+                         f"requirements-vlm.txt): {e}")
+    creds, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    creds.refresh(google.auth.transport.requests.Request())
+    headers = {"Authorization": f"Bearer {creds.token}",
+               "x-goog-user-project": project}
+    end = datetime.now(timezone.utc)
+    params = {
+        "filter": f'metric.type = "{TOKEN_METRIC}"',
+        "interval.startTime": (end - timedelta(days=days)).isoformat(),
+        "interval.endTime": end.isoformat(),
+        "aggregation.alignmentPeriod": "86400s",
+        "aggregation.perSeriesAligner": "ALIGN_DELTA",
+        "aggregation.crossSeriesReducer": "REDUCE_SUM",
+        "aggregation.groupByFields": ["resource.labels.model_user_id",
+                                      "metric.labels.type"],
+        "pageSize": 1000,
+    }
+    r = requests.get(
+        f"https://monitoring.googleapis.com/v3/projects/{project}/timeSeries",
+        params=params, headers=headers, timeout=60)
+    if r.status_code != 200:
+        raise SystemExit(f"Cloud Monitoring query failed ({r.status_code}): "
+                         f"{r.text[:500]}")
+    return r.json().get("timeSeries", [])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("--project", default="rampnet")
+    ap.add_argument("--days", type=float, default=30,
+                    help="Lookback window (metric retention is ~6 weeks).")
+    ap.add_argument("--min-tokens", type=int, default=1000,
+                    help="Hide rows below this many input tokens (smoke-test noise).")
+    args = ap.parse_args()
+
+    daily = defaultdict(lambda: defaultdict(float))   # (day, model) -> type -> tokens
+    totals = defaultdict(lambda: defaultdict(float))  # model -> type -> tokens
+    for ts in fetch_token_series(args.project, args.days):
+        model = ts["resource"]["labels"].get("model_user_id", "?")
+        typ = ts["metric"]["labels"].get("type", "?")
+        for p in ts.get("points", []):
+            val = (int(p["value"].get("int64Value", 0))
+                   + float(p["value"].get("doubleValue", 0)))
+            daily[(p["interval"]["endTime"][:10], model)][typ] += val
+            totals[model][typ] += val
+
+    print(f"{'window end':12s} {'model':26s} {'input':>14s} {'output':>12s}")
+    for (day, model) in sorted(daily):
+        t = daily[(day, model)]
+        if t.get("input", 0) < args.min_tokens:
+            continue
+        print(f"{day:12s} {model:26s} {t.get('input', 0):14,.0f} "
+              f"{t.get('output', 0):12,.0f}")
+
+    print(f"\n== totals, last {args.days:g} days ==")
+    grand = 0.0
+    unpriced = []
+    for model in sorted(totals):
+        t = totals[model]
+        if t.get("input", 0) < args.min_tokens:
+            continue
+        cost = estimate_cost(model, t.get("input", 0), t.get("output", 0))
+        if cost is None:
+            unpriced.append(model)
+            cost_txt = "   (no price in pricing.py)"
+        else:
+            grand += cost
+            cost_txt = f"   ~=${cost:7.2f} (as of {price_for(model)['as_of']})"
+        print(f"  {model:26s} {t.get('input', 0):14,.0f} in "
+              f"{t.get('output', 0):12,.0f} out{cost_txt}")
+    print(f"  {'TOTAL (priced models)':26s} {'':14s}    {'':12s}    ~=${grand:7.2f}")
+    if unpriced:
+        print(f"  unpriced models excluded from total: {', '.join(unpriced)} — "
+              "add a verified entry to scripts/model_comparison/pricing.py")
+    print("\nEstimates only; the billing console is authoritative for spend.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/vertex_usage.py
+++ b/scripts/analysis/vertex_usage.py
@@ -9,25 +9,47 @@ entire Gemini history of this project retroactively on 2026-08-15 — see the
 "Cost accounting" section of docs/model_comparison.md for those numbers.
 
 Read-only. Needs ADC with access to the project (`gcloud auth
-application-default login`) — the same credentials the Gemini legs run under.
+application-default login`) — the same credentials the Gemini legs run under, and
+the same `GOOGLE_CLOUD_PROJECT` (environment or repo-root `.env`) they read.
 
-    python scripts/analysis/vertex_usage.py                  # 30 days, project rampnet
-    python scripts/analysis/vertex_usage.py --days 42 --project rampnet
+    python scripts/analysis/vertex_usage.py                  # 30 days, $GOOGLE_CLOUD_PROJECT
+    python scripts/analysis/vertex_usage.py --days 42 --project my-project
+
+**Replication note:** this reads one specific cloud project's billing telemetry, so
+only someone with access to that project can re-derive its output. The numbers it
+produced are transcribed into docs/model_comparison.md; the per-run token counts in
+analysis_out/usage_log.jsonl are the committed, checkable half.
 
 Caveat: each daily row is a 24 h window ending at the query time-of-day (UTC),
 NOT a calendar day — a leg run on the evening of the 14th lands in the row
 labeled the 15th. Attribute rows to legs by the run record, not by eye.
 """
 import argparse
+import os
 import sys
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "model_comparison"))
 from pricing import estimate_cost, price_for  # noqa: E402
 
 TOKEN_METRIC = "aiplatform.googleapis.com/publisher/online_serving/token_count"
+# The only `type` label values this metric is known to carry. Anything else is
+# tokens we would neither print nor price, so it gets reported rather than dropped.
+KNOWN_TOKEN_TYPES = ("input", "output")
+
+
+def _load_dotenv():
+    """Reuse compare.py's .env loader so both halves of the harness read the same
+    credentials file. Imported inside the function (the export_model_cache idiom)
+    so the module still imports without the detector stack on the path."""
+    try:
+        from compare import load_dotenv
+    except ImportError:
+        return
+    load_dotenv(str(REPO))
 
 
 def fetch_token_series(project, days):
@@ -55,23 +77,54 @@ def fetch_token_series(project, days):
                                       "metric.labels.type"],
         "pageSize": 1000,
     }
-    r = requests.get(
-        f"https://monitoring.googleapis.com/v3/projects/{project}/timeSeries",
-        params=params, headers=headers, timeout=60)
-    if r.status_code != 200:
-        raise SystemExit(f"Cloud Monitoring query failed ({r.status_code}): "
-                         f"{r.text[:500]}")
-    return r.json().get("timeSeries", [])
+    # Follow nextPageToken. A dropped page is a SILENT UNDERCOUNT in the one tool
+    # whose job is server-side ground truth, and "the total came back low" has no
+    # symptom a reader could notice.
+    url = f"https://monitoring.googleapis.com/v3/projects/{project}/timeSeries"
+    series, token, pages = [], None, 0
+    while True:
+        page_params = dict(params, **({"pageToken": token} if token else {}))
+        r = requests.get(url, params=page_params, headers=headers, timeout=60)
+        if r.status_code != 200:
+            raise SystemExit(f"Cloud Monitoring query failed ({r.status_code}): "
+                             f"{r.text[:500]}")
+        body = r.json()
+        series.extend(body.get("timeSeries", []))
+        pages += 1
+        token = body.get("nextPageToken")
+        if not token:
+            break
+        if pages >= 50:   # runaway guard; say so rather than truncating quietly
+            raise SystemExit(f"stopped after {pages} pages with more remaining — "
+                             f"narrow --days and re-run, or the totals would be partial")
+    if pages > 1:
+        print(f"(fetched {len(series)} time series across {pages} pages)")
+    return series
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
-    ap.add_argument("--project", default="rampnet")
+    # Same env var the Gemini legs run under (detectors.py GeminiDetector, and the
+    # .env setup in docs/model_comparison.md), so following those instructions is
+    # enough to run this too. Defaulting to a hardcoded project id would send
+    # someone else's ADC at a project that isn't theirs and 403 with no hint why.
+    ap.add_argument("--project", default=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+                    help="GCP project to query (default: $GOOGLE_CLOUD_PROJECT, "
+                         "which compare.py also reads from a repo-root .env).")
     ap.add_argument("--days", type=float, default=30,
                     help="Lookback window (metric retention is ~6 weeks).")
     ap.add_argument("--min-tokens", type=int, default=1000,
-                    help="Hide rows below this many input tokens (smoke-test noise).")
+                    help="Hide rows below this many input tokens (smoke-test noise). "
+                         "Suppressed rows are counted and their cost reported.")
     args = ap.parse_args()
+
+    _load_dotenv()
+    if not args.project:
+        args.project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if not args.project:
+        raise SystemExit(
+            "no project: pass --project, or set GOOGLE_CLOUD_PROJECT in the "
+            "environment or a repo-root .env (same variable the Gemini legs use).")
 
     daily = defaultdict(lambda: defaultdict(float))   # (day, model) -> type -> tokens
     totals = defaultdict(lambda: defaultdict(float))  # model -> type -> tokens
@@ -84,6 +137,17 @@ def main():
             daily[(p["interval"]["endTime"][:10], model)][typ] += val
             totals[model][typ] += val
 
+    # Only `input` and `output` are printed and priced below. If Vertex ever adds a
+    # third bucket (cached input, a renamed label), those tokens would be billed and
+    # invisible here -- so surface it instead of letting the total read complete.
+    seen_types = {t for m in totals.values() for t in m}
+    unknown = sorted(seen_types - set(KNOWN_TOKEN_TYPES))
+    if unknown:
+        extra = sum(m[t] for m in totals.values() for t in unknown)
+        print(f"WARNING: unpriced token type(s) {', '.join(unknown)} carrying "
+              f"{extra:,.0f} tokens are excluded from every figure below. "
+              f"Price them in pricing.py or the total understates real spend.\n")
+
     print(f"{'window end':12s} {'model':26s} {'input':>14s} {'output':>12s}")
     for (day, model) in sorted(daily):
         t = daily[(day, model)]
@@ -94,12 +158,16 @@ def main():
 
     print(f"\n== totals, last {args.days:g} days ==")
     grand = 0.0
-    unpriced = []
+    unpriced, suppressed, suppressed_cost = [], [], 0.0
     for model in sorted(totals):
         t = totals[model]
-        if t.get("input", 0) < args.min_tokens:
-            continue
         cost = estimate_cost(model, t.get("input", 0), t.get("output", 0))
+        if t.get("input", 0) < args.min_tokens:
+            # Below the noise floor, but a cost ledger must not quietly drop rows:
+            # tally them and report the total they carry.
+            suppressed.append(model)
+            suppressed_cost += cost or 0.0
+            continue
         if cost is None:
             unpriced.append(model)
             cost_txt = "   (no price in pricing.py)"
@@ -112,6 +180,9 @@ def main():
     if unpriced:
         print(f"  unpriced models excluded from total: {', '.join(unpriced)} — "
               "add a verified entry to scripts/model_comparison/pricing.py")
+    if suppressed:
+        print(f"  {len(suppressed)} model(s) below --min-tokens {args.min_tokens:,} "
+              f"excluded (~${suppressed_cost:.2f}): {', '.join(suppressed)}")
     print("\nEstimates only; the billing console is authoritative for spend.")
 
 

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -48,6 +48,15 @@ from detectors import (  # noqa: E402
 )
 from pricing import estimate_cost, price_for  # noqa: E402
 
+# Where the spend record goes by default. NOT inside --cache-dir: .model_cache/ is
+# gitignored, and a cost ledger that lands there is lost to every other clone —
+# the exact problem export_model_cache.py exists to undo for the detections.
+# analysis_out/ is the established home for committed derived artifacts
+# (op_cache/, fp_taxonomy.json, silent_witness.json), and .gitignore re-includes
+# this file by name.
+DEFAULT_USAGE_LOG_REL = os.path.join("analysis_out", "usage_log.jsonl")
+DEFAULT_USAGE_LOG = str(REPO_ROOT / DEFAULT_USAGE_LOG_REL)
+
 
 def load_dotenv(root):
     """Load KEY=VALUE lines from a repo-root .env into os.environ (without
@@ -279,7 +288,7 @@ def score_model(detector, records, gts, panos_dir, radius_sq, label, city, cache
     return ModelRun(aggregate(pano_scores), failures, scored)
 
 
-def report_usage(detector, label, city, n_panos, usage_log_path):
+def report_usage(detector, label, city, panos_scored, usage_log_path):
     """Print and (append-)log a paid model's token usage + estimated cost.
 
     Standing rule: every experiment that spends API money records what it spent,
@@ -288,17 +297,26 @@ def report_usage(detector, label, city, n_panos, usage_log_path):
     detector during THIS run (cached panos made no call and cost nothing here);
     the dollar figure is an estimate from the verified table in pricing.py, and
     the billing console stays authoritative. Reconcile against actual project
-    token counts with scripts/analysis/vertex_usage.py."""
+    token counts with scripts/analysis/vertex_usage.py.
+
+    Called from a ``finally``, so it must survive being handed a half-finished
+    run: a leg that dies or is interrupted after paying for 400 calls is exactly
+    the one whose spend must not vanish. It never raises for that reason —
+    bookkeeping that can kill the run it is bookkeeping is worse than no
+    bookkeeping — and it is a no-op when the model made no calls."""
     usage = getattr(detector, "usage", None)
     if not usage or not usage.get("calls"):
         return
-    cost = estimate_cost(detector.model_id, usage["input_tokens"], usage["output_tokens"])
-    pricing = price_for(detector.model_id)
+    model_id = getattr(detector, "model_id", None)
+    cost = estimate_cost(model_id, usage["input_tokens"], usage["output_tokens"])
+    pricing = price_for(model_id)
     cost_txt = (f"  ~=${cost:.2f} (pricing as of {pricing['as_of']})" if cost is not None
                 else "  (no verified price in pricing.py — record one)")
+    # .get() on thinking: most providers don't report it, and a KeyError here
+    # would take down a run that has already been paid for.
     print(f"[{label}] API usage this run: {usage['calls']} calls, "
           f"{usage['input_tokens']:,} in / {usage['output_tokens']:,} out tokens "
-          f"({usage['thoughts_tokens']:,} thinking){cost_txt}")
+          f"({usage.get('thoughts_tokens', 0):,} thinking){cost_txt}")
     if not usage_log_path:
         return
     rec = {
@@ -306,15 +324,29 @@ def report_usage(detector, label, city, n_panos, usage_log_path):
         "bundle": city,
         "label": label,
         "provider": getattr(detector, "name", None),
-        "model_id": detector.model_id,
-        "panos_scored": n_panos,
+        "model_id": model_id,
+        # Panos this run actually scored, NOT the size of the bundle: on a
+        # resumed run most panos come from the cache and cost nothing, so
+        # len(gts) would understate cost-per-pano several-fold.
+        "panos_scored": panos_scored,
+        # The rig is part of the price: the same model on the same bundle costs
+        # ~6x more tiled than whole-pano, and without this two such runs log
+        # identically. Same reasoning as the detections export (9e87290).
+        "signature": detector.signature() if hasattr(detector, "signature") else None,
         **usage,
         "est_cost_usd": round(cost, 4) if cost is not None else None,
         "pricing": pricing,
     }
-    os.makedirs(os.path.dirname(usage_log_path) or ".", exist_ok=True)
-    with open(usage_log_path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(rec) + "\n")
+    try:
+        os.makedirs(os.path.dirname(usage_log_path) or ".", exist_ok=True)
+        with open(usage_log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(rec) + "\n")
+    except OSError as e:
+        # Print the record so the numbers survive in the run log even when the
+        # file can't be written; never let this abort the comparison.
+        print(f"[{label}] WARNING: could not write {usage_log_path}: "
+              f"{type(e).__name__}: {e}\n[{label}] usage record: {json.dumps(rec)}")
+        return
     print(f"[{label}] usage logged to {usage_log_path}")
 
 
@@ -522,10 +554,11 @@ def main():
                     help="Where to cache per-pano detections (keyed by model + rig + pano). "
                          "Re-runs reuse hits and don't re-pay the API.")
     ap.add_argument("--no-cache", action="store_true", help="Disable the detection cache.")
-    ap.add_argument("--usage-log",
+    ap.add_argument("--usage-log", default=DEFAULT_USAGE_LOG,
                     help="Append one JSONL record per paid-model run (token counts + "
-                         "estimated cost; see pricing.py). Default: usage_log.jsonl "
-                         "inside --cache-dir. Pass 'none' to disable.")
+                         f"estimated cost; see pricing.py). Default: {DEFAULT_USAGE_LOG_REL} "
+                         "(tracked in git — the spend record is a durable research fact, "
+                         "not scratch). Pass 'none' to disable.")
     args = ap.parse_args()
 
     load_dotenv(str(REPO_ROOT))
@@ -554,8 +587,7 @@ def main():
     radius_sq = radius_sq_for(args.radius)
     city = os.path.basename(os.path.normpath(args.bundle))
     cache = DetectionCache(args.cache_dir, enabled=not args.no_cache)
-    usage_log = (None if args.usage_log == "none"
-                 else args.usage_log or os.path.join(args.cache_dir, "usage_log.jsonl"))
+    usage_log = None if args.usage_log == "none" else args.usage_log
 
     print(f"Bundle: {args.bundle}  ({len(gts)} scored panos)  "
           f"match radius {args.radius}  ground truth: {gt_desc}")
@@ -571,6 +603,7 @@ def main():
             label = f"{label}#{seen[label]}"
         else:
             seen[label] = 1
+        run = None
         try:
             run = score_model(
                 detector, records, gts, panos_dir, radius_sq, label, city, cache)
@@ -583,8 +616,17 @@ def main():
             # validate_bundle before any of this. The type is printed so a genuine
             # bug here is still diagnosable rather than silently "not runnable".
             print(f"[{label}] not runnable: {type(e).__name__}: {e}\n")
+        finally:
+            # In a finally, not after the try: the run that dies or is Ctrl-C'd
+            # partway through has ALREADY paid for the calls it made, and that is
+            # precisely the spend worth recording. KeyboardInterrupt isn't an
+            # Exception, so on the success path alone it would unwind past this.
+            # panos_scored is None when score_model didn't return — the token
+            # counts are still exact, only the denominator is unknown.
+            report_usage(detector, label, city,
+                         len(run.scored) if run is not None else None, usage_log)
+        if run is None:
             continue
-        report_usage(detector, label, city, len(gts), usage_log)
         report = operating_report(run.report, run.scored, radius_sq, args.op_threshold)
         rows.append((label, report))
         # The detector's cache floor travels with the run so the sweep can drop

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -317,6 +317,11 @@ def report_usage(detector, label, city, panos_scored, usage_log_path):
     print(f"[{label}] API usage this run: {usage['calls']} calls, "
           f"{usage['input_tokens']:,} in / {usage['output_tokens']:,} out tokens "
           f"({usage.get('thoughts_tokens', 0):,} thinking){cost_txt}")
+    # Which BUILD answered, as distinct from the alias we asked for (#121).
+    versions = getattr(detector, "model_versions", None)
+    if versions:
+        served = ", ".join(f"{v} ({n:,} calls)" for v, n in sorted(versions.items()))
+        print(f"[{label}] served by: {served}")
     if not usage_log_path:
         return
     rec = {
@@ -325,6 +330,10 @@ def report_usage(detector, label, city, panos_scored, usage_log_path):
         "label": label,
         "provider": getattr(detector, "name", None),
         "model_id": model_id,
+        # The build(s) that actually served this run, against the alias above.
+        # Cannot be reconstructed later -- .model_cache stores points only -- so
+        # a run that didn't record it never can (#121).
+        "model_versions": dict(versions) if versions else None,
         # Panos this run actually scored, NOT the size of the bundle: on a
         # resumed run most panos come from the cache and cost nothing, so
         # len(gts) would understate cost-per-pano several-fold.

--- a/scripts/model_comparison/compare.py
+++ b/scripts/model_comparison/compare.py
@@ -31,6 +31,7 @@ import json
 import os
 import sys
 from collections import namedtuple
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -45,6 +46,7 @@ from rampnet.validation import collect, format_report  # noqa: E402
 from detectors import (  # noqa: E402
     GDINO_QUERY, OWLV2_QUERY, PanoSample, build_detector, parse_model_spec,
 )
+from pricing import estimate_cost, price_for  # noqa: E402
 
 
 def load_dotenv(root):
@@ -277,6 +279,45 @@ def score_model(detector, records, gts, panos_dir, radius_sq, label, city, cache
     return ModelRun(aggregate(pano_scores), failures, scored)
 
 
+def report_usage(detector, label, city, n_panos, usage_log_path):
+    """Print and (append-)log a paid model's token usage + estimated cost.
+
+    Standing rule: every experiment that spends API money records what it spent,
+    at the time it runs, so a paper can report cost alongside accuracy. Token
+    counts come from the provider's own usage metadata accumulated by the
+    detector during THIS run (cached panos made no call and cost nothing here);
+    the dollar figure is an estimate from the verified table in pricing.py, and
+    the billing console stays authoritative. Reconcile against actual project
+    token counts with scripts/analysis/vertex_usage.py."""
+    usage = getattr(detector, "usage", None)
+    if not usage or not usage.get("calls"):
+        return
+    cost = estimate_cost(detector.model_id, usage["input_tokens"], usage["output_tokens"])
+    pricing = price_for(detector.model_id)
+    cost_txt = (f"  ~=${cost:.2f} (pricing as of {pricing['as_of']})" if cost is not None
+                else "  (no verified price in pricing.py — record one)")
+    print(f"[{label}] API usage this run: {usage['calls']} calls, "
+          f"{usage['input_tokens']:,} in / {usage['output_tokens']:,} out tokens "
+          f"({usage['thoughts_tokens']:,} thinking){cost_txt}")
+    if not usage_log_path:
+        return
+    rec = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "bundle": city,
+        "label": label,
+        "provider": getattr(detector, "name", None),
+        "model_id": detector.model_id,
+        "panos_scored": n_panos,
+        **usage,
+        "est_cost_usd": round(cost, 4) if cost is not None else None,
+        "pricing": pricing,
+    }
+    os.makedirs(os.path.dirname(usage_log_path) or ".", exist_ok=True)
+    with open(usage_log_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+    print(f"[{label}] usage logged to {usage_log_path}")
+
+
 def rescore(scored, radius_sq, min_confidence=0.0):
     """Re-aggregate a finished run with predictions below ``min_confidence`` dropped.
 
@@ -481,6 +522,10 @@ def main():
                     help="Where to cache per-pano detections (keyed by model + rig + pano). "
                          "Re-runs reuse hits and don't re-pay the API.")
     ap.add_argument("--no-cache", action="store_true", help="Disable the detection cache.")
+    ap.add_argument("--usage-log",
+                    help="Append one JSONL record per paid-model run (token counts + "
+                         "estimated cost; see pricing.py). Default: usage_log.jsonl "
+                         "inside --cache-dir. Pass 'none' to disable.")
     args = ap.parse_args()
 
     load_dotenv(str(REPO_ROOT))
@@ -509,6 +554,8 @@ def main():
     radius_sq = radius_sq_for(args.radius)
     city = os.path.basename(os.path.normpath(args.bundle))
     cache = DetectionCache(args.cache_dir, enabled=not args.no_cache)
+    usage_log = (None if args.usage_log == "none"
+                 else args.usage_log or os.path.join(args.cache_dir, "usage_log.jsonl"))
 
     print(f"Bundle: {args.bundle}  ({len(gts)} scored panos)  "
           f"match radius {args.radius}  ground truth: {gt_desc}")
@@ -537,6 +584,7 @@ def main():
             # bug here is still diagnosable rather than silently "not runnable".
             print(f"[{label}] not runnable: {type(e).__name__}: {e}\n")
             continue
+        report_usage(detector, label, city, len(gts), usage_log)
         report = operating_report(run.report, run.scored, radius_sq, args.op_threshold)
         rows.append((label, report))
         # The detector's cache floor travels with the run so the sweep can drop

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -485,6 +485,10 @@ class _VLMDetector:
             self.max_edge = max_edge
         self.tile = tile
         self._views = views  # None -> equirect_tiling.default_views()
+        # Paid providers accumulate per-call token usage here so every run's
+        # cost is recorded (compare.py --usage-log); None = provider doesn't
+        # report usage (local GPU models are free in API terms).
+        self.usage = None
 
     def detect(self, sample):
         self._ensure_ready()
@@ -565,6 +569,8 @@ class GeminiDetector(_VLMDetector):
         # policy (benchmark imagery is public GSV/Mapillary). See docs/model_comparison.md.
         self.location = location or os.environ.get("GOOGLE_CLOUD_LOCATION") or "global"
         self._client = None
+        self.usage = {"calls": 0, "input_tokens": 0, "output_tokens": 0,
+                      "thoughts_tokens": 0}
 
     def _ensure_ready(self):
         try:
@@ -614,7 +620,23 @@ class GeminiDetector(_VLMDetector):
                 temperature=0.0,
             ),
         )
+        self._record_usage(resp)
         return boxes_from_gemini_response(resp)
+
+    def _record_usage(self, resp):
+        """Accumulate this call's token counts so the run's cost is a recorded
+        fact, not a reconstruction. Thinking tokens are billed as output, so
+        output_tokens already includes them; thoughts_tokens is kept separately
+        because it is invisible in the response text and dominates output cost.
+        Cached panos make no call, so this reflects what THIS run actually paid."""
+        um = getattr(resp, "usage_metadata", None)
+        if um is None:
+            return
+        thoughts = getattr(um, "thoughts_token_count", None) or 0
+        self.usage["calls"] += 1
+        self.usage["input_tokens"] += um.prompt_token_count or 0
+        self.usage["output_tokens"] += (um.candidates_token_count or 0) + thoughts
+        self.usage["thoughts_tokens"] += thoughts
 
     def _parse(self, raw, img_w, img_h):
         return gemini_boxes_to_points(raw)

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -490,6 +490,26 @@ class _VLMDetector:
         # report usage (local GPU models are free in API terms).
         self.usage = None
 
+    # The key contract for `usage`, in one place. Every paid provider reports
+    # input and output; almost none report thinking separately, so a reader must
+    # never assume that key exists (compare.py uses .get). Subclasses start the
+    # dict with init_usage() and add to it with accumulate_usage() rather than
+    # inventing their own shape.
+    USAGE_KEYS = ("calls", "input_tokens", "output_tokens", "thoughts_tokens")
+
+    def init_usage(self):
+        self.usage = dict.fromkeys(self.USAGE_KEYS, 0)
+
+    def accumulate_usage(self, input_tokens, output_tokens, thoughts_tokens=0):
+        """Add one paid call to the running total. ``output_tokens`` must ALREADY
+        include thinking, because that is how it bills; ``thoughts_tokens`` is
+        carried alongside only because it is invisible in the response text and
+        dominates output cost."""
+        self.usage["calls"] += 1
+        self.usage["input_tokens"] += input_tokens
+        self.usage["output_tokens"] += output_tokens
+        self.usage["thoughts_tokens"] += thoughts_tokens
+
     def detect(self, sample):
         self._ensure_ready()
         if self.tile:
@@ -569,8 +589,8 @@ class GeminiDetector(_VLMDetector):
         # policy (benchmark imagery is public GSV/Mapillary). See docs/model_comparison.md.
         self.location = location or os.environ.get("GOOGLE_CLOUD_LOCATION") or "global"
         self._client = None
-        self.usage = {"calls": 0, "input_tokens": 0, "output_tokens": 0,
-                      "thoughts_tokens": 0}
+        self.init_usage()
+        self._usage_warned = False   # warn once per run, not once per call
 
     def _ensure_ready(self):
         try:
@@ -633,10 +653,25 @@ class GeminiDetector(_VLMDetector):
         if um is None:
             return
         thoughts = getattr(um, "thoughts_token_count", None) or 0
-        self.usage["calls"] += 1
-        self.usage["input_tokens"] += um.prompt_token_count or 0
-        self.usage["output_tokens"] += (um.candidates_token_count or 0) + thoughts
-        self.usage["thoughts_tokens"] += thoughts
+        prompt = um.prompt_token_count or 0
+        candidates = um.candidates_token_count or 0
+        # The whole cost figure turns on candidates_token_count EXCLUDING thinking,
+        # which is what google-genai reports today and what makes
+        # total = prompt + candidates + thoughts hold. If a future SDK folds
+        # thinking into candidates instead, every thinking model's output silently
+        # doubles (~$20 on the 3.6-flash leg alone) with no other symptom -- and a
+        # unit test against a hand-built fake cannot catch that. So check it
+        # against the provider's own total, once, and say so loudly if it breaks.
+        total = getattr(um, "total_token_count", None)
+        if total and not self._usage_warned:
+            expected = prompt + candidates + thoughts
+            if abs(total - expected) > max(4, 0.02 * total):
+                self._usage_warned = True
+                print(f"[{self.model_id}] WARNING: usage_metadata does not add up "
+                      f"(total {total} vs prompt {prompt} + candidates {candidates} "
+                      f"+ thoughts {thoughts} = {expected}). The cost estimate may "
+                      f"double-count thinking; check the SDK's field semantics.")
+        self.accumulate_usage(prompt, candidates + thoughts, thoughts)
 
     def _parse(self, raw, img_w, img_h):
         return gemini_boxes_to_points(raw)

--- a/scripts/model_comparison/detectors.py
+++ b/scripts/model_comparison/detectors.py
@@ -30,7 +30,7 @@ import importlib.util
 import json
 import os
 import re
-from collections import namedtuple
+from collections import Counter, namedtuple
 
 # A pano to run a detector on. image_path points at the native-res JPEG in the
 # bundle's (git-ignored) panos/ dir; RampNet-from-bundle never opens it.
@@ -489,6 +489,13 @@ class _VLMDetector:
         # cost is recorded (compare.py --usage-log); None = provider doesn't
         # report usage (local GPU models are free in API terms).
         self.usage = None
+        # {resolved build -> calls}. `model_id` is what we ASKED for, and for a
+        # hosted model that is an alias the provider is free to move; this is what
+        # actually answered. Deliberately NOT in signature() -- that feeds
+        # cache_key, so adding it would miss every already-paid cached detection
+        # and re-bill the run (test_gemini_cache_key_is_frozen guards exactly
+        # that). None = provider reports no build. See #121.
+        self.model_versions = None
 
     # The key contract for `usage`, in one place. Every paid provider reports
     # input and output; almost none report thinking separately, so a reader must
@@ -499,6 +506,24 @@ class _VLMDetector:
 
     def init_usage(self):
         self.usage = dict.fromkeys(self.USAGE_KEYS, 0)
+
+    def record_model_version(self, version):
+        """Note which build answered this call, and say so if it changes mid-run.
+
+        A rotation partway through a leg is the case nobody would otherwise
+        notice: the alias, the signature and the cache key are all unchanged, so
+        two models' detections land in one published file indistinguishably."""
+        if not version:
+            return
+        if self.model_versions is None:
+            self.model_versions = Counter()
+        seen = set(self.model_versions)
+        self.model_versions[version] += 1
+        if seen and version not in seen:
+            print(f"[{self.model_id}] WARNING: the resolved model build changed "
+                  f"mid-run ({', '.join(sorted(seen))} -> {version}). This leg's "
+                  f"detections come from more than one model, and nothing in the "
+                  f"cache key or the published signature distinguishes them.")
 
     def accumulate_usage(self, input_tokens, output_tokens, thoughts_tokens=0):
         """Add one paid call to the running total. ``output_tokens`` must ALREADY
@@ -649,6 +674,9 @@ class GeminiDetector(_VLMDetector):
         output_tokens already includes them; thoughts_tokens is kept separately
         because it is invisible in the response text and dominates output cost.
         Cached panos make no call, so this reflects what THIS run actually paid."""
+        # Before the usage_metadata guard: a response can carry the resolved build
+        # without carrying usage, and the build is the half we cannot back-fill.
+        self.record_model_version(getattr(resp, "model_version", None))
         um = getattr(resp, "usage_metadata", None)
         if um is None:
             return

--- a/scripts/model_comparison/pricing.py
+++ b/scripts/model_comparison/pricing.py
@@ -13,9 +13,21 @@ which pulls the project's real token counts from Cloud Monitoring.
 """
 
 # USD per 1M tokens. Output prices include thinking tokens (billed as output).
+#
 # Source: https://ai.google.dev/gemini-api/docs/pricing (standard paid tier);
 # gemini-3.1-pro-preview is the <=200k-token-prompt tier (every harness call is
 # a single ~1.3k-token view, nowhere near the 200k boundary).
+#
+# CAVEAT ON THE SOURCE, and it matters: the measured spend these prices are applied
+# to was billed through **Vertex AI**, not the Gemini Developer API. GeminiDetector
+# takes the `vertexai=True` + ADC path whenever GOOGLE_GENAI_USE_VERTEXAI is set
+# (which is how every leg on this project ran), and vertex_usage.py reconciles
+# against Cloud Monitoring for a GCP project. The two rate cards agreed for these
+# models at `as_of`, but they are separate pages that can diverge, and the
+# introductory-expiry note below is an ai.google.dev fact that need not track
+# Vertex. Before quoting these dollars in a paper, re-check against
+# https://cloud.google.com/vertex-ai/generative-ai/pricing and stamp a new
+# `as_of` — the token counts are the durable measurement, not the dollars.
 PRICING = {
     "gemini-3.7-flash": {
         "input_per_m": 0.75, "output_per_m": 3.75, "as_of": "2026-08-15",

--- a/scripts/model_comparison/pricing.py
+++ b/scripts/model_comparison/pricing.py
@@ -1,0 +1,53 @@
+"""Per-token prices for the paid (API) models the harness can call.
+
+Every paid-model experiment must be costable after the fact (a paper reports
+what an experiment cost, not just what it scored), so the harness records token
+usage per run (see compare.py --usage-log) and prices it from this table. Keep
+the table verified-only: a price goes in with the date it was checked and the
+page it came from, never from memory. Prices change — the recorded token counts
+are the durable fact, the dollar figure is an estimate as of `as_of`, and the
+cloud billing console remains the authority for actual spend.
+
+Reconcile estimates against actuals with scripts/analysis/vertex_usage.py,
+which pulls the project's real token counts from Cloud Monitoring.
+"""
+
+# USD per 1M tokens. Output prices include thinking tokens (billed as output).
+# Source: https://ai.google.dev/gemini-api/docs/pricing (standard paid tier);
+# gemini-3.1-pro-preview is the <=200k-token-prompt tier (every harness call is
+# a single ~1.3k-token view, nowhere near the 200k boundary).
+PRICING = {
+    "gemini-3.7-flash": {
+        "input_per_m": 0.75, "output_per_m": 3.75, "as_of": "2026-08-15",
+        "note": "introductory through 2026-12-31; $1.50/$7.50 from 2027-01-01",
+    },
+    "gemini-3.6-flash": {
+        "input_per_m": 0.75, "output_per_m": 3.75, "as_of": "2026-08-15",
+        "note": "introductory through 2026-12-31; $1.50/$7.50 from 2027-01-01",
+    },
+    "gemini-3.1-pro-preview": {
+        "input_per_m": 2.00, "output_per_m": 12.00, "as_of": "2026-08-15",
+        "note": "prompts <=200k tokens tier",
+    },
+    "gemini-2.5-flash": {
+        "input_per_m": 0.30, "output_per_m": 2.50, "as_of": "2026-08-15",
+        "note": None,
+    },
+}
+
+
+def price_for(model_id):
+    """The pricing entry for a model id, or None when we have no verified price
+    (unknown/free/local models cost $0 in API terms but return None here so a
+    missing entry is visible rather than silently priced at zero)."""
+    return PRICING.get(model_id)
+
+
+def estimate_cost(model_id, input_tokens, output_tokens):
+    """Estimated USD for a (input, output) token count, or None if the model
+    has no verified price. Output counts must already include thinking tokens
+    (the SDK reports them separately; billing does not)."""
+    p = price_for(model_id)
+    if p is None:
+        return None
+    return (input_tokens * p["input_per_m"] + output_tokens * p["output_per_m"]) / 1e6

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -840,6 +840,72 @@ def test_gemini_usage_warns_when_the_sdk_stops_adding_up(capsys):
     assert "WARNING" not in capsys.readouterr().out
 
 
+def _gemini_resp(model_version=None, prompt=1000, candidates=50, thoughts=200):
+    usage = type("U", (), {"prompt_token_count": prompt,
+                           "candidates_token_count": candidates,
+                           "thoughts_token_count": thoughts,
+                           "total_token_count": prompt + candidates + thoughts})()
+    return type("R", (), {"usage_metadata": usage, "model_version": model_version})()
+
+
+def test_the_resolved_build_is_recorded_against_the_alias_we_asked_for(capsys):
+    # model_id is an alias the provider is free to move; this is what answered.
+    det = GeminiDetector(model_id="gemini-3.7-flash")
+    assert det.model_versions is None
+    for _ in range(3):
+        det._record_usage(_gemini_resp("gemini-3.7-flash-001"))
+    capsys.readouterr()
+    assert dict(det.model_versions) == {"gemini-3.7-flash-001": 3}
+    # And it stays OUT of the cache key: adding it there would miss every
+    # already-paid cached detection. test_gemini_cache_key_is_frozen guards the
+    # hash itself; this guards the reason.
+    assert "model_version" not in det.signature()
+    assert det.signature()["model_id"] == "gemini-3.7-flash"
+
+
+def test_a_build_rotation_mid_run_is_loud():
+    # The case nobody would otherwise notice: alias, signature and cache key are
+    # all unchanged, so two models' detections land in one file indistinguishably.
+    import io, contextlib
+    det = GeminiDetector(model_id="gemini-3.7-flash")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        det._record_usage(_gemini_resp("gemini-3.7-flash-001"))
+        det._record_usage(_gemini_resp("gemini-3.7-flash-002"))
+    out = buf.getvalue()
+    assert "WARNING" in out and "changed mid-run" in out
+    assert dict(det.model_versions) == {"gemini-3.7-flash-001": 1,
+                                        "gemini-3.7-flash-002": 1}
+
+
+def test_a_provider_that_reports_no_build_stays_none(capsys):
+    # None must mean "not reported", never an empty dict that reads as "asked and
+    # got nothing" -- the published files predating #121 are in exactly that state.
+    det = GeminiDetector(model_id="gemini-3.7-flash")
+    det._record_usage(_gemini_resp(None))
+    capsys.readouterr()
+    assert det.model_versions is None
+    assert det.usage["calls"] == 1     # the call still counted
+
+
+def test_the_usage_record_carries_the_build(tmp_path):
+    log = tmp_path / "usage_log.jsonl"
+    det = GeminiDetector(model_id="gemini-2.5-flash")
+    det._record_usage(_gemini_resp("gemini-2.5-flash-002"))
+    report_usage(det, "gemini-2.5-flash", "bend", 110, str(log))
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["model_id"] == "gemini-2.5-flash"          # what we asked for
+    assert rec["model_versions"] == {"gemini-2.5-flash-002": 1}   # what answered
+
+    # A local model reports neither, and must log null rather than {}.
+    class _Local:
+        name = "qwen"
+        model_id = "Qwen/Qwen3-VL-8B-Instruct"
+        usage = {"calls": 4, "input_tokens": 1, "output_tokens": 1}
+    report_usage(_Local(), "qwen", "bend", 110, str(log))
+    assert json.loads(log.read_text().splitlines()[1])["model_versions"] is None
+
+
 def test_gemini_usage_is_quiet_when_the_totals_agree(capsys):
     class _Usage:
         prompt_token_count = 1000

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -9,6 +9,8 @@ import json
 import os
 import sys
 
+import pytest
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "model_comparison"))
 
@@ -28,8 +30,11 @@ from dump_detections import detections_to_view_shapes  # noqa: E402
 from compare import (  # noqa: E402
     score_model, validate_bundle, validate_manual_bundle, DetectionCache, cache_key,
     ground_truths_from_verdicts, has_confidences, load_bundle,
-    load_manual_ground_truths, operating_report, rescore, sweep_rows,
+    load_manual_ground_truths, operating_report, report_usage, rescore, sweep_rows,
+    DEFAULT_USAGE_LOG,
 )
+import pricing  # noqa: E402
+from pricing import estimate_cost, price_for  # noqa: E402
 from rampnet.detection_eval import GroundTruth, radius_sq_for  # noqa: E402
 from prepare_yolo_dataset import (  # noqa: E402
     parse_box_size, _ground_distance_m, _box_wh, _resolve_distances, write_data_yaml,
@@ -780,19 +785,16 @@ def test_gemini_detect_fails_clearly_without_key_or_lib():
 
 # --- cost accounting (pricing.py + usage recording) -------------------------
 
-from pricing import estimate_cost, price_for  # noqa: E402
-from compare import report_usage  # noqa: E402
-
-
 def test_estimate_cost_known_and_unknown_models():
     # gemini-2.5-flash: $0.30/M in, $2.50/M out (pricing.py, verified 2026-08-15)
-    assert estimate_cost("gemini-2.5-flash", 2_000_000, 1_000_000) == 0.30 * 2 + 2.50
+    assert estimate_cost("gemini-2.5-flash", 2_000_000, 1_000_000) == pytest.approx(3.10)
     assert estimate_cost("not-a-model", 1, 1) is None
+    assert estimate_cost(None, 1, 1) is None
     assert price_for("not-a-model") is None
 
 
 def test_pricing_entries_are_complete():
-    for model, p in __import__("pricing").PRICING.items():
+    for model, p in pricing.PRICING.items():
         assert p["input_per_m"] > 0 and p["output_per_m"] > 0, model
         assert p["as_of"], f"{model}: a price without its verification date is a rumor"
 
@@ -819,6 +821,38 @@ def test_gemini_usage_accumulates_thinking_as_output():
     assert det.usage["calls"] == 2
 
 
+def test_gemini_usage_warns_when_the_sdk_stops_adding_up(capsys):
+    # The cost figure turns on candidates_token_count EXCLUDING thinking. If a
+    # future SDK folds thinking in, every thinking model's output silently doubles;
+    # the provider's own total is the only thing that can catch it.
+    class _Usage:
+        prompt_token_count = 1000
+        candidates_token_count = 250     # already includes the 200 thoughts
+        thoughts_token_count = 200
+        total_token_count = 1250         # != 1000 + 250 + 200
+
+    det = GeminiDetector(model_id="gemini-3.7-flash")
+    det._record_usage(type("R", (), {"usage_metadata": _Usage()})())
+    out = capsys.readouterr().out
+    assert "WARNING" in out and "does not add up" in out
+    # Warns once per run, not once per call — a full leg is ~750 calls.
+    det._record_usage(type("R", (), {"usage_metadata": _Usage()})())
+    assert "WARNING" not in capsys.readouterr().out
+
+
+def test_gemini_usage_is_quiet_when_the_totals_agree(capsys):
+    class _Usage:
+        prompt_token_count = 1000
+        candidates_token_count = 50
+        thoughts_token_count = 200
+        total_token_count = 1250         # == 1000 + 50 + 200, today's semantics
+
+    det = GeminiDetector(model_id="gemini-3.7-flash")
+    det._record_usage(type("R", (), {"usage_metadata": _Usage()})())
+    assert "WARNING" not in capsys.readouterr().out
+    assert det.usage["output_tokens"] == 250
+
+
 def test_report_usage_appends_jsonl(tmp_path):
     class _Det:
         name = "gemini"
@@ -839,6 +873,78 @@ def test_report_usage_appends_jsonl(tmp_path):
         usage = None
     report_usage(_Local(), "x", "richmond", 124, str(log))
     assert len(log.read_text().splitlines()) == 2
+
+
+def test_usage_record_carries_the_rig_that_priced_it(tmp_path):
+    # Two runs of the same model on the same bundle at different tiling cost ~6x
+    # different input, and without the signature the log cannot tell them apart.
+    log = tmp_path / "usage_log.jsonl"
+    for tile in (True, False):
+        det = GeminiDetector(model_id="gemini-2.5-flash", tile=tile)
+        det.usage = {"calls": 1, "input_tokens": 10, "output_tokens": 2,
+                     "thoughts_tokens": 0}
+        report_usage(det, "gemini-2.5-flash", "bend", 110, str(log))
+    a, b = [json.loads(line) for line in log.read_text().splitlines()]
+    assert a["signature"]["tile"] is True and b["signature"]["tile"] is False
+    assert a["signature"]["views"] and b["signature"]["views"] is None
+    # Everything else about the two records is identical apart from the timestamp,
+    # which is exactly why the signature has to be there.
+    assert {k: v for k, v in a.items() if k not in ("ts", "signature")} == \
+           {k: v for k, v in b.items() if k not in ("ts", "signature")}
+
+
+def test_report_usage_never_raises_on_a_partial_or_odd_run(tmp_path):
+    # It is called from a finally, after money has been spent. Every one of these
+    # would otherwise kill a run that had already paid.
+    log = tmp_path / "usage_log.jsonl"
+
+    class _NoThinkingField:          # most providers don't report thinking
+        name = "someprovider"
+        model_id = "gemini-2.5-flash"
+        usage = {"calls": 3, "input_tokens": 1000, "output_tokens": 200}
+
+    report_usage(_NoThinkingField(), "someprovider", "bend", None, str(log))
+    rec = json.loads(log.read_text().splitlines()[0])
+    assert rec["thoughts_tokens"] == 0 if "thoughts_tokens" in rec else True
+    # panos_scored is None when score_model never returned: the token counts are
+    # still exact, only the denominator is unknown.
+    assert rec["panos_scored"] is None and rec["calls"] == 3
+
+    class _NoModelId:               # a detector that never got as far as naming itself
+        usage = {"calls": 1, "input_tokens": 5, "output_tokens": 1}
+
+    report_usage(_NoModelId(), "mystery", "bend", 1, str(log))
+    rec = json.loads(log.read_text().splitlines()[1])
+    assert rec["model_id"] is None and rec["est_cost_usd"] is None
+
+
+def test_an_unwritable_usage_log_does_not_abort_the_run(tmp_path, capsys):
+    # The log write sits on the critical path of a paid multi-model comparison;
+    # losing the file must not lose the table.
+    class _Det:
+        name = "gemini"
+        model_id = "gemini-2.5-flash"
+        usage = {"calls": 2, "input_tokens": 100, "output_tokens": 10,
+                 "thoughts_tokens": 0}
+
+    blocked = tmp_path / "a_directory_where_the_file_goes"
+    blocked.mkdir()
+    report_usage(_Det(), "gemini-2.5-flash", "bend", 110, str(blocked))
+    out = capsys.readouterr().out
+    assert "WARNING" in out and "usage record" in out
+    # The numbers survive in the run log even though the file could not be written.
+    assert '"calls": 2' in out
+
+
+def test_the_default_usage_log_is_tracked_not_in_the_gitignored_cache():
+    # The whole point of recording spend is that it outlives the machine. Defaulting
+    # into .model_cache/ (gitignored) is the bug export_model_cache.py exists to undo.
+    assert ".model_cache" not in DEFAULT_USAGE_LOG
+    assert DEFAULT_USAGE_LOG.replace("\\", "/").endswith("analysis_out/usage_log.jsonl")
+    with open(os.path.join(REPO_ROOT, ".gitignore"), encoding="utf-8") as fh:
+        gitignore = fh.read()
+    assert "!analysis_out/usage_log.jsonl" in gitignore, \
+        "analysis_out/* is ignored, so the log needs an explicit re-include"
 
 
 # --- tiled detect() end-to-end (no live model) ------------------------------

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -778,6 +778,69 @@ def test_gemini_detect_fails_clearly_without_key_or_lib():
     raise AssertionError("expected GeminiDetector.detect to fail loudly without lib/key")
 
 
+# --- cost accounting (pricing.py + usage recording) -------------------------
+
+from pricing import estimate_cost, price_for  # noqa: E402
+from compare import report_usage  # noqa: E402
+
+
+def test_estimate_cost_known_and_unknown_models():
+    # gemini-2.5-flash: $0.30/M in, $2.50/M out (pricing.py, verified 2026-08-15)
+    assert estimate_cost("gemini-2.5-flash", 2_000_000, 1_000_000) == 0.30 * 2 + 2.50
+    assert estimate_cost("not-a-model", 1, 1) is None
+    assert price_for("not-a-model") is None
+
+
+def test_pricing_entries_are_complete():
+    for model, p in __import__("pricing").PRICING.items():
+        assert p["input_per_m"] > 0 and p["output_per_m"] > 0, model
+        assert p["as_of"], f"{model}: a price without its verification date is a rumor"
+
+
+def test_gemini_usage_accumulates_thinking_as_output():
+    class _Usage:
+        prompt_token_count = 1000
+        candidates_token_count = 50
+        thoughts_token_count = 200
+
+    class _Resp:
+        usage_metadata = _Usage()
+
+    det = GeminiDetector(model_id="gemini-3.7-flash")
+    assert det.usage == {"calls": 0, "input_tokens": 0, "output_tokens": 0,
+                         "thoughts_tokens": 0}
+    det._record_usage(_Resp())
+    det._record_usage(_Resp())
+    assert det.usage == {"calls": 2, "input_tokens": 2000,
+                         "output_tokens": 500,   # (50 visible + 200 thinking) x 2
+                         "thoughts_tokens": 400}
+    # A response with no usage metadata (e.g. a mocked/older client) is a no-op.
+    det._record_usage(type("R", (), {"usage_metadata": None})())
+    assert det.usage["calls"] == 2
+
+
+def test_report_usage_appends_jsonl(tmp_path):
+    class _Det:
+        name = "gemini"
+        model_id = "gemini-2.5-flash"
+        usage = {"calls": 6, "input_tokens": 2_000_000, "output_tokens": 1_000_000,
+                 "thoughts_tokens": 300}
+
+    log = tmp_path / "usage_log.jsonl"
+    report_usage(_Det(), "gemini-2.5-flash", "richmond", 124, str(log))
+    report_usage(_Det(), "gemini-2.5-flash", "bend", 110, str(log))
+    recs = [json.loads(line) for line in log.read_text().splitlines()]
+    assert [r["bundle"] for r in recs] == ["richmond", "bend"]
+    assert recs[0]["est_cost_usd"] == 3.10 and recs[0]["calls"] == 6
+    assert recs[0]["pricing"]["as_of"]
+    # A detector with no usage (local model) writes nothing.
+    class _Local:
+        model_id = "x"
+        usage = None
+    report_usage(_Local(), "x", "richmond", 124, str(log))
+    assert len(log.read_text().splitlines()) == 2
+
+
 # --- tiled detect() end-to-end (no live model) ------------------------------
 
 class _FakeTiledVLM(_VLMDetector):


### PR DESCRIPTION
**Standing rule this implements:** every experiment that spends API money records what it spent, as it runs, so papers can report cost alongside accuracy.

## What this adds

1. **Run-time recording** — `GeminiDetector` accumulates each call''s token counts from the SDK''s own `usage_metadata` (thinking tokens fold into output, matching how they''re billed). After each paid-model run, `compare.py` prints the usage + estimated cost and appends a JSONL record to `--usage-log` (default `<cache-dir>/usage_log.jsonl`, `--usage-log none` to disable). Cached panos make no call, so the record is what *that run* actually paid.
2. **Verified-only price table** — `scripts/model_comparison/pricing.py`. Every entry carries the date it was verified and a note on introductory-rate expiry (the Gemini 3.x flash rates double on 2027-01-01). Token counts are the durable fact; dollars are an estimate; the billing console stays authoritative.
3. **Server-side reconciliation** — `scripts/analysis/vertex_usage.py` pulls the project''s actual billed token counts per model from Cloud Monitoring (daily granularity, ~6 weeks retention). This recovers runs that predate the instrumentation, which is how the table below exists at all.
4. **Docs** — a "Cost accounting" section in `docs/model_comparison.md` with the measured numbers and caveats (the daily rows are query-anchored 24 h windows, not calendar days).

## Measured: the complete Gemini history of the benchmark (Cloud Monitoring, 2026-08-15)

| model | input tokens | output tokens | est. cost |
|---|---:|---:|---:|
| gemini-2.5-flash | 4,811,091 | 1,479,263 | $5.14 |
| gemini-3.6-flash | 17,449,987 | 6,119,688 | $36.04 |
| gemini-3.1-pro-preview | 17,405,320 | 593,380 | $41.93 |
| gemini-3.7-flash (leg in flight at time of measurement) | 14,589,790 | 3,584,187 | $24.38 |
| **total** | | | **~$107** |

Two findings worth keeping: tokenization is deterministic — a 125-pano city leg is exactly **957,000 input tokens** (125 panos x 6 views x 1,276 tokens/view) — and **thinking tokens dominate output cost** and vary enormously by model (3.6-flash emitted 6.1M output tokens on the same input where 3.1-pro emitted 0.59M), so flash legs are not as cheap relative to pro as the rate card suggests.

## Safety of the change

The detection-cache signature is untouched — `test_gemini_cache_key_is_frozen` still pins the hash, so none of the ~paid cached detections are invalidated. Suite: **555 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)