### PR TITLE
Land the galleries join-key fix on the Hub, and close the two holes that blocked it

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -71,13 +71,21 @@ Per-step, for adding a city to this benchmark:
 | Export the native-res bundle (`panos/` + `records.jsonl`) | auto-labeler | `scripts/export_benchmark.py` |
 | GT-verify a sample → `verdicts.json` | **RampNet** | `scripts/gt_gallery.py benchmark/<city>` |
 | Score P/R + Wilson CIs + threshold sweep | **RampNet** | `scripts/score_validation.py` / `rampnet.validation` |
-| Add the split to the HF benchmark dataset | **RampNet** | `scripts/build_benchmark_dataset.py` |
+| Add the split to the HF benchmark dataset | **RampNet** | `scripts/export_benchmark.py` — `build` → `verify` → `push` |
 
-⚠️ The last step lags: `build_benchmark_dataset.py` is still hardcoded to `bend` + `richmond`, so
-clovis, morgantown, annapolis, paterson, gainesville, budapest, and sao_paulo are **not** in the published dataset — and it does not yet carry
-`review_notes` or per-pano `note` into the parquet rows or the dataset card. Whoever finishes #21
-should make the caveats travel with the data, since that is the audience most likely to read a
-number with no idea how it was labeled.
+⚠️ **Two different tools share the name `export_benchmark.py`.** The bundle step above is the
+*auto-labeler's* (a run's results out to `benchmark/<city>/`); the publish step is *RampNet's*
+(the whole benchmark up to the Hub as Parquet). Adding a city means adding it to that script's
+`BENCHMARK_SPLITS` allowlist, or the package silently omits it.
+
+All nine splits are published, four configs each — `records`, `native`, `4096x2048`, `galleries`
+(#21, verified against the live repo 2026-08-17). `scripts/build_benchmark_dataset.py` is the
+two-city predecessor and publishes nothing; don't run it.
+
+What the published copy still does not carry is the reviewer's own commentary: `review_notes` and
+per-pano `note` stay in git here rather than travelling into the parquet rows or the dataset card,
+and Bend's four training-overlap panoramas (below) are unflagged there. Both are tracked in #127 —
+the caveats should reach the audience that runs `load_dataset` and never opens this repo.
 
 The GT gallery and scorer are **canonical in RampNet** (`scripts/gt_gallery.py`,
 `rampnet/validation.py` — decoupled from any imagery source, no network). The auto-labeler
@@ -135,6 +143,16 @@ Clovis is below the other cities on both metrics because it is 100% soft, 2018-e
 360 imagery, where richmond mixes in the sharper NCTECH iSTAR Pulsar (camera provenance is in the
 records, added in #50 and backfilled for morgantown/budapest in 2026-07-25). Note bend samples only
 10 empty panos where the others take 25.
+
+**Bend overlaps the training set by four panoramas**, which is the price of it being one of the
+paper's three training cities. An exact-id check on 2026-07-22 found `6WC0hdAYRsSAcluKSs5iRg`,
+`9kW9cxpuj7q8DMzf-ClrQQ`, `DJ8Zp111zu6KnMZz-0PHgQ` and `VgWpqFkTwCIROvM0z-DkOw` — 4 of bend's 110
+reviewed panos — in `rampnet-dataset`'s train/val splits. Dropping them (measured 2026-08-18 with
+`score_validation.py`) moves the headline **0.954 / 0.758 → 0.956 / 0.753** and the unbiased subset
+**0.972 / 0.738 → 0.976 / 0.731**: inside the Wilson intervals both ways, so nothing here rests on
+it. Bend is the only split where this can happen — the other three GSV splits are not training
+cities and Mapillary ids are a different id space — but that is a prediction, not a measurement,
+and the published dataset carries no `train_overlap` column to filter on yet (#127).
 
 **Precision tracks the camera across the US Mapillary splits**, now that every split carries
 `camera_make`/`camera_model`: clovis (100% GoPro Fusion, 2018) 0.914 → richmond (62% iSTAR Pulsar,

--- a/docs/adding_a_benchmark_city.md
+++ b/docs/adding_a_benchmark_city.md
@@ -215,7 +215,7 @@ city or mislabelling it.
 | `low_floor_sweep.py` → `SPLIT_IMAGERY_FALLBACK` | only if `records.jsonl` lacks camera provenance |
 | `low_floor_sweep.py` → `TTA_RECORD_SPLITS` | only if the committed detections used TTA |
 | `scripts/analysis/plot_operating_point.py` → `SERIES` | add a colour **from the validated palette, in slot order** — never a made-up hue. Past 8 slots, fold to "Other" or facet |
-| `scripts/build_benchmark_dataset.py` | ⚠️ still hardcoded to bend + richmond — the HF dataset lags the repo (issue #21) |
+| `scripts/export_benchmark.py` → `BENCHMARK_SPLITS` | **required** — the HF package is built from this allowlist, not from a glob, so a split missing here is silently absent from all four configs. A test keeps it in step with `scripts/analysis/miss_decomposition.py`. Republish with `build` → `verify` → `push` |
 
 ## Phase 6 — documentation (where a split actually becomes real)
 
@@ -252,8 +252,9 @@ run, say so explicitly and say why, rather than leaving a blank.
   GPU. The gallery crops are not — but the **A/B tags are**, under
   `benchmark/<city>/incremental_fp_tags.json`. Losing those means redoing the human pass.
 - **`panos/` is git-ignored and irreplaceable if the source decays.** Mapillary images can
-  disappear. `index.csv` records sha256 per pano; archive the bundle somewhere durable (the HF
-  dataset, issue #21) rather than relying on a laptop.
+  disappear. `index.csv` records sha256 per pano; archive the bundle somewhere durable — the HF
+  dataset [`rampnet-benchmark`](https://huggingface.co/datasets/projectsidewalk/rampnet-benchmark),
+  published in #21 — rather than relying on a laptop.
 - **Never review at native resolution.** It is the one methodological error the benchmark has
   already made once, and it cost a re-review of two cities.
 

--- a/docs/data_provenance.md
+++ b/docs/data_provenance.md
@@ -255,9 +255,27 @@ The informative cities point the other way: Bend and Portland have *grown* since
 (+8.7% and +1.6%), so a file downloaded today would be **larger** than Table 1, and the committed
 ones are smaller.
 
+**How big the gaps are, in each city's own units.** The drift argument above is directional; this
+is the magnitude. Measured against each city's growth between Table 1 and the 2026-07-31 snapshot
+in `data/inventories/` — Bend +1,194 (13,611 → 14,805), Portland +777 (45,324 → 46,101) — the
+committed files sit **21% of Bend's subsequent growth** below Table 1 and **37% of Portland's**.
+Both are therefore consistent with a download that predates whatever was counted for Table 1, but
+by *different* fractions of the interval, so they do not resolve to one download date. That is
+weak positive evidence for the survey-time reading and not more; a survey compiled city-by-city
+over some weeks would produce exactly this, and so would several other stories.
+
+**Re-verified independently, 2026-08-17.** The resolution check above was reproduced without
+`gov_provenance.py`, by matching each `all_locations.csv` row to the three committed files on
+rounded coordinates: **276,071 / 276,071 matched, 0 unmatched**, attributing 217,679 to NYC,
+45,035 to Portland and 13,357 to Bend — equal to the per-file counts, city by city. The record
+counts were also recounted straight from the blobs (13,357 Point features, 45,035 Point features,
+217,679 parsed `POINT` rows). Both agree with this section exactly.
+
 **Until that is settled, quote 276,071 for anything derived from the committed inputs** — the
 consumption rates in §3.1, the provenance CSV, and any re-run of Stage 1 — and quote 276,615 only
-when citing the paper's Table 1 as published.
+when citing the paper's Table 1 as published. **The published dataset card for
+`rampnet-stage1-inputs` carries this same reconciliation**, because that is where a replicator
+downloads the files and first notices the mismatch; the two must be kept in step.
 
 ## 4. Split of record
 

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -138,13 +138,39 @@ ds = load_dataset("projectsidewalk/rampnet-benchmark", "4096x2048", split="budap
 confidence, and the imagery a reviewer needs is the `4096x2048` config — `gt_gallery.py` renders at
 that size and never native. What remains blocking a second rater is a *person*, not an artifact.
 
-> **Outstanding: `galleries` needs one re-push.** As first published, a gallery row's `pano_id`
-> column held the *crop tag* — `low_floor_sweep.py` names each crop `{pano}_{x:.5f}_{y:.5f}` — so
-> the join to `records` documented on the card silently returned zero rows. The exporter now
-> writes `crop_id` (the tag), `pano_id` (parsed back out of it) and the detection's
-> `x_normalized` / `y_normalized`, which makes that join work. **The fix is in the code but not yet
-> on the Hub**: re-running `export_benchmark.py build --galleries ...` and pushing the 244 MB
-> `galleries` config is what lands it. `records`, `native` and `4096x2048` are unaffected.
+> **✅ Done 2026-08-17: the `galleries` join key is fixed on the Hub.** As first published, a
+> gallery row's `pano_id` column held the *crop tag* — `low_floor_sweep.py` names each crop
+> `{pano}_{x:.5f}_{y:.5f}` — so the join to `records` documented on the card silently returned zero
+> rows. Rows now carry `crop_id` (the tag), `pano_id` (parsed back out of it) and the detection's
+> `x_normalized` / `y_normalized`. Re-pushed as 9 splits / 314 crops / **399.5 MB**; `native`,
+> `4096x2048` and `records` were left as they were, since `upload_folder` adds and overwrites but
+> never deletes. Verified after the fact against the live repo: the join is 9-for-9 on paterson,
+> and `0uNeulmg68uHO_WKDIuqZw_0.85449_0.59961` parses back to a panorama id that contains its own
+> underscore — the case the right-anchored parse exists for.
+>
+> Two things had to be fixed before the re-push was safe to run, both found by attempting it:
+>
+> - **The card advertised the size of whatever was on local disk.** A galleries-only rebuild would
+>   have published "0.24 GB" — later measured as 0.40 GB — as the size of an 11.41 GB dataset. That
+>   is the same hole as the config list, one field over, so `build_manifest.json` now records each
+>   config's byte total and the card sums the union.
+> - **The published package predated the manifest**, so the first partial rebuild had nothing to
+>   union against and `card` refused — correctly, but with no way forward short of rebuilding
+>   11.41 GB to change one config. `export_benchmark.py adopt` writes the manifest from the
+>   published repo's own file listing, which is the only authority on what is up there.
+>
+> The exact sequence, which is what a replicator runs:
+>
+> ```bash
+> python scripts/export_benchmark.py adopt  --out dist/rampnet-benchmark   # only needed once
+> python scripts/export_benchmark.py build  --galleries analysis_out/op --out dist/rampnet-benchmark
+> python scripts/export_benchmark.py verify --out dist/rampnet-benchmark
+> python scripts/export_benchmark.py push   --out dist/rampnet-benchmark --message "..."
+> ```
+>
+> `build` also regenerates `records` from the committed `records.jsonl` / `verdicts.json`; it came
+> back byte-for-byte the same size as the published copy (179,356 bytes), which is the cheapest
+> available check that the rebuild path is stable.
 
 ## Every manual-review task, and what it would take to redo it
 
@@ -170,10 +196,11 @@ no imagery, no `.model_cache` and no GPU: open the committed crops, tag, commit 
 
 Applying the same to the other two is a size question, and here are the measured numbers:
 
-- **#55 A/B galleries: 244 MB as PNG** across the six cities still on disk (two cities' galleries
-  have already been deleted, though their tags survive — which is the failure mode this section
-  exists to prevent). Re-encoded as JPEG they would be far smaller. **Decision needed:** commit
-  re-encoded crops, or publish the galleries to HF.
+- **#55 A/B galleries: ✅ resolved by publishing them.** This once read "244 MB as PNG across the
+  six cities still on disk (two cities' galleries have already been deleted)". Re-measured
+  2026-08-17 while doing the re-push above, that is wrong on both counts: **all 9 splits are
+  present, 314 crops, 380.8 MB of PNG**, and they are on the Hub as the `galleries` config
+  (399.5 MB as Parquet). Nothing was deleted and no re-encode decision is needed.
 - **GT verification is the hard one.** Reviewers scan *whole panoramas* for missed ramps, so crops
   are not enough. But `gt_gallery.py` renders at the model's **4096×2048**, never native (the #26
   fairness note), so what is actually required is a **model-resolution derivative — roughly
@@ -315,7 +342,12 @@ source files are the archive:
 | `records` | a few MB | **the ground truth** — per-pano metadata, detections with their human verdict, reviewer-marked misses. Its own config so a verdict correction never rewrites an image blob |
 | `4096x2048` | **1.02 GB** | **what GT reviewers actually saw.** `gt_gallery.py` renders at the model's 4096×2048 and never native, so this — not the native archive — is what lets a second rater redo the pass |
 | `native` | **10.89 GB** | the resolution experiment (#25) and any future re-render |
-| `galleries` | 244 MB | the #55 A/B crops reviewers saw, 8 splits (also regenerable, so belt-and-braces) |
+| `galleries` | 244 MB | the #55 A/B crops reviewers saw (also regenerable, so belt-and-braces) |
+
+**As shipped, measured from the published repo 2026-08-17** — the sizes above were the plan's
+estimates, and every config carries the same 9 splits: `native` 10.01 GB, `4096x2048` 1.00 GB,
+`galleries` 399.5 MB, `records` 179 KB, **11.41 GB total**. `export_benchmark.py adopt` prints
+this table from the Hub, so it can be re-checked rather than trusted.
 
 (The plan below was written as loose `panos_native/<city>/` folders; it shipped as Parquet, one
 file per split at `data/<config>/<city>.parquet`, for the reasons in "Packaged as Parquet" further

--- a/scripts/build_benchmark_dataset.py
+++ b/scripts/build_benchmark_dataset.py
@@ -1,5 +1,11 @@
 """Build the RampNet deployment-validation benchmark as a HuggingFace dataset (issue #21).
 
+SUPERSEDED -- do not run this to publish. ``scripts/export_benchmark.py`` is what
+built and pushed ``projectsidewalk/rampnet-benchmark`` (all nine splits, four
+configs). This two-city predecessor is kept for one thing only: ``LEAKED_BEND_IDS``
+below is the sole record of the 2026-07-22 training-overlap check, which the real
+exporter does not yet carry as a column. Retire this file once it does (#127).
+
 Packs the committed benchmark bundles (``benchmark/{bend,richmond}/`` — native-res
 panoramas + model detections + human verdicts) into a ``DatasetDict`` with one
 split per city, writes a domain-labeled dataset card, and verifies that scoring

--- a/scripts/export_benchmark.py
+++ b/scripts/export_benchmark.py
@@ -374,24 +374,64 @@ def scan_index(out):
     return index
 
 
-def save_index(out, index):
-    """Record what this package contains, so a later partial rebuild cannot forget the rest."""
-    out.mkdir(parents=True, exist_ok=True)
-    merged = load_manifest(out)
-    merged.update(dict((config, sorted(set(cities))) for config, cities in index.items()))
-    (out / MANIFEST_NAME).write_text(json.dumps(
-        {"configs": merged, "git_commit": git_commit(),
+def config_bytes(out):
+    """{config: total parquet bytes} for what is on this disk right now."""
+    sizes = {}
+    for path in (Path(out) / "data").glob("*/*.parquet"):
+        sizes[path.parent.name] = sizes.get(path.parent.name, 0) + path.stat().st_size
+    return sizes
+
+
+def write_manifest(out, configs, sizes):
+    Path(out).mkdir(parents=True, exist_ok=True)
+    (Path(out) / MANIFEST_NAME).write_text(json.dumps(
+        {"configs": configs, "sizes": sizes, "git_commit": git_commit(),
          "written_at": datetime.date.today().isoformat()}, indent=2), encoding="utf-8")
 
 
-def load_manifest(out):
+def save_index(out, index):
+    """Record what this package contains, so a later partial rebuild cannot forget the rest."""
+    merged = load_manifest(out)
+    merged.update(dict((config, sorted(set(cities))) for config, cities in index.items()))
+    # Sizes travel with the config list for the same reason: the card advertises a total, and a
+    # partial rebuild only holds its own configs on disk. Record each rebuilt config's byte total
+    # so the next card can add back the ones it did not touch. See package_bytes().
+    sizes = load_sizes(out)
+    on_disk = config_bytes(out)
+    sizes.update(dict((config, on_disk[config]) for config in index if config in on_disk))
+    write_manifest(out, merged, sizes)
+
+
+def _manifest_field(out, field):
     path = Path(out) / MANIFEST_NAME
     if not path.is_file():
         return {}
     try:
-        return json.loads(path.read_text(encoding="utf-8")).get("configs", {})
+        return json.loads(path.read_text(encoding="utf-8")).get(field, {})
     except ValueError:
         return {}
+
+
+def load_manifest(out):
+    return _manifest_field(out, "configs")
+
+
+def load_sizes(out):
+    return _manifest_field(out, "sizes")
+
+
+def package_bytes(out, index):
+    """Total parquet bytes of the *published* package, not merely of what this run rebuilt.
+
+    render_card summed out.rglob("*.parquet"), which is right for a full build and wrong for every
+    partial one: re-pushing one config advertised that config as the whole dataset -- `galleries`
+    alone would have published "0.40 GB" over the 11.41 GB actually on the Hub. That is the same
+    hole as the config list, one field over, so it closes the same way. Configs present on this
+    disk are authoritative for their own size; the rest come from the manifest.
+    """
+    sizes = load_sizes(out)
+    sizes.update(config_bytes(out))
+    return sum(size for config, size in sizes.items() if config in index)
 
 
 def load_index(out, allow_partial=False):
@@ -446,7 +486,7 @@ def split_date_range(benchmark, cities):
 
 def render_card(out, benchmark, repo_id, index):
     cities = sorted(set(sum(index.values(), [])))
-    total = sum(f.stat().st_size for f in out.rglob("*.parquet"))
+    total = package_bytes(out, index)
     card_text = TEMPLATE.read_text(encoding="utf-8").format(
         configs_yaml=configs_yaml(index),
         git_commit=git_commit(),
@@ -664,15 +704,53 @@ def push(args):
     print("Pushing {} to {}".format(out, args.repo_id))
     api.create_repo(repo_id=args.repo_id, repo_type="dataset",
                     private=args.private, exist_ok=True)
+    # upload_folder adds and overwrites; it never deletes, so a partial --out re-pushes only the
+    # configs it holds and leaves the rest of the repo alone. The message must then say what this
+    # push actually carried, rather than the first publication's fixed wording.
     api.upload_folder(repo_id=args.repo_id, repo_type="dataset", folder_path=str(out),
-                      commit_message="Add benchmark panoramas (native + 4096x2048) and A/B galleries")
+                      commit_message=args.message)
     print("Done: https://huggingface.co/datasets/{}".format(args.repo_id))
+
+
+def adopt_index(siblings):
+    """(configs, sizes) from a published repo's file listing. Split out so it is testable."""
+    configs, sizes = {}, {}
+    for name, size in siblings:
+        parts = name.split("/")
+        if len(parts) != 3 or parts[0] != "data" or not parts[2].endswith(".parquet"):
+            continue
+        config = parts[1]
+        configs.setdefault(config, []).append(parts[2][: -len(".parquet")])
+        sizes[config] = sizes.get(config, 0) + (size or 0)
+    return dict((c, sorted(set(s))) for c, s in configs.items()), sizes
+
+
+def adopt(args):
+    """Write a manifest for a package that is already on the Hub.
+
+    build_manifest.json postdates the first publication of rampnet-benchmark, so the earliest
+    partial rebuild has nothing to union against and `card` refuses -- correctly, but with no way
+    forward short of rebuilding 11.41 GB to change one config. This reads the published repo's own
+    listing, which is the only authority on what is actually up there, and writes the manifest a
+    later `build` merges into. Run it once against an --out you are about to rebuild into.
+    """
+    from huggingface_hub import HfApi                # imported late: not needed to build or verify
+    out = Path(args.out)
+    info = HfApi().repo_info(args.repo_id, repo_type="dataset", files_metadata=True)
+    configs, sizes = adopt_index([(s.rfilename, s.size) for s in info.siblings])
+    if not configs:
+        sys.exit("error: {} publishes no data/<config>/<split>.parquet".format(args.repo_id))
+    write_manifest(out, configs, sizes)
+    for config in sorted(configs):
+        print("{:<12} {:>2} splits {:>15,} bytes".format(
+            config, len(configs[config]), sizes[config]))
+    print("{:,} bytes total -> {}".format(sum(sizes.values()), out / MANIFEST_NAME))
 
 
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("mode", choices=["build", "verify", "records", "card", "push"])
+    parser.add_argument("mode", choices=["build", "verify", "records", "card", "push", "adopt"])
     parser.add_argument("--out", required=True, type=Path)
     parser.add_argument("--benchmark", type=Path, default=REPO_ROOT / "benchmark",
                         help="repo benchmark/ dir; reads <city>/panos/")
@@ -682,6 +760,8 @@ def main():
                         help="directory holding <city>_incremental_fp/ PNG crops")
     parser.add_argument("--repo-id", default="projectsidewalk/rampnet-benchmark")
     parser.add_argument("--private", action="store_true")
+    parser.add_argument("--message", default="Add benchmark panoramas (native + 4096x2048) and A/B galleries",
+                        help="push: the Hub commit message; say what this push carried")
     parser.add_argument("--push", action="store_true",
                         help="with `card`: upload only README.md")
     parser.add_argument("--allow-partial", action="store_true",
@@ -690,7 +770,7 @@ def main():
                         help="verify: pass panoramas that no imagery_manifest.json pins")
     args = parser.parse_args()
     {"build": build, "verify": verify, "records": records,
-     "card": card, "push": push}[args.mode](args)
+     "card": card, "push": push, "adopt": adopt}[args.mode](args)
 
 
 if __name__ == "__main__":

--- a/scripts/export_stage1_inputs.py
+++ b/scripts/export_stage1_inputs.py
@@ -108,6 +108,8 @@ def main():
     parser.add_argument("--repo-id", default="projectsidewalk/rampnet-stage1-inputs")
     parser.add_argument("--push", action="store_true")
     parser.add_argument("--private", action="store_true")
+    parser.add_argument("--message", default="Add the paper's Stage 1 inputs: inventories, street data, manifests",
+                        help="the Hub commit message; say what this push actually carried")
     args = parser.parse_args()
 
     rows = []
@@ -163,8 +165,10 @@ def main():
     print("\nPushing to {}".format(args.repo_id))
     api.create_repo(repo_id=args.repo_id, repo_type="dataset",
                     private=args.private, exist_ok=True)
+    # Unchanged files are skipped by the preupload check, so re-running this to correct the card
+    # uploads only README.md -- at which point the first publication's fixed message is wrong.
     api.upload_folder(repo_id=args.repo_id, repo_type="dataset", folder_path=str(args.out),
-                      commit_message="Add the paper's Stage 1 inputs: inventories, street data, manifests")
+                      commit_message=args.message)
     print("Done: https://huggingface.co/datasets/{}".format(args.repo_id))
 
 

--- a/scripts/hf_package/README.benchmark_card.template.md
+++ b/scripts/hf_package/README.benchmark_card.template.md
@@ -50,7 +50,7 @@ precision figure, because several splits carry caveats the numbers alone do not 
 | **`records`** | **the ground truth** — per-panorama metadata, model detections with their human verdict, and reviewer-marked missed ramps | scoring any model against this benchmark |
 | `native` | the panoramas exactly as fetched — 4096 to 16384 px wide, depending on city and imagery source | the resolution experiment; any re-render at higher fidelity |
 | `4096x2048` | the same panoramas at the model's input size | **what ground-truth reviewers actually saw** — `gt_gallery.py` renders at 4096×2048 and never native, so this is the config a second rater needs |
-| `galleries` | the incremental false-positive crops shown in the operating-point A/B pass — 8 splits, not 9 | redoing that A/B |
+| `galleries` | the incremental false-positive crops shown in the operating-point A/B pass — 314 crops over the same 9 splits | redoing that A/B |
 
 ### The `records` config
 

--- a/scripts/hf_package/README.stage1_inputs_card.template.md
+++ b/scripts/hf_package/README.stage1_inputs_card.template.md
@@ -93,6 +93,30 @@ Published beside the data rather than discovered later:
 So **43.23% never became a training label**, mostly because no panorama resolved for the location
 or the install date failed the predates-capture check.
 
+### Why this says 276,071 and the paper says 276,615
+
+Table 1 of the paper totals **276,615** across these three cities (NYC 217,680, Portland 45,324,
+Bend 13,611) — **544 more than the files published here**, as Bend −254, Portland −289, NYC −1.
+If you are comparing the paper against this download, that is the difference you will find, and it
+is between Table 1 and the files rather than a loss anywhere in the pipeline. Three things are
+checkable from this repository:
+
+- **Nothing is dropped on read.** Every Bend and Portland feature is a `Point`, and every NYC row
+  parses as `POINT(...)`; all 276,071 records survive parsing.
+- **These are the files the paper's run consumed.** Every row of `manifests/all_locations.csv` —
+  the run's own output, recovered rather than regenerated — resolves to one of them: 276,071 /
+  276,071, none unmatched, with per-city attribution equal to the per-file counts exactly.
+- **They are an earlier state of the same inventories, not a re-download.** Both drifting cities
+  have *grown* since the paper (measured 2026-07-31: Bend 14,805, Portland 46,101), so a fresh
+  download today is **larger** than Table 1 while these are smaller. NYC is effectively frozen and
+  differs by a single record.
+
+What is **not** established is where Table 1's exact figures came from. The likeliest reading is
+counts read from each city's portal at survey time rather than from the downloaded files, but that
+is a hypothesis: the two deltas correspond to roughly three and five months of each city's own
+measured growth, which is the right order of magnitude but not one consistent date. We state it as
+unresolved rather than quietly reconciled. **Quote 276,071 for anything derived from these files.**
+
 ## Usage
 
 This is a set of source documents, not a row-iterable dataset — `load_dataset()` will not work.

--- a/tests/test_export_benchmark.py
+++ b/tests/test_export_benchmark.py
@@ -30,8 +30,8 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
 sys.path.insert(0, os.path.join(REPO_ROOT, "scripts", "analysis"))
 from export_benchmark import (  # noqa: E402
     BENCHMARK_SPLITS, GALLERIES, IMAGE_SUFFIXES, MANIFEST_NAME, MODEL_RES, NATIVE, RECORDS,
-    GALLERY_FEATURES, GALLERY_SCHEMA, collect, configs_yaml, load_index, parse_gallery_id,
-    split_date_range)
+    GALLERY_FEATURES, GALLERY_SCHEMA, adopt_index, collect, configs_yaml, load_index, load_sizes,
+    package_bytes, parse_gallery_id, save_index, split_date_range)
 
 
 # --------------------------------------------------------------------------- the split allowlist
@@ -162,6 +162,73 @@ def test_a_city_new_on_disk_is_added_to_what_the_manifest_knew(tmp_path):
                               GALLERIES: ["bend"]},
                    manifest={NATIVE: ["bend"], MODEL_RES: ["bend"], GALLERIES: ["bend"]})
     assert load_index(out)[NATIVE] == ["bend", "clovis"]
+
+
+# ------------------------------------------------------------- the size the card advertises
+
+def _sized(tmp_path, on_disk, sizes=None, manifest=None):
+    """A package whose parquet have real byte lengths, plus an optional manifest of sizes."""
+    for config, cities in on_disk.items():
+        d = tmp_path / "data" / config
+        d.mkdir(parents=True, exist_ok=True)
+        for city, nbytes in cities.items():
+            (d / "{}.parquet".format(city)).write_bytes(b"x" * nbytes)
+    if manifest is not None or sizes is not None:
+        (tmp_path / MANIFEST_NAME).write_text(
+            json.dumps({"configs": manifest or {}, "sizes": sizes or {}}), encoding="utf-8")
+    return tmp_path
+
+
+def test_a_partial_rebuild_advertises_the_whole_package_not_just_what_it_rebuilt(tmp_path):
+    """The galleries re-push: one config on disk, three only on the Hub.
+
+    Summing the local parquet would have published `galleries`' own 0.40 GB as the size of an
+    11.41 GB dataset -- the config-list hole, one field over.
+    """
+    out = _sized(tmp_path, {GALLERIES: {"bend": 40}},
+                 manifest={NATIVE: ["bend"], MODEL_RES: ["bend"], GALLERIES: ["bend"],
+                           RECORDS: ["bend"]},
+                 sizes={NATIVE: 1000, MODEL_RES: 100, GALLERIES: 25, RECORDS: 5})
+    assert package_bytes(out, load_index(out)) == 1000 + 100 + 40 + 5
+
+
+def test_the_rebuilt_config_reports_its_new_size_not_the_one_on_record(tmp_path):
+    """Disk wins for a config this run rebuilt -- that is the whole point of re-pushing it."""
+    out = _sized(tmp_path, {GALLERIES: {"bend": 40}},
+                 manifest={GALLERIES: ["bend"]}, sizes={GALLERIES: 25})
+    assert package_bytes(out, {GALLERIES: ["bend"]}) == 40
+
+
+def test_a_config_the_card_does_not_declare_is_not_counted_in_its_total(tmp_path):
+    out = _sized(tmp_path, {}, manifest={NATIVE: ["bend"]}, sizes={NATIVE: 1000, "dropped": 7})
+    assert package_bytes(out, {NATIVE: ["bend"]}) == 1000
+
+
+def test_save_index_records_what_it_rebuilt_and_preserves_the_rest(tmp_path):
+    out = _sized(tmp_path, {GALLERIES: {"bend": 40}},
+                 manifest={NATIVE: ["bend"], GALLERIES: ["bend"]},
+                 sizes={NATIVE: 1000, GALLERIES: 25})
+    save_index(out, {GALLERIES: ["bend"]})
+    assert load_sizes(out) == {NATIVE: 1000, GALLERIES: 40}
+
+
+# --------------------------------------------------------- adopting an already-published package
+
+def test_adopt_reads_configs_splits_and_sizes_from_a_published_listing():
+    configs, sizes = adopt_index([
+        ("data/native/bend.parquet", 10), ("data/native/clovis.parquet", 20),
+        ("data/galleries/bend.parquet", 5),
+    ])
+    assert configs == {NATIVE: ["bend", "clovis"], GALLERIES: ["bend"]}
+    assert sizes == {NATIVE: 30, GALLERIES: 5}
+
+
+def test_adopt_ignores_everything_that_is_not_a_config_parquet():
+    configs, sizes = adopt_index([
+        ("README.md", 1), (".gitattributes", 1), ("data/native/bend.parquet", 10),
+        ("data/native/extra/nested.parquet", 99), ("data/native/notes.txt", 3),
+    ])
+    assert configs == {NATIVE: ["bend"]} and sizes == {NATIVE: 10}
 
 
 # ------------------------------------------------------------------------------ the card's dates


### PR DESCRIPTION
Closes the one action [#109](https://github.com/ProjectSidewalk/RampNet/pull/109) left owed: the `galleries` join-key fix was in code but not on the Hub. **It is now live** — and getting it there surfaced two more silent-publication holes of the same family, which are fixed here.

## The re-push is done

`projectsidewalk/rampnet-benchmark`'s `galleries` config now carries `crop_id`, a `pano_id` parsed back out of it, and the detection's `x_normalized` / `y_normalized`. Before, `pano_id` held the crop tag, so the join the card documents returned zero rows.

Verified against the live repo after pushing:

- 314 embedded images round-trip **byte-identical**
- the join is **9-for-9** on paterson against `records`
- `0uNeulmg68uHO_WKDIuqZw_0.85449_0.59961` parses back to a panorama id that **contains its own underscore** — the case the right-anchored parse exists for
- `native`, `4096x2048` and `records` untouched; repo still totals **11.41 GB** across four configs

## Two holes found by attempting the push

**The card advertised the size of whatever sat on local disk.** `render_card` summed `out.rglob("*.parquet")` — right for a full build, wrong for every partial one. A galleries-only rebuild would have published **0.40 GB as the size of an 11.41 GB dataset**. This is precisely the hole `load_index` already closes for the config list, one field over, so it closes the same way: `build_manifest.json` records each config's byte total and `package_bytes()` sums the union, with on-disk configs authoritative for their own size.

**The published package predates the manifest.** `rampnet-benchmark` was pushed before `build_manifest.json` existed, so the first partial rebuild had nothing to union against and `card` refused — correctly, but with no way forward short of rebuilding 11.41 GB to change one config. New `adopt` mode writes the manifest from the published repo's own file listing, the only authority on what is actually up there. `adopt_index` is split out so it tests without a network call.

Also: `push` had a hardcoded commit message naming the first publication's contents, wrong for every push after it. Now `--message`.

## Two documented facts were wrong

Both corrected from measurement:

| claim | where | actual |
| :--- | :--- | :--- |
| `galleries` has "8 splits, not 9" | card template | **9 splits** — all four configs carry the same 9. Added in #109 and not yet shipped, so the live card never claimed it |
| `galleries` is 244 MB, crops survive for "six cities", "two cities' galleries already deleted" | `replication.md` | **9 splits, 314 crops, 380.8 MB PNG / 399.5 MB Parquet.** Nothing was deleted |

## Replication

`docs/replication.md` now carries the exact four-command sequence as run, and notes that `build` also regenerates `records` — which came back byte-for-byte the same size as the published copy (179,356 bytes), the cheapest available check that the rebuild path is stable.

8 tests added; suite **986 → 992**.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])

---

## Second commit: the 544-record gap, told where replicators hit it

The README footnote and `data_provenance.md` §3.3 both reconcile the committed inventories' **276,071** records against the paper's Table 1 total of **276,615**. The published dataset card did not — it gave 276,071 and the per-city counts with no mention of Table 1. That card is where someone downloads the files, so it is where the mismatch is first noticed and where the explanation belongs. It now carries the reconciliation, separating what is established from what is not.

Everything in it was re-derived independently first, not copied from the earlier write-up:

- the three files recounted straight from the blobs — **13,357 / 45,035 / 217,679 = 276,071**
- the join redone **without** `gov_provenance.py`, matching `all_locations.csv` on rounded coordinates — **276,071 / 276,071, 0 unmatched**, attributing 217,679 NYC / 45,035 Portland / 13,357 Bend, equal to the per-file counts city by city

§3.3 also gains the magnitude version of the drift argument, which until now was directional only: against each city's growth between Table 1 and the 2026-07-31 snapshot, the committed files sit **21% of Bend's subsequent growth** below Table 1 and **37% of Portland's**. Consistent with predating it — but by different fractions, so they do not resolve to one download date. That is weak positive evidence for the survey-time reading, and it is recorded as weak.

Two useful side effects of regenerating the card through the real exporter rather than hand-editing it: the published inputs **re-verified against their pinned hashes** (`location_data` ×3 and `all_locations.csv` all "verified"), and it picked up a section #109 added to the template but never re-pushed — the same code-fixed / Hub-stale shape as the galleries schema.

`export_stage1_inputs.py` gets the same `--message` flag, for the same reason.
