### PR TITLE
Fix the stale status header on the #84 write-up

### DIFF
--- a/docs/stage2_epoch_curve_84.md
+++ b/docs/stage2_epoch_curve_84.md
@@ -1,8 +1,11 @@
 # Run A: the Stage 2 epoch curve (#84)
 
-**Status: training COMPLETE 2026-08-16. The auto-label half of the curve is below and replicates the
-paper run, minimum included. The `manual_gold` half — the question this run exists to answer — is
-not scored yet.**
+**Status: COMPLETE — training 2026-08-16, scoring 2026-08-17. The auto-label half of the curve is
+below and replicates the paper run, minimum included. The `manual_gold` half — the question this run
+exists to answer — is scored below too, along with a protocol-matched TTA arm. The answer is a
+fourth outcome the pre-registration did not enumerate: under its own 0.01 tie bar there is no
+resolvable human peak. Only epoch 1 sits clear of the maximum; epochs 2–8 are tied with one another,
+so the curve steps up once and is then flat.**
 
 ## What this run is
 


### PR DESCRIPTION
The status header on `docs/stage2_epoch_curve_84.md` still said the `manual_gold` half was **"not scored yet"**. It was scored the next day in 03f34e9, and the document answers the question three hundred lines below its own header — so the first line a reader sees contradicted the rest of the file.

The replacement text is lifted from the doc's own conclusion (line 407 onward) rather than newly asserted: no resolvable human peak under the pre-registered 0.01 tie bar, only epoch 1 clear of the maximum, epochs 2–8 tied with one another, one step up then flat. It also notes the protocol-matched TTA arm added in 38b141e.

**No numbers, data or analysis changed** — this is one paragraph of status text.

### How it surfaced

While scoring Run A's 8 checkpoints on `manual_gold` today, not realising #124 had already done it. That re-run turned out to be an exact replication — all 8 epochs, all three metrics, matching the committed `docs/data/run_a_84_manual_gold/summary.csv` to 4 decimal places, same checkpoint fingerprints — despite running on different GPUs and on gold-set panoramas that had to be restored from makelab2 after `/gscratch/scrubbed` purged klone's copy of the test split.

Those restored panoramas were separately verified byte-identical to the copy in this checkout (1,000/1,000, digest `91550b3040b95a95`), which is worth knowing because `evaluate.py` keys its heatmap cache on checkpoint + dataset + TTA and **not** on the image bytes, so a drifted restore would have been invisible.

None of that is in this PR — say the word if the replication is worth a line in the doc and I'll add it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-opus-5[1m])